### PR TITLE
T3879-Traduzir o Modulo "Account" do Core - Odoo 12

### DIFF
--- a/addons/account/i18n/pt_BR.po
+++ b/addons/account/i18n/pt_BR.po
@@ -2575,17 +2575,17 @@ msgstr "TRANSPORTE E SEGURO PAGOS PARA"
 #. module: account
 #: model:account.incoterms,name:account.incoterm_CPT
 msgid "CARRIAGE PAID TO"
-msgstr ""
+msgstr "TRANSPORTE PAGO A"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_CFR
 msgid "COST AND FREIGHT"
-msgstr ""
+msgstr "CUSTO E FRETE"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_CIF
 msgid "COST, INSURANCE AND FREIGHT"
-msgstr ""
+msgstr "CUSTO, SEGURO E FRETE"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -2982,6 +2982,8 @@ msgid ""
 "Choose how you want to credit this invoice. You cannot Modify and Cancel if "
 "the invoice is already reconciled"
 msgstr ""
+"Escolha como quer creditar esta fatura. Você não pode Modificar e Cancelar se "
+"a fatura já está reconciliada"
 
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.actions_account_fiscal_year
@@ -3071,7 +3073,7 @@ msgstr "Valor de Moeda/Conta"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Collect customer payments in one-click using Euro SEPA Service"
-msgstr ""
+msgstr "Recolher pagamentos de clientes com um clique utilizando o Serviço Euro SEPA"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -3079,6 +3081,8 @@ msgid ""
 "Collect information and produce statistics on the trade in goods in Europe "
 "with intrastat."
 msgstr ""
+"Recolher informações e produzir estatísticas sobre o comércio de mercadorias na Europa".
+"com intrastat."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account_tag__color
@@ -3096,12 +3100,12 @@ msgstr "Entidade Comercial"
 #: code:addons/account/models/account_invoice.py:519
 #, python-format
 msgid "Commercial partner and vendor account owners must be identical."
-msgstr ""
+msgstr "O parceiro comercial e os proprietários da conta do fornecedor devem ser idênticos."
 
 #. module: account
 #: model:ir.model,name:account.model_account_common_journal_report
 msgid "Common Journal Report"
-msgstr ""
+msgstr "Relatório de Diário Comum"
 
 #. module: account
 #: model:ir.actions.act_window,name:account.action_account_common_menu
@@ -3184,7 +3188,7 @@ msgstr "Conjunto Completo de Impostos"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__composer_id
 msgid "Composer"
-msgstr ""
+msgstr "Composição"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__composition_mode
@@ -3213,7 +3217,7 @@ msgstr "Saldo Calculado"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_reconcile_model_form
 msgid "Conditions on Bank Statement Line"
-msgstr ""
+msgstr "Condições na linha de extrato bancário"
 
 #. module: account
 #: model:ir.model,name:account.model_res_config_settings
@@ -3295,7 +3299,7 @@ msgstr "Parabéns, você concluiu tudo!"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_invoice_onboarding_panel
 msgid "Congratulations! You are all set."
-msgstr ""
+msgstr "Parabéns! Está tudo pronto."
 
 #. module: account
 #: model:ir.model,name:account.model_res_partner
@@ -3326,7 +3330,7 @@ msgstr "Conteúdo"
 #: model:ir.model.fields,field_description:account.field_res_partner__contracts_count
 #: model:ir.model.fields,field_description:account.field_res_users__contracts_count
 msgid "Contracts Count"
-msgstr ""
+msgstr "Contagem de Contratos"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_form
@@ -3340,6 +3344,8 @@ msgid ""
 "Correction of <a href=# data-oe-model=account.invoice data-oe-"
 "id=%d>%s</a><br>Reason: %s"
 msgstr ""
+"Correção de <a href=# data-oe-model=account.invoice data-oe-"
+"id=%d>%s</a><br>Razão: %s"
 
 #. module: account
 #: model:account.account.type,name:account.data_account_type_direct_costs
@@ -3369,7 +3375,7 @@ msgstr "Conta de Contrapartida"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_reconcile_model_form
 msgid "Counterpart Values"
-msgstr ""
+msgstr "Valores da Contrapartida"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_fiscal_position__country_id
@@ -3392,7 +3398,7 @@ msgstr "Criar"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_setup_bank_manual_config__create_or_link_option
 msgid "Create Or Link Option"
-msgstr ""
+msgstr "Opção Criar ou Ligar"
 
 #. module: account
 #: code:addons/account/models/company.py:276
@@ -3575,7 +3581,7 @@ msgstr "Criado por"
 #: code:addons/account/models/account_invoice.py:419
 #, python-format
 msgid "Created by: %s"
-msgstr ""
+msgstr "Criado por: %s"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__create_date
@@ -3858,37 +3864,37 @@ msgstr "Personalize a aparência das suas faturas."
 #. module: account
 #: model:account.incoterms,name:account.incoterm_DAF
 msgid "DELIVERED AT FRONTIER"
-msgstr ""
+msgstr "ENTREGUE NA FRONTEIRA"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_DAP
 msgid "DELIVERED AT PLACE"
-msgstr ""
+msgstr "ENTREGUE NO LOCAL"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_DAT
 msgid "DELIVERED AT TERMINAL"
-msgstr ""
+msgstr "ENTREGUE NO TERMINAL"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_DDP
 msgid "DELIVERED DUTY PAID"
-msgstr ""
+msgstr "DIREITOS PAGOS"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_DDU
 msgid "DELIVERED DUTY UNPAID"
-msgstr ""
+msgstr "DIREITOS NÃO PAGOS"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_DEQ
 msgid "DELIVERED EX QUAY"
-msgstr ""
+msgstr "ENTREGUE NO CAIS"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_DES
 msgid "DELIVERED EX SHIP"
-msgstr ""
+msgstr "ENTREGUE NO NAVIO"
 
 #. module: account
 #: selection:account.cash.rounding,rounding_method:0
@@ -3935,7 +3941,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move__reverse_date
 msgid "Date of the reverse accounting entry."
-msgstr ""
+msgstr "Data do lançamento contabilístico invertido."
 
 #. module: account
 #. openerp-web
@@ -3963,6 +3969,10 @@ msgid ""
 "greater than the last day of a month, this number will instead select the "
 "last day of this month."
 msgstr ""
+"Dia do mês em que a fatura deve chegar ao seu termo. Se zero ou "
+"negativo, este valor será ignorado, e nenhum dia específico será definido. Se "
+"maior do que o último dia de um mês, este número irá, em vez disso, selecionar o"
+"Último dia deste mês."
 
 #. module: account
 #: code:addons/account/models/company.py:51
@@ -4025,7 +4035,7 @@ msgstr "Sequência de Nota de Crédito Dedicada"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__invoice_reference_type
 msgid "Default Communication Type"
-msgstr ""
+msgstr "Tipo de comunicação padrão"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_journal__default_credit_account_id
@@ -4046,7 +4056,7 @@ msgstr "Imposto Padrão de Compra"
 #. module: account
 #: model:ir.model.fields,help:account.field_res_config_settings__invoice_reference_type
 msgid "Default Reference Type on Invoices."
-msgstr ""
+msgstr "Tipo de referência padrão nas faturas"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__account_sale_tax_id
@@ -4057,7 +4067,7 @@ msgstr "Imposto de vendas padrão"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Default Sending Options"
-msgstr ""
+msgstr "Opções de Envio por Padrão"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__tax_ids
@@ -4070,12 +4080,12 @@ msgstr "Taxas padrão"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__incoterm_id
 msgid "Default incoterm"
-msgstr ""
+msgstr "Incoterm padrão"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Default payment communication on customer invoices"
-msgstr ""
+msgstr "Comunicação de pagamento por padrão nas faturas dos clientes"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -4086,13 +4096,13 @@ msgstr "Impostos padrões aplicados a transações locais"
 #: model:ir.model.fields,help:account.field_product_product__supplier_taxes_id
 #: model:ir.model.fields,help:account.field_product_template__supplier_taxes_id
 msgid "Default taxes used when buying the product."
-msgstr ""
+msgstr "Impostos por padrão utilizados na compra do produto."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_product_product__taxes_id
 #: model:ir.model.fields,help:account.field_product_template__taxes_id
 msgid "Default taxes used when selling the product."
-msgstr ""
+msgstr "Impostos por padrão utilizados na venda do produto."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -4117,7 +4127,7 @@ msgstr "Defina as datas de abertura e fechamento do ano fiscal."
 #. module: account
 #: model:ir.model.fields,help:account.field_account_journal__bank_statements_source
 msgid "Defines how the bank statements will be registered"
-msgstr ""
+msgstr "Define como os extratos bancários serão registrados"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice__cash_rounding_id
@@ -4141,17 +4151,17 @@ msgstr "Grau de confiança que você tem neste devedor"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__auto_delete
 msgid "Delete Emails"
-msgstr ""
+msgstr "Apagar e-mails"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__auto_delete_message
 msgid "Delete Message Copy"
-msgstr ""
+msgstr "Apagar cópia da mensagem"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice_send__auto_delete
 msgid "Delete sent emails (mass mailing only)"
-msgstr ""
+msgstr "Eliminar e-mails enviados (apenas envio em massa)"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__deprecated
@@ -4204,6 +4214,9 @@ msgid ""
 "used by itself, however it can still be used in a group. 'adjustment' is "
 "used to perform tax adjustment."
 msgstr ""
+"Determina onde o imposto é selecionável. Nota : 'Nenhum' significa que um imposto não pode ser "
+"usado por si mesmo, porém ainda pode ser usado em grupo. O 'ajuste' é".
+"usado para realizar o ajuste de impostos."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement__difference
@@ -4228,7 +4241,7 @@ msgstr "Diferença entre o saldo final calculado e o saldo final especificado."
 #: code:addons/account/models/account_move.py:408
 #, python-format
 msgid "Difference debit - credit: "
-msgstr ""
+msgstr "Diferença de débito - crédito:"
 
 #. module: account
 #: model:ir.model,name:account.model_digest_digest
@@ -4241,12 +4254,14 @@ msgid ""
 "Disable this option to use a simplified versions of vendor bills, where "
 "products are hidden."
 msgstr ""
