### PR TITLE
T3227-Corrigir erro de l10n_br após atualização

### DIFF
--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -192,5 +192,7 @@ class TestSaleOrder(TestSale):
             'order_line': [(0, False, {'product_id': product_shared.product_variant_id.id, 'order_id': so_1.id})],
         })
 
-        self.assertEqual(set(so_1.order_line.tax_id.ids), set([tax_company_1.id]),
-            'Only taxes from the right company are put by default')
+        # self.assertEqual(set(so_1.order_line.tax_id.ids), set([tax_company_1.id]),
+        #     'Only taxes from the right company are put by default')
+        # Teste torna-se inutil pois o metodo '_compute_tax_id' foi totalmente sobrescrito
+        # na localizacao


### PR DESCRIPTION
* [REF] Comenta teste incompativel com localizacao

O seguinte teste inserido aqui é incompatível com a localização: https://github.com/odoo/odoo/pull/35294

PR relacionado: https://github.com/multidadosti-erp/odoo-brasil-addons/pull/281

[T3227](https://multi.multidadosti.com.br/web#id=3636&view_type=form&model=project.task&action=323&active_id=61)