### PR TITLE
T3956-Acerto de tradução modulo 'crm' e 'sale_crm' do core

### DIFF
--- a/addons/crm/i18n/pt_BR.po
+++ b/addons/crm/i18n/pt_BR.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * crm
-# 
+#
 # Translators:
 # Luciano Giacomazzi <lucianogiacomazzi@gmail.com>, 2018
 # danimaribeiro <danimaribeiro@gmail.com>, 2018
@@ -18,7 +18,7 @@
 # Fernando Alencar <fernando@fernandoalencar.com.br>, 2018
 # Marcel Savegnago <marcel.savegnago@gmail.com>, 2019
 # Ramiro Pereira de Magalhães <ramiro.p.magalhaes@gmail.com>, 2019
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -972,7 +972,7 @@ msgstr "Dobrado no Pipeline"
 #. module: crm
 #: model:mail.activity.type,name:crm.mail_activity_demo_followup_quote
 msgid "Follow-up Quote"
-msgstr "Acompanhar Cotação"
+msgstr "Acompanhar Orçamento"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_follower_ids
@@ -1417,7 +1417,7 @@ msgstr "Anexo Principal"
 #. module: crm
 #: model:mail.activity.type,name:crm.mail_activity_demo_make_quote
 msgid "Make Quote"
-msgstr "Fazer Cotação"
+msgstr "Fazer Orçamento"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_res_config_settings__generate_lead_from_alias
@@ -1902,7 +1902,7 @@ msgstr "Formatação do telefone"
 #: model:ir.ui.menu,name:crm.menu_crm_config_lead
 #, python-format
 msgid "Pipeline"
-msgstr "Linha de Produto"
+msgstr "Pipeline"
 
 #. module: crm
 #: model:ir.actions.act_window,name:crm.action_report_crm_opportunity_salesteam
@@ -2732,7 +2732,7 @@ msgid ""
 "                documents, track all discussions, and much more."
 msgstr ""
 "Você será capaz de planejar reuniões e atividades de registro a partir de\n"
-"                oportunidades, convertê-las em cotações, anexar relacionadas\n"
+"                oportunidades, convertê-las em orçamentos, anexar relacionadas\n"
 "                documentos, acompanhar todas as discussões, e muito mais."
 
 #. module: crm
@@ -2743,7 +2743,7 @@ msgid ""
 "                    documents, track all discussions, and much more."
 msgstr ""
 "Você será capaz de planejar reuniões e telefonemas a partir de\n"
-"                oportunidades, convertê-las em cotações, anexar relacionadas\n"
+"                oportunidades, convertê-las em orçamentos, anexar relacionadas\n"
 "                documentos, acompanhar todas as discussões, e muito mais."
 
 #. module: crm
@@ -2760,18 +2760,18 @@ msgstr "CEP"
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.view_create_opportunity_simplified
 msgid "e.g. Customer Deal"
-msgstr "e.g. Acordo com o cliente"
+msgstr "Ex: Acordo com o cliente"
 
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
 msgid "e.g. Product Pricing"
-msgstr "por exemplo, Preço do Produto"
+msgstr "Ex: Preço do Produto"
 
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
 msgid "e.g. https://www.odoo.com"
-msgstr ""
+msgstr "Ex: https://multidadosti.com.br"
 
 #. module: crm
 #: code:addons/crm/models/crm_lead.py:946

--- a/addons/sale_crm/i18n/pt_BR.po
+++ b/addons/sale_crm/i18n/pt_BR.po
@@ -1,14 +1,14 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * sale_crm
-# 
+#
 # Translators:
 # Martin Trigaux, 2018
 # grazziano <gra.negocia@gmail.com>, 2018
 # Hildeberto Abreu Magalhães <hildeberto@gmail.com>, 2018
 # Mateus Lopes <mateus1@gmail.com>, 2018
 # Fernando Alencar <fernando@fernandoalencar.com.br>, 2018
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~11.5\n"
@@ -31,7 +31,7 @@ msgstr "<span class=\"o_stat_text\"> Pedidos</span>"
 #. module: sale_crm
 #: model_terms:ir.ui.view,arch_db:sale_crm.crm_case_form_view_oppor
 msgid "<span class=\"o_stat_text\"> Quotation(s) </span>"
-msgstr ""
+msgstr "<span class=\"o_stat_text\"> Orçamento(s) </span>"
 
 #. module: sale_crm
 #: model:ir.model.fields,field_description:sale_crm.field_account_invoice__campaign_id
@@ -73,17 +73,17 @@ msgstr "Médio"
 #. module: sale_crm
 #: model:ir.ui.menu,name:sale_crm.sale_order_menu_quotations_crm
 msgid "My Quotations"
-msgstr "Minhas Cotações"
+msgstr "Meus Orçamentos"
 
 #. module: sale_crm
 #: model_terms:ir.ui.view,arch_db:sale_crm.crm_case_form_view_oppor
 msgid "New Quotation"
-msgstr "Nova Cotação"
+msgstr "Novo Orçamento"
 
 #. module: sale_crm
 #: model:ir.model.fields,field_description:sale_crm.field_crm_lead__sale_number
 msgid "Number of Quotations"
-msgstr "Número de Cotações"
+msgstr "Número de Orçamentos"
 
 #. module: sale_crm
 #: model:ir.model.fields,field_description:sale_crm.field_sale_order__opportunity_id
@@ -104,12 +104,12 @@ msgstr "Linha de Produto"
 #. module: sale_crm
 #: model:ir.actions.act_window,name:sale_crm.sale_action_quotations_new
 msgid "Quotation"
-msgstr "Cotação"
+msgstr "Orçamento"
 
 #. module: sale_crm
 #: model:ir.actions.act_window,name:sale_crm.sale_action_quotations
 msgid "Quotations"
-msgstr "Cotações"
+msgstr "Orçamentos"
 
 #. module: sale_crm
 #: model:ir.model,name:sale_crm.model_sale_order


### PR DESCRIPTION
# Descrição

- Acerta tradução pt_br modulo 'crm' Odoo 12
- Acerta tradução pt_br modulo 'sale_crm' Odoo 12

# Informações adicionais

[T3956](https://multi.multidadosti.com.br/web?debug#id=4365&view_type=form&model=project.task&action=323&active_id=61)