+"Desactivar esta opção para utilizar uma versão simplificada das faturas do fornecedor, onde"
+"Os produtos estão escondidos."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid ""
 "Disable to have a simplified view of vendor bills, without the products."
-msgstr ""
+msgstr "Não é possível ter uma visão simplificada das contas do fornecedor, sem os produtos."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.invoice_form
@@ -4325,7 +4340,7 @@ msgstr "Nome exibido"
 #: model:ir.model.fields,field_description:account.field_res_company__qr_code
 #: model:ir.model.fields,field_description:account.field_res_config_settings__qr_code
 msgid "Display SEPA QR code"
-msgstr ""
+msgstr "Mostrar o código QR SEPA"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_line__display_type
@@ -4341,7 +4356,7 @@ msgstr "Exibir em Faturas"
 #: code:addons/account/models/digest.py:16
 #, python-format
 msgid "Do not have access, skip this data for user's digest email"
-msgstr ""
+msgstr "Não tem acesso, salte estes dados para o e-mail de digitação do usuário"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice_send__auto_delete_message
@@ -4349,6 +4364,8 @@ msgid ""
 "Do not keep a copy of the email in the document communication history (mass "
 "mailing only)"
 msgstr ""
+"Não guardar uma cópia do e-mail no histórico de comunicação do documento (massa)".
+"apenas para envio por correio)".
 
 #. module: account
 #: selection:res.company,account_dashboard_onboarding_state:0
@@ -4441,7 +4458,7 @@ msgstr "Data de vencimento"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_line_form
 msgid "Due the"
-msgstr ""
+msgstr "Devido ao"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
@@ -4471,7 +4488,7 @@ msgstr "Regras de IVA para bens digitais da UE"
 #. module: account
 #: model:account.incoterms,name:account.incoterm_EXW
 msgid "EX WORKS"
-msgstr ""
+msgstr "EX-TRABALHOS"
 
 #. module: account
 #: code:addons/account/models/chart_template.py:387
@@ -4509,12 +4526,12 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__invoice_is_email
 msgid "Email by default"
-msgstr ""
+msgstr "Email por padrão"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_form
 msgid "Email your Vendor Bills"
-msgstr ""
+msgstr "Envie as suas faturas de fornecedor por e-mail"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_common_journal_report__date_to
@@ -4542,7 +4559,7 @@ msgstr "Caixa Físico Final"
 #. module: account
 #: model:ir.model.fields,help:account.field_account_fiscal_year__date_to
 msgid "Ending Date, included in the fiscal year."
-msgstr ""
+msgstr "Data de fim, incluída no ano fiscal."
 
 #. module: account
 #: model:ir.actions.act_window,name:account.action_move_line_form
@@ -4558,7 +4575,7 @@ msgstr "Entradas classificadas por"
 #: code:addons/account/models/account_move.py:911
 #, python-format
 msgid "Entries are not from the same account."
-msgstr ""
+msgstr "As entradas não são da mesma conta."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
@@ -4651,22 +4668,22 @@ msgstr "Referência Externa"
 #: code:addons/account/static/src/xml/account_reconciliation.xml:333
 #, python-format
 msgid "External link"
-msgstr ""
+msgstr "Link externo"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_FAS
 msgid "FREE ALONGSIDE SHIP"
-msgstr ""
+msgstr "GRÁTIS AO LONGO DO NAVIO"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_FCA
 msgid "FREE CARRIER"
-msgstr ""
+msgstr "TRANSPORTADOR LIVRE"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_FOB
 msgid "FREE ON BOARD"
-msgstr ""
+msgstr "GRATUITO A BORDO"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__starred_partner_ids
@@ -4791,7 +4808,7 @@ msgstr "Primeiro Dia do Ano Fiscal"
 #. module: account
 #: model:ir.model.fields,help:account.field_account_financial_year_op__fiscalyear_last_month
 msgid "Fiscal year last month."
-msgstr ""
+msgstr "Ano fiscal do mês passado."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_financial_year_op__fiscalyear_last_day
@@ -4866,12 +4883,12 @@ msgstr "Seguidores (Parceiros)"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_journal__inbound_payment_method_ids
 msgid "For Incoming Payments"
-msgstr ""
+msgstr "Para Contas a receber"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_journal__outbound_payment_method_ids
 msgid "For Outgoing Payments"
-msgstr ""
+msgstr "Para Contas a pagar"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_payment_term_line__value_amount
@@ -4883,18 +4900,19 @@ msgstr "Para porcentagem introduzir um valor entre 0-100."
 msgid ""
 "Forbidden unit price, account and quantity on non-accountable invoice line"
 msgstr ""
+"Preço unitário, conta e quantidade proibidos na linha de fatura não contabilizável".
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__force_second_tax_included
 #: model:ir.model.fields,help:account.field_account_reconcile_model_template__force_second_tax_included
 msgid "Force the second tax to be managed as a price included tax."
-msgstr ""
+msgstr "Forçar o segundo imposto a ser gerido como um preço com imposto incluído."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__force_tax_included
 #: model:ir.model.fields,help:account.field_account_reconcile_model_template__force_tax_included
 msgid "Force the tax to be managed as a price included tax."
-msgstr ""
+msgstr "Forçar o imposto a ser gerido como um preço com imposto incluído."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_account__currency_id
@@ -4957,7 +4975,7 @@ msgstr ""
 #: code:addons/account/models/account_invoice.py:385
 #, python-format
 msgid "From: "
-msgstr ""
+msgstr "De: "
 
 #. module: account
 #: model:ir.model,name:account.model_account_full_reconcile
@@ -5055,7 +5073,7 @@ msgstr "Vá para o painel de configuração"
 #: code:addons/account/models/company.py:459
 #, python-format
 msgid "Go to the journal configuration"
-msgstr ""
+msgstr "Ir para a configuração do diário"
 
 #. module: account
 #: selection:res.partner,trust:0
@@ -5096,7 +5114,7 @@ msgstr "Agrupar Linhas da Fatura"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_register_payments__group_invoices
 msgid "Group Invoices"
-msgstr ""
+msgstr "Faturas de Grupo"
 
 #. module: account
 #: selection:account.tax,amount_type:0
@@ -5107,7 +5125,7 @@ msgstr "Grupo de Taxas"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Group payments into a single batch to ease the reconciliation process"
-msgstr ""
+msgstr "Agrupar pagamentos em um único lote para facilitar o processo de reconciliação"
 
 #. module: account
 #: selection:account.cash.rounding,rounding_method:0
@@ -5138,13 +5156,13 @@ msgstr "Tem entradas não conciliadas"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_setup_bank_manual_config__qr_code_valid
 msgid "Has all required arguments"
-msgstr ""
+msgstr "Tem todos os argumentos necessários"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__has_error
 #: model:ir.model.fields,help:account.field_account_invoice_send__has_error
 msgid "Has error"
-msgstr ""
+msgstr "Tem erro"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_abstract_payment__hide_payment_method
@@ -5282,6 +5300,9 @@ msgid ""
 "                                                                    type and recipient bank account in the generated payments. If disabled,\n"
 "                                                                    a distinct payment will be generated for each invoice."
 msgstr ""
+"Se ativado, agrupa faturas por parceiro comercial, conta de fatura,\n"
+"                                                                    tipo e conta bancária do destinatário nos pagamentos gerados. Se incapacitado,\n"
+"                                                                    será gerado um pagamento distinto para cada fatura."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_tax__include_base_amount
@@ -5299,6 +5320,8 @@ msgid ""
 "If set, the accounting entries created during the bank statement reconciliation process will be created at this date.\n"
 "This is useful if the accounting period in which the entries should normally be booked is already closed."
 msgstr ""
+"Se definidos, os lançamentos contábeis criados durante o processo de reconciliação do extrato bancário serão criados nesta data.\n"
+"Isto é útil se o período contabilístico em que os lançamentos devem normalmente ser contabilizados já estiver encerrado".
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_tax__analytic
@@ -5334,6 +5357,8 @@ msgid ""
 "If this checkbox is ticked, this entry will be automatically reversed at the"
 " reversal date you defined."
 msgstr ""
+"Se esta caixa de seleção estiver marcada, esta entrada será automaticamente revertida no"
+"data de inversão que você definiu."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -5357,6 +5382,7 @@ msgstr ""
 msgid ""
 "If you have not installed a chart of account, please install one first.<br>"
 msgstr ""
+"Se você não tiver instalado um plano de contas, por favor instale um primeiro.<br>".
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_unreconcile_view
@@ -5493,7 +5519,7 @@ msgstr "Importar Extrato Bancário em formato .QIF"
 #: selection:account.invoice,state:0
 #: model_terms:ir.ui.view,arch_db:account.view_account_invoice_filter
 msgid "In Payment"
-msgstr ""
+msgstr "Em Pagamento"
 
 #. module: account
 #: code:addons/account/models/account_bank_statement.py:345
@@ -5609,11 +5635,13 @@ msgid ""
 "Incoterms are used to divide transaction costs and responsibilities between "
 "buyer and seller."
 msgstr ""
+"Os Incoterms são usados para dividir os custos e responsabilidades de transação entre"
+"comprador e vendedor."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move_line__tax_line_id
 msgid "Indicates that this journal item is a tax line"
-msgstr ""
+msgstr "Indica que este item do diário é uma linha de imposto"
 
 #. module: account
 #. openerp-web
@@ -5661,7 +5689,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account.field_account_account__internal_group
 #: model:ir.model.fields,field_description:account.field_account_account_type__internal_group
 msgid "Internal Group"
-msgstr ""
+msgstr "Grupo Interno"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move__narration
@@ -5720,7 +5748,7 @@ msgstr "\"Faixa de CEP\"inválida, por favor, configure-a corretamente."
 #: code:addons/account/models/company.py:106
 #, python-format
 msgid "Invalid fiscal year last day"
-msgstr ""
+msgstr "Ano fiscal inválido no dia anterior"
 
 #. module: account
 #: code:addons/account/models/account_invoice.py:1351
@@ -5770,12 +5798,12 @@ msgstr "Data da Fatura"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__invoice_icon
 msgid "Invoice Icon"
-msgstr ""
+msgstr "Ícone da fatura"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.onboarding_invoice_layout_step
 msgid "Invoice Layout"
