### PR TITLE
T3945-Traduzir Modulo: MAIL_BOT Odoo 12

### DIFF
--- a/addons/mail_bot/i18n/pt_BR.po
+++ b/addons/mail_bot/i18n/pt_BR.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * mail_bot
-# 
+#
 # Translators:
 # Rodrigo de Almeida Sottomaior Macedo <rmsolucoeseminformatic4@gmail.com>, 2018
 # Martin Trigaux, 2018
@@ -11,14 +11,15 @@
 # Yannick Belot <yannickbh@gmail.com>, 2018
 # Marcelo Costa <marcelo@comdesk.com.br>, 2019
 # Lauro de Lima <lauro@ciclix.com>, 2019
-# 
+# Augusto Costa <gustotc@gmail.com>, 2020
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~11.5\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-10-02 10:05+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: Lauro de Lima <lauro@ciclix.com>, 2019\n"
+"Last-Translator: Augusto Costa <gustotc@gmail.com>, 2020\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/odoo/teams/41243/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -189,7 +190,7 @@ msgstr ""
 msgid ""
 "Odoo has now the permission to send you native notifications on this device."
 msgstr ""
-"Odoo agora tem permissão para enviar para você notificações neste "
+"MultiERP agora tem permissão para enviar para você notificações neste "
 "dispositivo."
 
 #. module: mail_bot
@@ -199,7 +200,7 @@ msgstr ""
 msgid ""
 "Odoo will not have the permission to send native notifications on this "
 "device."
-msgstr "Odoo não tem permissão para enviar notificações deste dispositivo."
+msgstr "MultiERP não tem permissão para enviar notificações deste dispositivo."
 
 #. module: mail_bot
 #: model:ir.model.fields,field_description:mail_bot.field_res_users__odoobot_state


### PR DESCRIPTION
# Descrição

[MIG] Acerta tradução PT_BR  modulo 'mail_bot' para Odoo 12

# Informações adicionais

[T3945](https://multi.multidadosti.com.br/web?#id=4354&view_type=form&model=project.task&action=323&active_id=61)