### PR TITLE
T3958-Acerto na tradução pt_br modulo 'account' Odoo 12

### DIFF
--- a/addons/account/i18n/pt_BR.po
+++ b/addons/account/i18n/pt_BR.po
@@ -674,7 +674,7 @@ msgstr "<strong>Código de Cliente:</strong>"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 msgid "<strong>Customer: </strong>"
-msgstr "Cliente:"
+msgstr "<strong>Cliente: </strong>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
@@ -3793,7 +3793,7 @@ msgstr "Usuário atual marcou uma notificação vinculada a esta mensagem"
 #: model_terms:ir.ui.view,arch_db:account.invoice_tree
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_tree
 msgid "Customer"
-msgstr "Parceiro"
+msgstr "Cliente"
 
 #. module: account
 #: selection:account.invoice,type:0 selection:account.invoice.report,type:0
@@ -3849,7 +3849,7 @@ msgstr "Impostos de Clientes"
 #: model:ir.ui.menu,name:account.menu_finance_receivables
 #: model_terms:ir.ui.view,arch_db:account.view_account_invoice_report_search
 msgid "Customers"
-msgstr "Parceiros"
+msgstr "Clientes"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.onboarding_invoice_layout_step


### PR DESCRIPTION
# Descrição

- Acerta tradução pt_br modulo 'account' Odoo 12

# Informações adicionais

[T3958](https://multi.multidadosti.com.br/web?debug#id=4367&view_type=form&model=project.task&action=323&active_id=61)