-msgstr ""
+msgstr "Layout da fatura"
 
 #. module: account
 #: model:ir.model,name:account.model_account_invoice_line
@@ -5802,7 +5830,7 @@ msgstr "Número da Fatura:"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__module_account_payment
 msgid "Invoice Online Payment"
-msgstr ""
+msgstr "Pagamento Online da Fatura"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_line__invoice_id
@@ -5859,7 +5887,7 @@ msgstr "Fatura paga"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_invoice_send_wizard_form
 msgid "Invoice send & Print"
-msgstr ""
+msgstr "Envio e impressão de facturas"
 
 #. module: account
 #: model:mail.message.subtype,description:account.mt_invoice_validated
@@ -5931,12 +5959,12 @@ msgstr "Faturas devidas a você"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
 msgid "Invoices to Validate"
-msgstr ""
+msgstr "Faturas a Validar"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_payment__reconciled_invoice_ids
 msgid "Invoices whose journal items have been reconciled with this payment's."
-msgstr ""
+msgstr "Faturas cujos itens do diário foram reconciliados com os deste pagamento."
 
 #. module: account
 #: model:ir.actions.report,name:account.account_invoices_without_payment
@@ -5949,13 +5977,13 @@ msgstr "Faturas sem Pagamento"
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 #: model_terms:ir.ui.view,arch_db:account.view_partner_property_form
 msgid "Invoicing"
-msgstr "Faturamento"
+msgstr "Financeiro"
 
 #. module: account
 #: selection:account.reconcile.model,match_amount:0
 #: selection:account.reconcile.model.template,match_amount:0
 msgid "Is Between"
-msgstr ""
+msgstr "Está entre"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement__message_is_follower
@@ -5968,28 +5996,28 @@ msgstr "É um seguidor"
 #: selection:account.reconcile.model,match_amount:0
 #: selection:account.reconcile.model.template,match_amount:0
 msgid "Is Greater Than"
-msgstr ""
+msgstr "É maior que"
 
 #. module: account
 #: selection:account.reconcile.model,match_amount:0
 #: selection:account.reconcile.model.template,match_amount:0
 msgid "Is Lower Than"
-msgstr ""
+msgstr "É mais baixo que"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__printed
 msgid "Is Printed"
-msgstr ""
+msgstr "Está Impresso"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__is_second_tax_price_included
 msgid "Is Second Tax Included in Price"
-msgstr ""
+msgstr "O segundo imposto está incluído no preço"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__is_tax_price_included
 msgid "Is Tax Included in Price"
-msgstr ""
+msgstr "O imposto está incluído no preço"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice_line__is_rounding_line
@@ -6016,7 +6044,7 @@ msgstr "Funciona como uma conta padrão para debitar valores"
 #. module: account
 #: model:ir.model.fields,help:account.field_account_journal__alias_name
 msgid "It creates draft vendor bill by sending an email."
-msgstr ""
+msgstr "Ele cria o projeto de lei do fornecedor enviando um e-mail."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice__reconciled
@@ -6106,7 +6134,7 @@ msgstr "Lançamentos de Diário"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_move_filter
 msgid "Journal Entries by Date"
-msgstr ""
+msgstr "Entradas em Diário por Data"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__move_id
@@ -6176,7 +6204,7 @@ msgstr "Itens do Diário"
 #. module: account
 #: model:ir.actions.act_window,name:account.action_move_line_select_tax_audit
 msgid "Journal Items for Tax Audit"
-msgstr ""
+msgstr "Itens de Diário para Auditoria Fiscal"
 
 #. module: account
 #. openerp-web
@@ -6208,12 +6236,12 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice_import_wizard__journal_id
 msgid "Journal where to generate the bills"
-msgstr ""
+msgstr "Diário onde gerar as faturas"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__journal_currency_id
 msgid "Journal's Currency"
-msgstr ""
+msgstr "Moeda do Diário"
 
 #. module: account
 #: model:ir.actions.act_window,name:account.action_account_journal_form
@@ -6251,7 +6279,7 @@ msgstr "Junho"
 #: selection:res.company,account_setup_coa_state:0
 #: selection:res.company,account_setup_fy_data_state:0
 msgid "Just done"
-msgstr ""
+msgstr "Acabei de fazer."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_tax_adjustments_wizard__reason
@@ -6306,11 +6334,14 @@ msgid ""
 " anglo-saxon accounting with automated valuation method is configured, the "
 "expense account on the product category will be used."
 msgstr ""
+"Mantenha este campo vazio para usar o valor padrão da categoria do produto. Se"
+" Anglo-saxon contabilidade com método de avaliação automatizado é configurado, o "
+"conta de despesas na categoria de produto será usada."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_digest_digest__kpi_account_total_revenue_value
 msgid "Kpi Account Total Revenue Value"
-msgstr ""
+msgstr "Valor total da receita da conta Kpi"
 
 #. module: account
 #. openerp-web
@@ -6332,7 +6363,7 @@ msgstr "Rótulo"
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__match_label_param
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_template__match_label_param
 msgid "Label Parameter"
-msgstr ""
+msgstr "Parâmetro de Rótulo"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_tax__description
@@ -6595,22 +6626,22 @@ msgstr "Responsabilidade"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__nbr
 msgid "Line Count"
-msgstr ""
+msgstr "Contagem de linhas"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__show_line_subtotals_tax_selection
 msgid "Line Subtotals Tax Display"
-msgstr ""
+msgstr "Exibição do imposto de subtotais de linha"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Line subtotals tax display"
-msgstr ""
+msgstr "Exibição do imposto de subtotais de linha"
 
 #. module: account
 #: selection:account.setup.bank.manual.config,create_or_link_option:0
 msgid "Link to an existing journal"
-msgstr ""
+msgstr "Link para um diário existente"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice__move_id
@@ -6627,7 +6658,7 @@ msgstr "Liquidez"
 #: code:addons/account/models/chart_template.py:154
 #, python-format
 msgid "Liquidity Transfer"
-msgstr ""
+msgstr "Transferência de Liquidez"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_chart_template__tax_template_ids
@@ -6666,7 +6697,7 @@ msgstr "Registra uma nota interna"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.onboarding_invoice_layout_step
 msgid "Looks great!"
-msgstr ""
+msgstr "Parece ótimo!"
 
 #. module: account
 #: code:addons/account/models/account_bank_statement.py:175
@@ -6694,7 +6725,7 @@ msgstr "DIVER"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__mail_activity_type_id
 msgid "Mail Activity Type"
-msgstr ""
+msgstr "Tipo de atividade de correio"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__mailing_list_ids
@@ -6784,7 +6815,7 @@ msgstr ""
 #: code:addons/account/models/chart_template.py:932
 #, python-format
 msgid "Manually create a write-off on clicked button."
-msgstr ""
+msgstr "Crie manualmente um write-off no botão clicado."
 
 #. module: account
 #: selection:res.company,fiscalyear_last_month:0
@@ -6816,13 +6847,13 @@ msgstr "Campanha de e-mail em massa"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__mass_mailing_name
 msgid "Mass Mailing Name"
-msgstr ""
+msgstr "Nome para envio em massa"
 
 #. module: account
 #: selection:account.reconcile.model,match_label:0
 #: selection:account.reconcile.model.template,match_label:0
 msgid "Match Regex"
-msgstr ""
+msgstr "Combinar Regex"
 
 #. module: account
 #: selection:account.reconcile.model,rule_type:0
@@ -6831,7 +6862,7 @@ msgstr ""
 #: code:addons/account/models/chart_template.py:934
 #, python-format
 msgid "Match existing invoices/bills."
-msgstr ""
+msgstr "Combinar faturas/contas existentes."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line__matched_credit_ids
@@ -6880,7 +6911,7 @@ msgstr "Comentário"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_from_invoices
 msgid "Memo will be computed from invoices"
-msgstr ""
+msgstr "O memorando será calculado a partir das facturas"
 
 #. module: account
 #. openerp-web
@@ -6950,17 +6981,17 @@ msgstr "Operações Diversas"
 #. module: account
 #: sql_constraint:account.invoice.line:0
 msgid "Missing required account on accountable invoice line."
-msgstr ""
+msgstr "Falta conta obrigatória na linha de fatura responsável."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__moderator_id
 msgid "Moderated By"
-msgstr ""
+msgstr "Moderado por"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__moderation_status
 msgid "Moderation Status"
-msgstr ""
+msgstr "Estado de Moderação"
 
 #. module: account
 #. openerp-web
@@ -7087,7 +7118,7 @@ msgstr "Necessita ação"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__need_moderation
 msgid "Need moderation"
-msgstr ""
+msgstr "Precisa de moderação"
 
 #. module: account
 #. openerp-web
@@ -7137,7 +7168,7 @@ msgstr "Próximo Número"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__sequence_number_next_prefix
 msgid "Next Number Prefix"
-msgstr ""
+msgstr "Prefixo do próximo número"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line__blocked
@@ -7164,6 +7195,8 @@ msgid ""
 "No account was found to create the invoice, be sure you have installed a "
 "chart of account."
 msgstr ""
+"Não foi encontrada nenhuma conta para criar a fatura, certifique-se de ter instalado um"
+"plano de contas".
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__no_auto_thread
@@ -7239,6 +7272,8 @@ msgid ""
 "Note that the easiest way to create a credit note is to do it directly\n"
 "                from the customer invoice."
 msgstr ""
+"Note que a maneira mais fácil de criar uma nota de crédito é fazê-lo diretamente\n"
+"                da fatura do cliente."
 
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.action_invoice_in_refund
@@ -7246,6 +7281,8 @@ msgid ""
 "Note that the easiest way to create a vendor credit note it to do it "
 "directly from the vendor bill."
 msgstr ""
+"Note que a maneira mais fácil de criar uma nota de crédito do fornecedor é fazê-lo".
+"diretamente da conta do fornecedor."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__note
@@ -7370,12 +7407,12 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line__tax_line_grouping_key
 msgid "Old Taxes"
-msgstr ""
+msgstr "Impostos Antigos"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_line_form
 msgid "On the"
-msgstr ""
+msgstr "Sobre a"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_invoice_confirm_view
@@ -7555,6 +7592,9 @@ msgid ""
 "href=#id=%s&model=account.journal>email alias</a> to allow draft vendor "
 "bills to be created upon reception of an email."
 msgstr ""
