### PR TITLE
T3899-Traduzir o Modulo "NOTE" do Core - Odoo 12

### DIFF
--- a/addons/note/i18n/pt_BR.po
+++ b/addons/note/i18n/pt_BR.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * note
-# 
+#
 # Translators:
 # Rodrigo de Almeida Sottomaior Macedo <rmsolucoeseminformatic4@gmail.com>, 2018
 # Martin Trigaux, 2018
@@ -15,14 +15,15 @@
 # Marcelo Costa <marcelo@comdesk.com.br>, 2018
 # Emanuel Martins <emanuel.breno@gmail.com>, 2019
 # Marcel Savegnago <marcel.savegnago@gmail.com>, 2019
-# 
+# Augusto Costa <gustotc@gmail.com>, 2020
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-29 10:09+0000\n"
 "PO-Revision-Date: 2018-08-24 09:21+0000\n"
-"Last-Translator: Marcel Savegnago <marcel.savegnago@gmail.com>, 2019\n"
+"Last-Translator: Augusto Costa <gustotc@gmail.com>, 2020\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/odoo/teams/41243/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -74,7 +75,7 @@ msgstr "Tipo de Atividade"
 #. module: note
 #: model_terms:ir.actions.act_window,help:note.action_note_note
 msgid "Add a new personal note"
-msgstr ""
+msgstr "Adicionar uma nova anotação pessoal"
 
 #. module: note
 #: model_terms:ir.actions.act_window,help:note.note_tag_action
@@ -86,14 +87,14 @@ msgstr "Adicione uma nova tag"
 #: code:addons/note/static/src/xml/systray.xml:14
 #, python-format
 msgid "Add a note"
-msgstr "Adicionar uma nota"
+msgstr "Adicionar uma anotação"
 
 #. module: note
 #. openerp-web
 #: code:addons/note/static/src/xml/systray.xml:6
 #, python-format
 msgid "Add new note"
-msgstr ""
+msgstr "Adicionar nova anotação"
 
 #. module: note
 #: model_terms:ir.ui.view,arch_db:note.view_note_note_filter
@@ -184,7 +185,7 @@ msgstr "Dobrado por Padrão"
 #. module: note
 #: model_terms:ir.ui.view,arch_db:note.view_note_note_kanban
 msgid "Follower"
-msgstr ""
+msgstr "Seguidor"
 
 #. module: note
 #: model:ir.model.fields,field_description:note.field_note_note__message_follower_ids
@@ -216,7 +217,7 @@ msgstr "Agrupar Por"
 #: model:ir.model.fields,field_description:note.field_note_stage__id
 #: model:ir.model.fields,field_description:note.field_note_tag__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: note
 #: model:ir.model.fields,help:note.field_note_note__message_unread
@@ -277,7 +278,7 @@ msgstr "Reunião"
 #. module: note
 #: model:note.stage,name:note.note_stage_01
 msgid "Meeting Minutes"
-msgstr ""
+msgstr "Atas de Reunião"
 
 #. module: note
 #: model:ir.model.fields,field_description:note.field_note_note__message_has_error
@@ -319,27 +320,27 @@ msgstr "Tipo da Próxima Atividade"
 #: model_terms:ir.ui.view,arch_db:note.view_note_note_filter
 #: model_terms:ir.ui.view,arch_db:note.view_note_note_form
 msgid "Note"
-msgstr "Nota"
+msgstr "Anotação"
 
 #. module: note
 #: model:ir.model.fields,field_description:note.field_note_note__memo
 msgid "Note Content"
-msgstr "Conteúdo da Nota"
+msgstr "Conteúdo da Anotação"
 
 #. module: note
 #: model:ir.model,name:note.model_note_stage
 msgid "Note Stage"
-msgstr "Estágio da Nota"
+msgstr "Estágio da Anotação"
 
 #. module: note
 #: model:ir.model.fields,field_description:note.field_note_note__name
 msgid "Note Summary"
-msgstr "Resumo da Nota"
+msgstr "Resumo da Anotação"
 
 #. module: note
 #: model:ir.model,name:note.model_note_tag
 msgid "Note Tag"
