### PR TITLE
T2077 - Apagar registros de Unidades de Medida Iguais

### DIFF
--- a/addons/product/data/product_demo.xml
+++ b/addons/product/data/product_demo.xml
@@ -277,7 +277,7 @@
         </record>
 
         <record id="product_product_8" model="product.product">
-            <field name="name">iMac</field>
+            <field name="name">iMac6</field>
             <field name="categ_id" ref="product_category_5"/>
             <field name="standard_price">1299.0</field>
             <field name="list_price">1799.0</field>

--- a/addons/product/tests/common.py
+++ b/addons/product/tests/common.py
@@ -45,7 +45,7 @@ class TestProductCommon(common.SavepointCase):
             'uom_id': cls.uom_unit.id,
             'uom_po_id': cls.uom_unit.id})
         cls.product_3 = Product.create({
-            'name': 'Stone',
+            'name': 'Stone 2',
             'uom_id': cls.uom_dozen.id,
             'uom_po_id': cls.uom_dozen.id})
 
@@ -54,7 +54,7 @@ class TestProductCommon(common.SavepointCase):
             'uom_id': cls.uom_dozen.id,
             'uom_po_id': cls.uom_dozen.id})
         cls.product_5 = Product.create({
-            'name': 'Stone Tools',
+            'name': 'Burnt Cement',
             'uom_id': cls.uom_unit.id,
             'uom_po_id': cls.uom_unit.id})
 
@@ -98,6 +98,6 @@ class TestProductCommon(common.SavepointCase):
             'uom_po_id': cls.uom_unit.id})
 
         cls.product_10 = Product.create({
-            'name': 'Stone',
+            'name': 'Rock',
             'uom_id': cls.uom_unit.id,
             'uom_po_id': cls.uom_unit.id})

--- a/addons/purchase/test/fifo_price.yml
+++ b/addons/purchase/test/fifo_price.yml
@@ -26,7 +26,7 @@
         product_qty: 10.0
         product_uom: product.product_uom_kgm
         price_unit: 50.0
-        name: 'FIFO Ice Cream'
+        name: 'FIFO Ice Cream 1'
         date_planned: !eval time.strftime('%Y-%m-%d')
 - 
   I confirm the first purchase order
@@ -60,7 +60,7 @@
         product_qty: 30.0
         product_uom: product.product_uom_kgm
         price_unit: 80.0
-        name: 'FIFO Ice Cream'
+        name: 'FIFO Ice Cream 2'
         date_planned: !eval time.strftime('%Y-%m-%d')
 - 
   I confirm the second purchase order
@@ -162,13 +162,13 @@
         product_qty: 30
         product_uom: product.product_uom_kgm
         price_unit: 0.150
-        name: 'FIFO Ice Cream'
+        name: 'FIFO Ice Cream 3'
         date_planned: !eval time.strftime('%Y-%m-%d')
       - product_id: product_fifo_icecream
         product_qty: 10.0
         product_uom: product.product_uom_kgm
         price_unit: 150.0
-        name: 'FIFO Ice Cream'
+        name: 'FIFO Ice Cream 4'
         date_planned: !eval time.strftime('%Y-%m-%d')
 - 
   I confirm the purchase order in USD
@@ -322,7 +322,7 @@
         product_qty: 50.0
         product_uom: product.product_uom_kgm
         price_unit: 50.0
-        name: 'FIFO Ice Cream'
+        name: 'FIFO Ice Cream 5'
         date_planned: !eval time.strftime('%Y-%m-%d')
 - 
   I confirm the first purchase order
@@ -345,7 +345,7 @@
         product_qty: 600.0
         product_uom: product.product_uom_kgm
         price_unit: 80
-        name: 'FIFO Ice Cream'
+        name: 'FIFO Ice Cream 6'
         date_planned: !eval time.strftime('%Y-%m-%d')
 - 
   I confirm the second negative purchase order

--- a/addons/purchase/test/fifo_returns.yml
+++ b/addons/purchase/test/fifo_returns.yml
@@ -3,7 +3,7 @@
 -
   !record {model: product.product, id: product_fiforet_icecream}:
     default_code: FIFORET
-    name: FIFO Ice Cream
+    name: FIFO Ice Cream 9
     type: product
     standard_price: 0.0
     categ_id: product.product_category_1
@@ -25,7 +25,7 @@
         product_qty: 10.0
         product_uom: product.product_uom_kgm
         price_unit: 50.0
-        name: 'FIFO Ice Cream'
+        name: 'FIFO Ice Cream 7'
         date_planned: !eval time.strftime('%Y-%m-%d')
 - 
   I create a draft Purchase Order for second shipment for 30 kg at 80 euro
@@ -37,7 +37,7 @@
         product_qty: 30.0
         product_uom: product.product_uom_kgm
         price_unit: 80.0
-        name: 'FIFO Ice Cream'
+        name: 'FIFO Ice Cream 8'
         date_planned: !eval time.strftime('%Y-%m-%d')
 - 
   I confirm the first purchase order

--- a/addons/website_sale/data/demo.xml
+++ b/addons/website_sale/data/demo.xml
@@ -855,7 +855,7 @@ Weight: 31 grams</field>
 
         <record id="website_sale_order_line_4" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_4"/>
-            <field name="name">iMac</field>
+            <field name="name">iMac1</field>
             <field name="product_id" ref="product.product_product_8"/>
             <field name="product_uom_qty">1</field>
             <field name="product_uom" ref="product.product_uom_unit"/>
@@ -893,7 +893,7 @@ Weight: 31 grams</field>
 
         <record id="website_sale_order_line_6" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_6"/>
-            <field name="name">iMac</field>
+            <field name="name">iMac2</field>
             <field name="product_id" ref="product.product_product_8"/>
             <field name="product_uom_qty">1</field>
             <field name="product_uom" ref="product.product_uom_unit"/>
@@ -912,7 +912,7 @@ Weight: 31 grams</field>
 
         <record id="website_sale_order_line_7" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_7"/>
-            <field name="name">iMac</field>
+            <field name="name">iMac3</field>
             <field name="product_id" ref="product.product_product_8"/>
             <field name="product_uom_qty">1</field>
             <field name="product_uom" ref="product.product_uom_unit"/>
@@ -931,7 +931,7 @@ Weight: 31 grams</field>
 
         <record id="website_sale_order_line_8" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_8"/>
-            <field name="name">iMac</field>
+            <field name="name">iMac4</field>
             <field name="product_id" ref="product.product_product_8"/>
             <field name="product_uom_qty">1</field>
             <field name="product_uom" ref="product.product_uom_unit"/>
@@ -1032,7 +1032,7 @@ Weight: 31 grams</field>
 
         <record id="website_sale_order_line_14" model="sale.order.line">
             <field name="order_id" ref="website_sale_order_13"/>
-            <field name="name">iMac</field>
+            <field name="name">iMac5</field>
             <field name="product_id" ref="product.product_product_8"/>
             <field name="product_uom_qty">1</field>
             <field name="product_uom" ref="product.product_uom_unit"/>


### PR DESCRIPTION
# Descrição

**Restringe a criação de un. de medida e o registro duplicado**
- Retirado o create/edit do form de vendas
- Não é mais possível criar uma unidade de medida que já exista

# Informações adicionais

[T2077](https://multi.multidadosti.com.br/web#id=2486&view_type=form&model=project.task&action=323&active_id=61)
Tabela: product_uom
Campos duplicados: 20, 21, >=39