+"Ou definir um <a data-oe-id=%s data-oe-model=\"account.journal\" "
+"href=#id=%s&model=account.journal>pseudônimo de e-mail</a> para permitir o projeto de fornecedor "
+"contas a serem criadas após a recepção de um e-mail."
 
 #. module: account
 #: code:addons/account/models/account_invoice.py:692
@@ -7701,7 +7741,7 @@ msgstr "Mensagem Principal"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_group__parent_path
 msgid "Parent Path"
-msgstr ""
+msgstr "Caminho do Pai"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line__parent_state
@@ -7745,24 +7785,24 @@ msgstr "Empresa Parceira"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__country_id
 msgid "Partner Company's Country"
-msgstr ""
+msgstr "País da empresa parceira"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_partner__contract_ids
 #: model:ir.model.fields,field_description:account.field_res_users__contract_ids
 msgid "Partner Contracts"
-msgstr ""
+msgstr "Contratos de Parceiros"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__match_partner
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_template__match_partner
 msgid "Partner Is Set"
-msgstr ""
+msgstr "Parceiro está definido"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_reconcile_model_form
 msgid "Partner Is Set & Matches"
-msgstr ""
+msgstr "Parceiro está definido & correspondências"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__partner_name
@@ -7790,7 +7830,7 @@ msgstr "Passado"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Pay your bills in one-click using Euro SEPA Service"
-msgstr ""
+msgstr "Pague as suas contas com um clique utilizando o Serviço Euro SEPA"
 
 #. module: account
 #: model:account.account.type,name:account.data_account_type_payable
@@ -7847,7 +7887,7 @@ msgstr "Diferença do Pagamento"
 #: model:ir.model.fields,field_description:account.field_account_payment__payment_difference_handling
 #: model:ir.model.fields,field_description:account.field_account_register_payments__payment_difference_handling
 msgid "Payment Difference Handling"
-msgstr ""
+msgstr "Tratamento da diferença de pagamento"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_abstract_payment__journal_id
@@ -7877,7 +7917,7 @@ msgstr "Tipo de Método de Pagamento"
 #: model_terms:ir.ui.view,arch_db:account.view_account_bank_journal_form
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_form
 msgid "Payment Method Types"
-msgstr ""
+msgstr "Tipos de formas de pagamento"
 
 #. module: account
 #. openerp-web
@@ -7909,7 +7949,7 @@ msgstr "Recibo de Pagamento:"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__reference
 msgid "Payment Ref."
-msgstr ""
+msgstr "Ref. Pagamento"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_payment__payment_reference
@@ -7959,7 +7999,7 @@ msgstr "Prazos de pagamento: 15 Dias"
 #. module: account
 #: model:account.payment.term,note:account.account_payment_term_2months
 msgid "Payment terms: 2 Months"
-msgstr ""
+msgstr "Condições de pagamento: 2 Meses"
 
 #. module: account
 #: model:account.payment.term,note:account.account_payment_term_net
@@ -7974,7 +8014,7 @@ msgstr "Prazo de pagamento: 30% de Adiantamento no Fim do Mês Seguinte"
 #. module: account
 #: model:account.payment.term,note:account.account_payment_term_45days
 msgid "Payment terms: 45 Days"
-msgstr ""
+msgstr "Condições de pagamento: 45 Dias"
 
 #. module: account
 #: model:account.payment.term,note:account.account_payment_term
@@ -8022,12 +8062,14 @@ msgid ""
 "Payments are used to register liquidity movements. You can process those "
 "payments by your own means or by using installed facilities."
 msgstr ""
+"Os pagamentos são utilizados para registar movimentos de liquidez. Você pode processar esses movimentos".
+"pagamentos pelos seus próprios meios ou usando as instalações instaladas."
 
 #. module: account
 #: code:addons/account/models/account_payment.py:444
 #, python-format
 msgid "Payments without a customer can't be matched"
-msgstr ""
+msgstr "Os pagamentos sem um cliente não podem ser correspondidos"
 
 #. module: account
 #: model:ir.actions.act_window,name:account.action_invoice_tree_pending_invoice
@@ -8072,7 +8114,7 @@ msgstr "Percentagem do balanço"
 #: code:addons/account/models/account_invoice.py:1975
 #, python-format
 msgid "Percentages on the Payment Terms lines must be between 0 and 100."
-msgstr ""
+msgstr "As percentagens nas linhas de Condições de Pagamento devem estar entre 0 e 100."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_invoice_filter
@@ -8093,7 +8135,7 @@ msgstr "Planejado"
 #: code:addons/account/models/account_invoice.py:1172
 #, python-format
 msgid "Please add at least one invoice line."
-msgstr ""
+msgstr "Por favor, adicione pelo menos uma linha de fatura."
 
 #. module: account
 #: code:addons/account/wizard/pos_box.py:27
@@ -8212,12 +8254,12 @@ msgstr "Prefixo das contas de caixa principais"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_chart_template__transfer_account_code_prefix
 msgid "Prefix of the main transfer accounts"
-msgstr ""
+msgstr "Prefixo das principais contas de transferência"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__transfer_account_code_prefix
 msgid "Prefix of the transfer accounts"
-msgstr ""
+msgstr "Prefixo das contas de transferência"
 
 #. module: account
 #: model:account.account.type,name:account.data_account_type_prepayments
@@ -8336,6 +8378,8 @@ msgid ""
 "Programmation Error: Can't call _get_invoice_matching_query() for different "
 "rules than 'invoice_matching'"
 msgstr ""
+"Erro de Programação": Não é possível chamar _get_invoice_matching_query() para diferente "
+"regras do que 'correspondência de faturação'".
 
 #. module: account
 #: code:addons/account/models/account_reconcile_model.py:489
@@ -8344,6 +8388,8 @@ msgid ""
 "Programmation Error: Can't call _get_wo_suggestion_query() for different "
 "rules than 'writeoff_suggestion'"
 msgstr ""
+"Erro de Programação": Não pode chamar _get_wo_suggestion_query() para diferente "
+"regras do que 'writeoff_suggestion'".
 
 #. module: account
 #: code:addons/account/models/account_payment.py:282
@@ -8415,7 +8461,7 @@ msgstr "Quantidade:"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__rating_value
 msgid "Rating Value"
-msgstr ""
+msgstr "Valor de Avaliação"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_refund__description
@@ -8450,7 +8496,7 @@ msgstr "Contas de Recebíveis"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__account_id
 msgid "Receivable/Payable Account"
-msgstr ""
+msgstr "Conta a receber/pagar"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.product_template_form_view
@@ -8479,7 +8525,7 @@ msgstr "Destinatários"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line__recompute_tax_line
 msgid "Recompute Tax Line"
-msgstr ""
+msgstr "Recompute Linha de Imposto"
 
 #. module: account
 #. openerp-web
@@ -8500,7 +8546,7 @@ msgstr "Conciliar lançamentos"
 #. module: account
 #: model:ir.model,name:account.model_account_reconcile_model_template
 msgid "Reconcile Model Template"
-msgstr ""
+msgstr "Reconciliar Modelo de Modelo"
 
 #. module: account
 #: selection:account.payment,state:0
@@ -8512,7 +8558,7 @@ msgstr "Conciliado"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_payment__reconciled_invoice_ids
 msgid "Reconciled Invoices"
-msgstr ""
+msgstr "Faturas reconciliadas"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
@@ -8559,7 +8605,7 @@ msgstr "Gravar transações em moedas extrangeiras"
 #: code:addons/account/models/account.py:930
 #, python-format
 msgid "Recursion found for tax '%s'."
-msgstr ""
+msgstr "Recurssão encontrada para impostos '%s'."
 
 #. module: account
 #. openerp-web
@@ -8639,14 +8685,14 @@ msgstr "Registrar Pagamento"
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.action_bank_statement_tree
 msgid "Register a bank statement"
-msgstr ""
+msgstr "Registrar um extrato bancário"
 
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.action_account_payments
 #: model_terms:ir.actions.act_window,help:account.action_account_payments_payable
 #: model_terms:ir.actions.act_window,help:account.action_account_payments_transfer
 msgid "Register a payment"
-msgstr ""
+msgstr "Registrar um pagamento"
 
 #. module: account
 #: selection:account.account.type,type:0
@@ -8666,7 +8712,7 @@ msgstr "Modelo de Documento Relacionado"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__rating_ids
 msgid "Related ratings"
-msgstr ""
+msgstr "Avaliações relacionadas"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice__residual_company_signed
@@ -8750,7 +8796,7 @@ msgstr "Valor residual em Moeda"
 #: code:addons/account/models/account_journal_dashboard.py:32
 #, python-format
 msgid "Residual amount"
-msgstr ""
+msgstr "Valor residual"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement__user_id
@@ -8766,13 +8812,13 @@ msgstr "Usuário Responsável"
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__match_partner_category_ids
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_template__match_partner_category_ids
 msgid "Restrict Partner Categories to"
-msgstr ""
+msgstr "Restringir categorias de parceiros a"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__match_partner_ids
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_template__match_partner_ids
 msgid "Restrict Partners to"
-msgstr ""
+msgstr "Restringir parceiros a"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__match_same_currency
@@ -8780,6 +8826,7 @@ msgstr ""
 msgid ""
 "Restrict to propositions having the same currency as the statement line."
 msgstr ""
+"Restringir a propostas que tenham a mesma moeda que a linha de declaração."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_digest_digest__kpi_account_total_revenue
@@ -8794,12 +8841,12 @@ msgstr "Reconhecimento de Receita"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__account_line_id
 msgid "Revenue/Expense Account"
-msgstr ""
+msgstr "Conta de receita/despesa"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move__reverse_date
 msgid "Reversal Date"
-msgstr ""
+msgstr "Data de estorno"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_reversal__date
@@ -8810,12 +8857,12 @@ msgstr "Data do estorno"
 #: code:addons/account/models/account_move.py:399
 #, python-format
 msgid "Reversal of: %s"
-msgstr ""
+msgstr "Reversão de: %s"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move__auto_reverse
 msgid "Reverse Automatically"
-msgstr ""
+msgstr "Reverter automaticamente"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move__reverse_entry_id
@@ -8834,7 +8881,7 @@ msgstr "Movimentações Reversas"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
 msgid "Reversed entry"