-msgstr "Marcador da Nota"
+msgstr "Marcador da Anotação"
 
 #. module: note
 #: code:addons/note/models/res_users.py:61
@@ -349,7 +350,7 @@ msgstr "Marcador da Nota"
 #: model:note.stage,name:note.note_stage_02
 #, python-format
 msgid "Notes"
-msgstr "Observações"
+msgstr "Anotações"
 
 #. module: note
 #: model_terms:ir.actions.act_window,help:note.action_note_note
@@ -357,6 +358,9 @@ msgid ""
 "Notes are private, unless you share them by inviting follower on a note.\n"
 "            (Useful for meeting minutes)."
 msgstr ""
+"As anotações são privadas, a menos que você as compartilhe convidando seguidores em uma anotação.\n"
+"            (Útil para atas de reuniões)".
+
 
 #. module: note
 #: model:ir.model.fields,field_description:note.field_note_note__message_needaction_counter
@@ -402,7 +406,7 @@ msgstr "Proprietário"
 #. module: note
 #: model:ir.model.fields,help:note.field_note_stage__user_id
 msgid "Owner of the note stage"
-msgstr "Proprietário do estágio da nota"
+msgstr "Proprietário do estágio da anotação"
 
 #. module: note
 #: selection:note.note,activity_state:0
@@ -412,14 +416,14 @@ msgstr "Planejado"
 #. module: note
 #: model:ir.model.fields,field_description:note.field_mail_activity__note_id
 msgid "Related Note"
-msgstr ""
+msgstr "Anotação relacionada"
 
 #. module: note
 #. openerp-web
 #: code:addons/note/static/src/xml/systray.xml:23
 #, python-format
 msgid "Remember..."
-msgstr ""
+msgstr "Lembre-se..."
 
 #. module: note
 #: selection:mail.activity.type,category:0
@@ -437,7 +441,7 @@ msgstr "Usuário Responsável"
 #: code:addons/note/static/src/xml/systray.xml:25
 #, python-format
 msgid "SAVE"
-msgstr ""
+msgstr "GRAVAR"
 
 #. module: note
 #: model:ir.model.fields,field_description:note.field_note_note__sequence
@@ -450,7 +454,7 @@ msgstr "Seqüência"
 #: code:addons/note/static/src/xml/systray.xml:18
 #, python-format
 msgid "Set date and time"
-msgstr ""
+msgstr "Definir data e hora"
 
 #. module: note
 #: model_terms:ir.ui.view,arch_db:note.view_note_note_filter
@@ -472,7 +476,7 @@ msgstr "Nome do Estágio"
 #. module: note
 #: model_terms:ir.ui.view,arch_db:note.view_note_stage_form
 msgid "Stage of Notes"
-msgstr "Estágios das Notas"
+msgstr "Estágios das anotações"
 
 #. module: note
 #: model:ir.actions.act_window,name:note.action_note_stage
@@ -484,7 +488,7 @@ msgstr "Estágios"
 #. module: note
 #: model_terms:ir.ui.view,arch_db:note.view_note_stage_tree
 msgid "Stages of Notes"
-msgstr "Estágio das Notas"
+msgstr "Estágio das anotações"
 
 #. module: note
 #: model:ir.model.fields,field_description:note.field_note_note__stage_ids
@@ -555,7 +559,7 @@ msgstr "Contador de Mensagens Não Lidas"
 #. module: note
 #: model:ir.model.fields,help:note.field_note_stage__sequence
 msgid "Used to order the note stages"
-msgstr "Usado para ordenar os estágios das notas"
+msgstr "Usado para ordenar os estágios das anotações"
 
 #. module: note
 #: model:ir.model,name:note.model_res_users


### PR DESCRIPTION
# Descrição

[MIG] Atualiza tradução PT_BR modulo 'note' Odoo 12

# Informações adicionais

[T3899](https://multi.multidadosti.com.br/web?#id=4308&view_type=form&model=project.task&action=323&active_id=61)
