### PR TITLE
 T3882-Traduzir o Modulo "Mail" do Core - Odoo 12

### DIFF
--- a/addons/mail/i18n/pt_BR.po
+++ b/addons/mail/i18n/pt_BR.po
@@ -1438,7 +1438,7 @@ msgstr "Criar próxima atividade"
 #: code:addons/mail/models/mail_thread.py:400
 #, python-format
 msgid "Create a new %(document)s"
-msgstr "Crie um novo %(documento)s"
+msgstr "Crie um novo %(document)s"
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:392


### PR DESCRIPTION
# Descrição

[MIG] Atualiza tradução PT_BR ao modulo 'mail' do Core do Odoo 12

# Informações adicionais

[T3882](https://multi.multidadosti.com.br/web?#id=4291&view_type=form&model=project.task&action=323&active_id=61)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