-msgstr ""
+msgstr "Entrada inversa"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.onboarding_chart_of_account_step
@@ -8901,7 +8948,7 @@ msgstr "Débito Direto SEPA(SDD)"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "SEPA QR Code"
-msgstr ""
+msgstr "Código QR SEPA"
 
 #. module: account
 #: selection:account.journal,type:0
@@ -8927,7 +8974,7 @@ msgstr "Imposto sobre Vendas"
 #. module: account
 #: model:ir.actions.act_window,name:account.action_open_account_onboarding_sale_tax
 msgid "Sales tax"
-msgstr ""
+msgstr "Imposto sobre vendas"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__user_id
@@ -8941,35 +8988,35 @@ msgstr "Vendedor"
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__match_same_currency
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_template__match_same_currency
 msgid "Same Currency Matching"
-msgstr ""
+msgstr "Correspondência da mesma moeda"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.onboarding_sample_invoice_step
 msgid "Sample Invoice"
-msgstr ""
+msgstr "Exemplo de Fatura"
 
 #. module: account
 #: code:addons/account/models/company.py:462
 #, python-format
 msgid "Sample invoice"
-msgstr ""
+msgstr "Exemplo de fatura"
 
 #. module: account
 #: code:addons/account/models/company.py:468
 #, python-format
 msgid "Sample invoice line name"
-msgstr ""
+msgstr "Exemplo de nome da linha da fatura"
 
 #. module: account
 #: code:addons/account/models/company.py:475
 #, python-format
 msgid "Sample invoice line name 2"
-msgstr ""
+msgstr "Exemplo de nome da linha de fatura 2"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.onboarding_sample_invoice_step
 msgid "Sample invoice sent!"
-msgstr ""
+msgstr "Exemplo de fatura enviada!"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_setup_bank_manual_config__sanitized_acc_number
@@ -9026,7 +9073,7 @@ msgstr "Pesquisar Modelos de Planos de Conta"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_position_filter
 msgid "Search Fiscal Positions"
-msgstr ""
+msgstr "Pesquisar Posições Fiscais"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_invoice_filter
@@ -9074,7 +9121,7 @@ msgstr "Segunda Conta Analítica"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__second_analytic_tag_ids
 msgid "Second Analytic Tags"
-msgstr ""
+msgstr "Segunda Tags Analíticas"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__second_journal_id
@@ -9096,19 +9143,19 @@ msgstr "Segunda Taxa"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__second_tax_amount_type
 msgid "Second Tax Amount Type"
-msgstr ""
+msgstr "Segundo tipo de montante de imposto"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__force_second_tax_included
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_template__force_second_tax_included
 msgid "Second Tax Included in Price"
-msgstr ""
+msgstr "Segundo Imposto Incluído no Preço"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__second_amount
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_template__second_amount
 msgid "Second Write-off Amount"
-msgstr ""
+msgstr "Segundo Valor de Baixa"
 
 #. module: account
 #: selection:account.invoice.line,display_type:0
@@ -9145,7 +9192,7 @@ msgstr "Selecione um parceiro ou escolha uma contraparte"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.invoice_supplier_form
 msgid "Select an old vendor bill"
-msgstr ""
+msgstr "Selecione uma conta antiga do fornecedor"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_payment_term_line__value
@@ -9195,7 +9242,7 @@ msgstr "Enviar"
 #: model_terms:ir.ui.view,arch_db:account.account_invoice_send_wizard_form
 #: model_terms:ir.ui.view,arch_db:account.invoice_form
 msgid "Send & Print"
-msgstr ""
+msgstr "Enviar & Imprimir"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__invoice_is_email
@@ -9207,7 +9254,7 @@ msgstr "Enviar E-mail"
 #: code:addons/account/wizard/account_invoice_send.py:76
 #, python-format
 msgid "Send Invoice"
-msgstr ""
+msgstr "Enviar Fatura"
 
 #. module: account
 #: selection:account.abstract.payment,payment_type:0
@@ -9224,17 +9271,17 @@ msgstr "Enviar Recibo Por Email"
 #. module: account
 #: model:ir.actions.act_window,name:account.action_open_account_onboarding_sample_invoice
 msgid "Send a sample invoice"
-msgstr ""
+msgstr "Enviar um modelo de fatura"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.onboarding_sample_invoice_step
 msgid "Send an invoice to test the customer portal."
-msgstr ""
+msgstr "Envie uma fatura para testar o portal do cliente."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.onboarding_sample_invoice_step
 msgid "Send sample"
-msgstr ""
+msgstr "Enviar amostra"
 
 #. module: account
 #: selection:account.payment,state:0
@@ -9271,7 +9318,7 @@ msgstr "Seqüência"
 #: code:addons/account/static/src/xml/account_reconciliation.xml:239
 #, python-format
 msgid "Set"
-msgstr ""
+msgstr "Conjunto"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_form
@@ -9297,7 +9344,7 @@ msgstr "Defina de ativo para falso para esconder o imposto sem removê-lo."
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.onboarding_sale_tax_step
 msgid "Set taxes"
-msgstr ""
+msgstr "Definir impostos"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_chart_template__visible
@@ -9362,7 +9409,7 @@ msgstr "Código Abreviado"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_register_payments__show_communication_field
 msgid "Show Communication Field"
-msgstr ""
+msgstr "Mostrar Campo de Comunicação"
 
 #. module: account
 #: model:res.groups,name:account.group_account_user
@@ -9374,7 +9421,7 @@ msgstr "Mostrar Todas as Funcionalidades de Contabilidade"
 #: model:ir.model.fields,field_description:account.field_account_payment__show_partner_bank_account
 #: model:ir.model.fields,field_description:account.field_account_register_payments__show_partner_bank_account
 msgid "Show Partner Bank Account"
-msgstr ""
+msgstr "Mostrar conta bancária do parceiro"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_tax_search
@@ -9400,18 +9447,18 @@ msgstr "Mostrar diário no dashboard"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__group_show_line_subtotals_tax_included
 msgid "Show line subtotals with taxes (B2C)"
-msgstr ""
+msgstr "Mostrar subtotais de linha com impostos (B2C)"
 
 #. module: account
 #: model:res.groups,comment:account.group_show_line_subtotals_tax_included
 msgid "Show line subtotals with taxes included (B2C)"
-msgstr ""
+msgstr "Mostrar subtotais de linha com impostos incluídos (B2C)"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__group_show_line_subtotals_tax_excluded
 #: model:res.groups,comment:account.group_show_line_subtotals_tax_excluded
 msgid "Show line subtotals without taxes (B2B)"
-msgstr ""
+msgstr "Mostrar subtotais de linha sem impostos (B2B)"
 
 #. module: account
 #. openerp-web
@@ -9437,7 +9484,7 @@ msgstr ""
 #: code:addons/account/static/src/js/reconciliation/reconciliation_renderer.js:764
 #, python-format
 msgid "Some fields are undefined"
-msgstr ""
+msgstr "Alguns campos são indefinidos"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_setup_bank_manual_config__bank_bic
@@ -9453,7 +9500,7 @@ msgstr "Documento de Origem"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__source_email
 msgid "Source Email"
-msgstr ""
+msgstr "Email de origem"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_cash_rounding__strategy
@@ -9500,42 +9547,42 @@ msgstr "Estado"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__account_dashboard_onboarding_state
 msgid "State of the account dashboard onboarding panel"
-msgstr ""
+msgstr "Estado do painel de bordo do painel de bordo da conta"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__account_invoice_onboarding_state
 msgid "State of the account invoice onboarding panel"
-msgstr ""
+msgstr "Estado da fatura da conta no painel de embarque"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__account_setup_bank_data_state
 msgid "State of the onboarding bank data step"
-msgstr ""
+msgstr "Estado da etapa de dados do banco de bordo"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__account_setup_coa_state
 msgid "State of the onboarding charts of account step"
-msgstr ""
+msgstr "Estado da etapa dos mapas de bordo da conta"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__account_setup_fy_data_state
 msgid "State of the onboarding fiscal year step"
-msgstr ""
+msgstr "Estado da etapa do ano fiscal de embarque"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__account_onboarding_invoice_layout_state
 msgid "State of the onboarding invoice layout step"
-msgstr ""
+msgstr "Estado da etapa de layout da fatura de embarque"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__account_onboarding_sale_tax_state
 msgid "State of the onboarding sale tax step"
-msgstr ""
+msgstr "Estado da etapa fiscal da venda a bordo"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__account_onboarding_sample_invoice_state
 msgid "State of the onboarding sample invoice step"
-msgstr ""
+msgstr "Estado da etapa da fatura da amostra de embarque"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move_line__parent_state
@@ -9616,7 +9663,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.onboarding_fiscal_year_step
 #: model_terms:ir.ui.view,arch_db:account.onboarding_sale_tax_step
 msgid "Step Completed!"
-msgstr ""
+msgstr "Passo Concluído!"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__subject
@@ -9644,14 +9691,14 @@ msgstr "Subtipo"
 #: code:addons/account/models/chart_template.py:933
 #, python-format
 msgid "Suggest a write-off."
-msgstr ""
+msgstr "Sugira uma anulação."
 
 #. module: account
 #: selection:account.reconcile.model,rule_type:0
 #: code:addons/account/models/account_reconcile_model.py:20
 #, python-format
 msgid "Suggest counterpart values."
-msgstr ""
+msgstr "Sugerir valores de contrapartida."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -9728,7 +9775,7 @@ msgstr "Ajuste de impostos"
 #. module: account
 #: model:ir.model,name:account.model_tax_adjustments_wizard
 msgid "Tax Adjustments Wizard"
-msgstr ""
+msgstr "Assistente de Ajustes de Impostos"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_line__price_tax
@@ -9740,7 +9787,7 @@ msgstr "Valor do Imposto"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__tax_amount_type
 msgid "Tax Amount Type"
-msgstr ""
+msgstr "Tipo de Valor do Imposto"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_tax_search
@@ -9804,7 +9851,7 @@ msgstr "Grupo de Imposto"
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_template__force_tax_included
 #, python-format
 msgid "Tax Included in Price"
-msgstr ""
+msgstr "Impostos Incluídos no Preço"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__tax_line_ids
@@ -9821,12 +9868,12 @@ msgstr "Mapeamento de Impostos"
 #. module: account
 #: model:ir.model,name:account.model_account_fiscal_position_tax_template
 msgid "Tax Mapping Template of Fiscal Position"
-msgstr ""
+msgstr "Modelo de Mapeamento de Impostos da Posição Fiscal"
 
 #. module: account
 #: model:ir.model,name:account.model_account_fiscal_position_tax
 msgid "Tax Mapping of Fiscal Position"
-msgstr ""
+msgstr "Mapeamento da Posição Fiscal"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_tax__name
@@ -9869,12 +9916,12 @@ msgstr "Modelo de Impostos"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move__tax_type_domain
 msgid "Tax Type Domain"
-msgstr ""
+msgstr "Tipo de Imposto Domínio"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__amount_by_group
 msgid "Tax amount by group"
-msgstr ""
+msgstr "Valor do imposto por grupo"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__tax_calculation_rounding_method
@@ -9894,7 +9941,7 @@ msgstr "Mostrar taxas em B2C"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__amount_tax_signed
 msgid "Tax in Invoice Currency"
-msgstr ""
+msgstr "Imposto na moeda da fatura"
 
 #. module: account
 #: sql_constraint:account.tax:0 sql_constraint:account.tax.template:0
@@ -9914,12 +9961,12 @@ msgstr "Imposto a Aplicar"
 #. module: account
 #: selection:res.config.settings,show_line_subtotals_tax_selection:0
 msgid "Tax-Excluded"
-msgstr ""
+msgstr "Excluído de impostos"
 
 #. module: account
 #: selection:res.config.settings,show_line_subtotals_tax_selection:0
 msgid "Tax-Included"
-msgstr ""
+msgstr "Inclui impostos"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -9944,7 +9991,7 @@ msgstr "Impostos"
 #: model:ir.model.fields,field_description:account.field_account_move_line__tax_ids
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
 msgid "Taxes Applied"
-msgstr ""
+msgstr "Impostos Aplicados"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_position_template_form
@@ -9954,7 +10001,7 @@ msgstr "Mapear taxas"
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move_line__tax_ids
 msgid "Taxes that apply on the base amount"
-msgstr ""
+msgstr "Impostos que se aplicam sobre o montante base"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_tax_template_search
@@ -9982,6 +10029,9 @@ msgid ""
 "                                                                                                                                                                       This does not especially correspond to the invoices reconciled with the payment,\n"
 "                                                                                                                                                                       as it can have been generated first, and reconciled later"
 msgstr ""
+"Campo técnico contendo as faturas para as quais o pagamento foi gerado.\n"
+"                                                                                                                                                                       Isto não corresponde especialmente às faturas reconciliadas com o pagamento,\n".
+"                                                                                                                                                                       como pode ter sido gerado primeiro, e reconciliado depois".
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice_line__display_type
@@ -10066,6 +10116,8 @@ msgid ""
 "Technical field used inside the view to make the force_second_tax_included "
 "field invisible if the tax is a group."
 msgstr ""
+"Campo técnico usado dentro da vista para fazer o force_second_tax_included"
+"campo invisível se o imposto for um grupo."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__is_second_tax_price_included
@@ -10073,6 +10125,8 @@ msgid ""
 "Technical field used inside the view to make the force_second_tax_included "
 "field readonly if the tax is already price included."
 msgstr ""
+"Campo técnico usado dentro da vista para fazer o force_second_tax_included"
+"campo só leitura se o imposto já tiver o preço incluído."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__tax_amount_type
@@ -10080,6 +10134,8 @@ msgid ""
 "Technical field used inside the view to make the force_tax_included field "
 "invisible if the tax is a group."
 msgstr ""
+"Campo técnico usado dentro da vista para fazer o campo force_tax_included"
+"invisível se o imposto for um grupo."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__is_tax_price_included
@@ -10087,6 +10143,8 @@ msgid ""
 "Technical field used inside the view to make the force_tax_included field "
 "readonly if the tax is already price included."
 msgstr ""
+"Campo técnico usado dentro da vista para fazer o campo force_tax_included"
+"só leitura se o imposto já estiver incluído no preço."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_abstract_payment__payment_method_code
@@ -10110,7 +10168,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move__tax_type_domain
 msgid "Technical field used to have a dynamic taxes domain on the form view."
-msgstr ""
+msgstr "Campo técnico usado para ter um domínio dinâmico de impostos na vista do formulário."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_abstract_payment__hide_payment_method
@@ -10140,6 +10198,8 @@ msgid ""
 "Technical field used to know if the tax_ids field has been modified in the "
 "UI."
 msgstr ""
+"Campo técnico usado para saber se o campo tax_ids foi modificado no "
+"UI."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_abstract_payment__show_partner_bank_account
@@ -10149,6 +10209,8 @@ msgid ""
 "Technical field used to know whether the field `partner_bank_account_id` "
 "needs to be displayed or not in the payments form views"
 msgstr ""
+"Campo técnico utilizado para saber se o campo `partner_bank_account_id_id`" "
+"precisa de ser exibido ou não nas visualizações da forma de pagamento".
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move_line__tax_exigible
@@ -10170,6 +10232,8 @@ msgid ""
 "Technical field used to store the bank account number before its creation, "
 "upon the line's processing"
 msgstr ""
+"Campo técnico utilizado para armazenar o número da conta bancária antes da sua criação,"
+"no processamento da linha"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move_line__tax_line_grouping_key
@@ -10178,6 +10242,9 @@ msgid ""
 "lines (in account.move form view) between the moment the user changed it and"
 " the moment the ORM reflects that change in its one2many"
 msgstr ""
+"Campo técnico utilizado para armazenar os valores antigos dos campos utilizados para o cálculo de impostos"
+"linhas (em account.move form view) entre o momento em que o utilizador a alterou e"
+"o momento em que o ORM reflete essa mudança no seu one2many".
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__chart_template_id
@@ -10229,6 +10296,8 @@ msgid ""
 "The 'Internal Group' is used to filter accounts based on the internal group "
 "set on the account type."
 msgstr ""
+"O 'Grupo Interno' é usado para filtrar contas baseadas no grupo interno".
+"definir no tipo de conta."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_account__internal_type
@@ -10246,7 +10315,7 @@ msgstr ""
 #: code:addons/account/models/account_move.py:1059
 #, python-format
 msgid "The account %s (%s) is deprecated."
-msgstr ""
+msgstr "A conta %s (%s) está depreciada."
 
 #. module: account
 #: code:addons/account/models/account_invoice.py:521
@@ -10255,6 +10324,8 @@ msgid ""
 "The account selected for payment does not belong to the same company as this"
 " invoice."
 msgstr ""
+"A conta selecionada para pagamento não pertence à mesma empresa que esta".
+"fatura."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_setup_bank_manual_config__journal_id
@@ -10295,7 +10366,7 @@ msgstr ""
 #: code:addons/account/models/account_bank_statement.py:319
 #, python-format
 msgid "The amount of a cash transaction cannot be 0."
-msgstr ""
+msgstr "O valor de uma transação em dinheiro não pode ser 0."
 
 #. module: account
 #: code:addons/account/models/account.py:932
@@ -10304,6 +10375,8 @@ msgid ""
 "The application scope of taxes in a group must be either the same as the "
 "group or left empty."
 msgstr ""
+"O âmbito de aplicação dos impostos de um grupo deve ser o mesmo que o "
+"grupo ou deixado vazio."
 
 #. module: account
 #: code:addons/account/models/account.py:551
@@ -10320,6 +10393,9 @@ msgid ""
 "                                                                                                       This is useful if you install accounting after having used invoicing for some time and\n"
 "                                                                                                       don't want to reconcile all the past payments with bank statements."
 msgstr ""
+"O widget de reconciliação bancária não vai pedir para reconciliar pagamentos mais antigos que esta data.\n"
+"                                                                                                       Isto é útil se você instalar a contabilidade depois de ter usado a faturação durante algum tempo e\n".
+"                                                                                                       não quero reconciliar todos os pagamentos passados com extratos bancários."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_res_config_settings__account_bank_reconciliation_start
@@ -10328,6 +10404,9 @@ msgid ""
 "               This is useful if you install accounting after having used invoicing for some time and\n"
 "               don't want to reconcile all the past payments with bank statements."
 msgstr ""
+"O widget de reconciliação bancária não vai pedir para reconciliar pagamentos mais antigos que esta data.\n"
+"               Isto é útil se você instalar a contabilidade depois de ter usado a facturação durante algum tempo e\n".
+"               não quero reconciliar todos os pagamentos passados com extractos bancários."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move_line__statement_id
@@ -10377,6 +10456,8 @@ msgid ""
 "The currency of the bank statement line must be different than the statement"
 " currency."
 msgstr ""
+"A moeda da linha do extrato bancário deve ser diferente da moeda do extrato"
+"moeda."
 
 #. module: account
 #: code:addons/account/models/account.py:551
@@ -10385,6 +10466,8 @@ msgid ""
 "The currency of the journal should be the same than the default credit "
 "account."
 msgstr ""
+"A moeda do diário deve ser a mesma que o crédito padrão".
+"conta."
 
 #. module: account
 #: code:addons/account/models/account.py:553
@@ -10393,6 +10476,8 @@ msgid ""
 "The currency of the journal should be the same than the default debit "
 "account."
 msgstr ""
+"A moeda do diário deve ser a mesma que o débito padrão".
+"conta."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_journal__currency_id
@@ -10403,7 +10488,7 @@ msgstr "A moeda utilizada para entradas no informe/demonstrativo"
 #: code:addons/account/models/account_invoice.py:1981
 #, python-format
 msgid "The day of the month used for this term must be stricly positive."
-msgstr ""
+msgstr "O dia do mês utilizado para este termo deve ser rigorosamente positivo."
 
 #. module: account
 #: code:addons/account/models/account_bank_statement.py:193
@@ -10441,13 +10526,15 @@ msgid ""
 "The field Vendor is required, please complete it to validate the Vendor "
 "Bill."
 msgstr ""
+"O campo Fornecedor é obrigatório, por favor complete-o para validar o Fornecedor".
+"Bill."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_res_partner__property_account_position_id
 #: model:ir.model.fields,help:account.field_res_users__property_account_position_id
 msgid ""
 "The fiscal position determines the taxes/accounts used for this contact."
-msgstr ""
+msgstr "A posição fiscal determina os impostos/contas usados para este contato."
 
 #. module: account
 #: code:addons/account/wizard/account_invoice_send.py:59
@@ -10456,6 +10543,8 @@ msgid ""
 "The following invoice(s) will not be sent by email, because the customers "
 "don't have email address."
 msgstr ""
+"A factura ou facturas seguintes não serão enviadas por e-mail, porque os clientes".
+"não tem endereço de e-mail."
 
 #. module: account
 #: code:addons/account/models/account.py:564
@@ -10598,6 +10687,8 @@ msgid ""
 "The payment communication that will be automatically populated once the "
 "invoice validation. You can also write a free communication."
 msgstr ""
+"A comunicação de pagamento que será automaticamente preenchida uma vez que o "
+"validação da fatura". Você também pode escrever uma comunicação gratuita".
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -10605,6 +10696,8 @@ msgid ""
 "The payments which have not been matched with a bank statement will not be "
 "shown in bank reconciliation data if they were made before this date."
 msgstr ""
+"Os pagamentos que não forem combinados com um extrato bancário não serão".
+"mostrado nos dados de reconciliação bancária, se foram feitos antes desta data."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__match_partner_category_ids
@@ -10613,6 +10706,8 @@ msgid ""
 "The reconciliation model will only be applied to the selected "
 "customer/vendor categories."
 msgstr ""
+"O modelo de reconciliação só será aplicado ao selecionado".
+"categorias de clientes/fornecedores".
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__match_partner_ids
@@ -10621,6 +10716,8 @@ msgid ""
 "The reconciliation model will only be applied to the selected "
 "customers/vendors."
 msgstr ""
+"O modelo de reconciliação só será aplicado ao selecionado".
+"clientes/vendedores."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__match_nature
@@ -10631,6 +10728,10 @@ msgid ""
 "        * Amount Paid: Only applied when paying an amount.\n"
 "        * Amount Paid/Received: Applied in both cases."
 msgstr ""
+"O modelo de reconciliação só será aplicado ao tipo de transação selecionada:\n".
+"        * Montante Recebido: Só aplicado ao receber uma quantia.\n"
+"        * Montante pago: Só aplicado quando se paga uma quantia.\n"
+"        * Montante Pago/Recebido: Aplicado em ambos os casos."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__match_partner
@@ -10638,6 +10739,7 @@ msgstr ""
 msgid ""
 "The reconciliation model will only be applied when a customer/vendor is set."
 msgstr ""
+"O modelo de reconciliação só será aplicado quando um cliente/vendedor for definido."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__match_amount
@@ -10646,6 +10748,8 @@ msgid ""
 "The reconciliation model will only be applied when the amount being lower "
 "than, greater than or between specified amount(s)."
 msgstr ""
+"O modelo de reconciliação só será aplicado quando o valor for inferior".
+"do que, maior ou entre quantidade(s) especificada(s)."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__match_label
@@ -10656,6 +10760,10 @@ msgid ""
 "        * Not Contains: Negation of \"Contains\".\n"
 "        * Match Regex: Define your own regular expression."
 msgstr ""
+"O modelo de reconciliação só será aplicado quando o rótulo:\n"
+"        * Contém: A etiqueta da proposta deve conter esta string (insensível a maiúsculas e minúsculas).\n".
+"        * Não contém: Negativo de "Contém".n"
+"        * Match Regex: Define a tua própria expressão regular."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__match_journal_ids
@@ -10663,6 +10771,7 @@ msgstr ""
 msgid ""
 "The reconciliation model will only be available from the selected journals."
 msgstr ""
+"O modelo de reconciliação só estará disponível nos periódicos selecionados."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move_line__amount_residual_currency
@@ -10696,6 +10805,8 @@ msgid ""
 "The selected unit of measure has to be in the same category as the product "
 "unit of measure."
 msgstr ""
+"A unidade de medida seleccionada tem de estar na mesma categoria que o produto".
+"unidade de medida."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_tax__sequence
@@ -10714,6 +10825,8 @@ msgid ""
 "The sum of total residual amount propositions matches the statement line "
 "amount under this percentage."
 msgstr ""
+"A soma das propostas do montante total residual corresponde à linha de declaração".
+"montante abaixo desta percentagem."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__match_total_amount
@@ -10722,6 +10835,8 @@ msgid ""
 "The sum of total residual amount propositions matches the statement line "
 "amount."
 msgstr ""
+"A soma das propostas do montante total residual corresponde à linha de declaração".
+"montante."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_cash_rounding__rounding_method
@@ -10751,6 +10866,8 @@ msgid ""
 "There is no Transfer Account defined in the accounting settings. Please "
 "define one to be able to confirm this transfer."
 msgstr ""
+"Não existe uma Conta de Transferência definida nas definições contabilísticas. Por favor".
+"Defina um para poder confirmar esta transferência."
 
 #. module: account
 #: code:addons/account/models/account_bank_statement.py:181
@@ -10852,6 +10969,8 @@ msgid ""
 "This allows you grouping payments into a single batch and eases the reconciliation process.\n"
 "-This installs the account_batch_payment module."
 msgstr ""
+"Isto permite agrupar pagamentos em um único lote e facilita o processo de reconciliação.\n"
+"-Isto instala o módulo account_batch_payment."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -10893,6 +11012,8 @@ msgid ""
 "This customer invoice credit note has been created from: <a href=# data-oe-"
 "model=account.invoice data-oe-id=%d>%s</a><br>Reason: %s"
 msgstr ""
+"Esta nota de crédito da fatura do cliente foi criada a partir de: <a href=# data-oe-"
+"model=account.invoice data-oe-id=%d>%s</a>>br> Razão: %s"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -11008,6 +11129,8 @@ msgid ""
 "This parameter will be bypassed in case of a statement line communication "
 "matching exactly existing entries"
 msgstr ""
+"Este parâmetro será contornado no caso de uma comunicação de linha de declaração".
+"correspondendo exatamente às entradas existentes".
 
 #. module: account
 #. openerp-web
@@ -11054,6 +11177,8 @@ msgid ""
 "This vendor bill credit note has been created from: <a href=# data-oe-"
 "model=account.invoice data-oe-id=%d>%s</a><br>Reason: %s"
 msgstr ""
+"Esta nota de crédito da fatura do fornecedor foi criada a partir de: <a href=# data-oe-"
+"model=account.invoice data-oe-id=%d>%s</a><br>Razão: %s"
 
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.action_validate_account_move
@@ -11101,7 +11226,7 @@ msgstr ""
 #: code:addons/account/static/src/xml/account_reconciliation.xml:169
 #, python-format
 msgid "To speed up reconciliation, define"
-msgstr ""
+msgstr "Para acelerar a reconciliação, defina"
 
 #. module: account
 #: selection:account.invoice,activity_state:0
@@ -11131,7 +11256,7 @@ msgstr "Valor Total"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_line_tax_audit_tree
 msgid "Total Base Amount"
-msgstr ""
+msgstr "Valor Base Total"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
@@ -11171,7 +11296,7 @@ msgstr "Total Residual"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__user_currency_price_total
 msgid "Total Without Tax in Currency"
-msgstr ""
+msgstr "Total Sem Imposto em Moeda"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice_line__price_subtotal_signed
@@ -11238,6 +11363,8 @@ msgid ""
 "Tracked values are stored in a separate model. This field allow to "
 "reconstruct the tracking and to generate statistics on the model."
 msgstr ""
+"Os valores rastreados são armazenados em um modelo separado. Este campo permite "
+"reconstruir o rastreamento e gerar estatísticas sobre o modelo."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__tracking_value_ids
@@ -11418,7 +11545,7 @@ msgstr "Quantia Não Tributada na Moeda da Empresa"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__amount_untaxed_invoice_signed
 msgid "Untaxed Amount in Invoice Currency"
-msgstr ""
+msgstr "Valor não tributado na moeda de faturação"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__price_total
@@ -11440,7 +11567,7 @@ msgstr "Enviar"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_invoice_import_wizard_form_view
 msgid "Upload Files"
-msgstr ""
+msgstr "Carregar arquivos"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_chart_template__use_anglo_saxon
@@ -11475,12 +11602,12 @@ msgstr "Usar contabilidade anglo-saxão"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__module_account_batch_payment
 msgid "Use batch payments"
-msgstr ""
+msgstr "Utilizar pagamentos por lotes"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Use budgets to compare actual with expected revenues and costs"
-msgstr ""
+msgstr "Utilizar orçamentos para comparar receitas e custos reais com os previstos"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -11495,12 +11622,12 @@ msgstr "Usar os níveis de acompanhamento e agendar ações"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__group_products_in_bills
 msgid "Use products in vendor bills"
-msgstr ""
+msgstr "Utilizar produtos nas contas do fornecedor"
 
 #. module: account
 #: model:res.groups,name:account.group_products_in_bills
 msgid "Use products on vendor bills"
-msgstr ""
+msgstr "Utilizar produtos nas contas do fornecedor"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__template_id
@@ -11614,7 +11741,8 @@ msgstr "Validar Movimento de Conta"
 msgid ""
 "Validate the statement line automatically (reconciliation based on your "
 "rule)."
-msgstr ""
+msgstr ""Validar a linha de declaração automaticamente (reconciliação baseada na sua "
+"regra).""
 
 #. module: account
 #: selection:account.bank.statement,state:0
@@ -11686,7 +11814,7 @@ msgstr "Nota de Crédito de fornecedor"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__vendor_display_name
 msgid "Vendor Display Name"
-msgstr ""
+msgstr "Nome de exibição do fornecedor"
 
 #. module: account
 #: code:addons/account/models/account_payment.py:774
@@ -11705,7 +11833,7 @@ msgstr "Termos de Pagamento do Fornecedor"
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_search
 msgid "Vendor Payments"
-msgstr ""
+msgstr "Pagamentos de fornecedores"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.invoice_supplier_form
@@ -11735,7 +11863,7 @@ msgstr "Visão"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_partner_property_form
 msgid "View accounts detail"
-msgstr ""
+msgstr "Ver detalhe de contas"
 
 #. module: account
 #: selection:res.partner,invoice_warn:0
@@ -11768,7 +11896,7 @@ msgstr "Aviso"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__group_warning_account
 msgid "Warnings in Invoices"
-msgstr ""
+msgstr "Avisos nas faturas"
 
 #. module: account
 #: code:addons/account/models/company.py:518
@@ -11777,6 +11905,8 @@ msgid ""
 "We cannot find a chart of accounts for this company, you should configure it. \n"
 "Please go to Account Configuration and select or install a fiscal localization."
 msgstr ""
+"Não conseguimos encontrar um plano de contas para esta empresa, você deve configurá-lo. \n"
+"Por favor, vá para Configuração de Conta e selecione ou instale uma localização fiscal."
 
 #. module: account
 #: code:addons/account/models/company.py:457
@@ -11785,6 +11915,8 @@ msgid ""
 "We cannot find any journal for this company. You should create one.\n"
 "Please go to Configuration > Journals."
 msgstr ""
+"Não conseguimos encontrar nenhum diário para esta empresa. Você deveria criar um.\n"
+"Por favor, vá para Configuração > Periódicos."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement__website_message_ids
@@ -11806,6 +11938,8 @@ msgid ""
 "When receiving an email with a bill, or uploading scanned bills, Odoo will "
 "parse them (OCR) and auto-complete (AI) Draft Bills to validate."
 msgstr ""
+"Não conseguimos encontrar nenhum diário para esta empresa. Você deveria criar um.\n"
+"Por favor, vá para Configuração > Periódicos."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_journal__post_at_bank_rec
@@ -11814,6 +11948,9 @@ msgid ""
 "draft state, so that the related journal entries are only posted when "
 "performing bank reconciliation."
 msgstr ""
+"Se os pagamentos feitos nesta revista devem ou não ser gerados em".
+"rascunho de estado, para que os lançamentos de diário relacionados só sejam publicados quando"
+"a fazer a reconciliação bancária."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice_send__is_log
@@ -11828,7 +11965,7 @@ msgstr "Se este diário deve ser exibido no dashboard ou não"
 #. module: account
 #: model:ir.model.fields,help:account.field_account_setup_bank_manual_config__new_journal_name
 msgid "Will be used to name the Journal related to this bank account"
-msgstr ""
+msgstr "Será usado para nomear o Diário relacionada com esta conta bancária"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_common_journal_report__amount_currency
@@ -11852,14 +11989,14 @@ msgstr "Baixa"
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__amount
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_template__amount
 msgid "Write-off Amount"
-msgstr ""
+msgstr "Valor de anulação"
 
 #. module: account
 #. openerp-web
 #: code:addons/account/static/src/xml/account_reconciliation.xml:217
 #, python-format
 msgid "Writeoff Date"
-msgstr ""
+msgstr "Data de anulação"
 
 #. module: account
 #: sql_constraint:account.move.line:0
@@ -11867,6 +12004,8 @@ msgid ""
 "Wrong credit or debit value in accounting entry! Credit and debit should be "
 "positive."
 msgstr ""
+"Valor de crédito ou débito errado no lançamento contabilístico! O crédito e o débito devem ser "
+"Positivo."
 
 #. module: account
 #: sql_constraint:account.move.line:0
@@ -11874,6 +12013,8 @@ msgid ""
 "Wrong credit or debit value in accounting entry! Credit or debit should be "
 "zero."
 msgstr ""
+"Valor de crédito ou débito errado no lançamento contabilístico! O crédito ou débito deve ser "
+"zero."
 
 #. module: account
 #: code:addons/account/models/account_move.py:944
@@ -11906,6 +12047,8 @@ msgid ""
 "You can not delete payment terms as other records still reference it. "
 "However, you can archive it."
 msgstr ""
+"Você não pode apagar as condições de pagamento, pois outros registros ainda fazem referência a ele. "
+"No entanto, você pode arquivá-lo."
 
 #. module: account
 #: code:addons/account/models/account_fiscal_year.py:55
@@ -11938,6 +12081,9 @@ msgid ""
 "invoices, once validated, to help the customer to refer to that particular "
 "invoice when making the payment."
 msgstr ""
+"Você pode definir aqui a comunicação padrão que aparecerá no cliente".
+"facturas, uma vez validadas, para ajudar o cliente a referir-se a esse particular".
+"factura ao fazer o pagamento."
 
 #. module: account
 #: code:addons/account/models/account_move.py:373
@@ -11995,6 +12141,8 @@ msgid ""
 "You cannot create journal items with a secondary currency without filling "
 "both 'currency' and 'amount currency' fields."
 msgstr ""
+"Você não pode criar itens de diário com uma moeda secundária sem preencher"
+"ambos os campos 'moeda' e 'moeda do montante'."
 
 #. module: account
 #: code:addons/account/models/company.py:187
@@ -12011,7 +12159,7 @@ msgstr ""
 #: code:addons/account/models/account_payment.py:611
 #, python-format
 msgid "You cannot delete a payment that is already posted."
-msgstr ""
+msgstr "Não é possível eliminar um pagamento que já tenha sido lançado."
 
 #. module: account
 #: code:addons/account/models/account_invoice.py:786
@@ -12106,7 +12254,7 @@ msgstr "Você não pode misturar itens de contas a receber e a pagar."
 #: code:addons/account/models/account_move.py:124
 #, python-format
 msgid "You cannot modify a journal entry linked to a posted payment."
-msgstr ""
+msgstr "Você não pode modificar um lançamento contábil manual ligado a um pagamento lançado."
 
 #. module: account
 #: code:addons/account/models/account_move.py:331
@@ -12134,6 +12282,7 @@ msgstr ""
 msgid ""
 "You cannot perform this action on an account that contains journal items."
 msgstr ""
+"Você não pode executar esta ação em uma conta que contém itens de diário."
 
 #. module: account
 #: code:addons/account/wizard/pos_box.py:36
@@ -12150,6 +12299,8 @@ msgid ""
 "You cannot register payments for customer invoices and credit notes at the "
 "same time."
 msgstr ""
+"Você não pode registrar pagamentos para faturas de clientes e notas de crédito no "
+"ao mesmo tempo."
 
 #. module: account
 #: code:addons/account/models/account_payment.py:96
@@ -12158,12 +12309,14 @@ msgid ""
 "You cannot register payments for vendor bills and supplier refunds at the "
 "same time."
 msgstr ""
+"Você não pode registrar pagamentos para contas de fornecedores e reembolsos de fornecedores no"
+"ao mesmo tempo."
 
 #. module: account
 #: code:addons/account/models/account.py:644
 #, python-format
 msgid "You cannot remove the bank account from the journal once set."
-msgstr ""
+msgstr "Você não pode remover a conta bancária do diário uma vez definida."
 
 #. module: account
 #: code:addons/account/models/account.py:332
@@ -12182,6 +12335,8 @@ msgid ""
 "You cannot set a currency on this account as it already has some journal "
 "entries having a different foreign currency."
 msgstr ""
+"Você não pode definir uma moeda nesta conta, pois ela já tem algum diário".
+"entradas com uma moeda estrangeira diferente."
 
 #. module: account
 #: code:addons/account/models/account.py:294
@@ -12190,6 +12345,8 @@ msgid ""
 "You cannot switch an account to prevent the reconciliation if some partial "
 "reconciliations are still pending."
 msgstr ""
+"Você não pode trocar uma conta para impedir a reconciliação se alguma parte"
+"As reconciliações ainda estão pendentes."
 
 #. module: account
 #: code:addons/account/models/account_move.py:1112
@@ -12238,18 +12395,20 @@ msgid ""
 "You have to define an 'Internal Transfer Account' in your cash register's "
 "journal."
 msgstr ""
+"Você tem que definir uma 'Conta de Transferência Interna' na sua caixa registadora".
+"Diário."
 
 #. module: account
 #: code:addons/account/models/account.py:142
 #, python-format
 msgid "You must first define an opening move."
-msgstr ""
+msgstr "É preciso primeiro definir um movimento de abertura."
 
 #. module: account
 #: code:addons/account/models/account_invoice.py:1683
 #, python-format
 msgid "You must first select a partner."
-msgstr ""
+msgstr "Você deve primeiro selecionar um parceiro."
 
 #. module: account
 #. openerp-web
@@ -12345,27 +12504,27 @@ msgstr "código"
 #. module: account
 #: selection:account.payment.term.line,option:0
 msgid "day(s) after the end of the invoice month"
-msgstr ""
+msgstr "dia(s) após o final do mês da fatura"
 
 #. module: account
 #: selection:account.payment.term.line,option:0
 msgid "day(s) after the invoice date"
-msgstr ""
+msgstr "dia(s) após a data da fatura"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.setup_bank_account_wizard
 msgid "e.g BE15001559627230"
-msgstr ""
+msgstr "por exemplo, BE15001559627230"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.setup_bank_account_wizard
 msgid "e.g Bank of America"
-msgstr ""
+msgstr "por exemplo, Bank of America"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.setup_bank_account_wizard
 msgid "e.g Checking account"
-msgstr ""
+msgstr "por exemplo, Conta de verificação"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_reconcile_model_form
@@ -12394,7 +12553,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__invoice_without_email
 msgid "invoice(s) that will not be sent"
-msgstr ""
+msgstr "fatura(s) que não será(ão) enviada(s)"
 
 #. module: account
 #. openerp-web
@@ -12428,7 +12587,7 @@ msgstr "pagamentos pendentes"
 #: code:addons/account/static/src/xml/account_reconciliation.xml:169
 #, python-format
 msgid "reconciliation models"
-msgstr ""
+msgstr "modelos de reconciliação"
 
 #. module: account
 #. openerp-web
@@ -12449,7 +12608,7 @@ msgstr "segundos por transação"
 #: code:addons/account/static/src/xml/account_reconciliation.xml:319
 #, python-format
 msgid "statement lines"
-msgstr ""
+msgstr "linhas de declaração"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_partner_property_form


### PR DESCRIPTION
# Descrição

[MIG] Atualiza tradução de 'account' para 12.0

# Informações adicionais

[T3879](https://multi.multidadosti.com.br/web#id=4288&view_type=form&model=project.task&action=323&active_id=61)