### PR TITLE
T3974-Acertar tradução PT_BR módulo 'inventory' do Odoo 12

### DIFF
--- a/addons/stock/i18n/pt_BR.po
+++ b/addons/stock/i18n/pt_BR.po
@@ -50,6 +50,9 @@ msgid ""
 "\n"
 "%s --> Product UoM is %s (%s) - Move UoM is %s (%s)"
 msgstr ""
+"\n"
+"\n"
+"%s --> UdM do Produto é %s (%s) - UdM de Mudança é %s (%s)"
 
 #. module: stock
 #: code:addons/stock/models/stock_move.py:342
@@ -59,6 +62,9 @@ msgid ""
 "\n"
 "Blocking: %s"
 msgstr ""
+"\n"
+"\n"
+"Bloqueando: %s"
 
 #. module: stock
 #: code:addons/stock/models/stock_move.py:329
@@ -82,6 +88,12 @@ msgid ""
 " * Done: has been processed, can't be modified or cancelled anymore.\n"
 " * Cancelled: has been cancelled, can't be confirmed anymore."
 msgstr ""
+" * Rascunho: ainda não confirmado e não será agendado até ser confirmado.\n"
+" * Aguardando outra operação: aguardando que outro movimento prossiga antes de ficar automaticamente disponível (por exemplo, em Fluxos de produção por ordem de cliente).\n"
+" * Esperar: se não estiver pronto para ser enviado porque os produtos necessários não puderam ser reservados.\n"
+" * Pronto: os produtos estão reservados e prontos para serem enviados. Se a política de envio é 'O mais rápido possível', isto acontece assim que qualquer coisa é reservada.\n"
+" * Feito: foi processado, não pode mais ser modificado ou cancelado.\n"
+" * Cancelado: foi cancelado, não pode mais ser confirmado."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_move_picking_form
@@ -110,6 +122,11 @@ msgid ""
 "* Available: When products are reserved, it is set to 'Available'.\n"
 "* Done: When the shipment is processed, the state is 'Done'."
 msgstr ""
+"* Novo: Quando o movimento de estoque é criado e ainda não confirmado.\n"
+"* Waiting Another Move: Este estado pode ser visto quando um movimento está esperando por outro, por exemplo, em um fluxo acorrentado.\n"
+"* Disponibilidade em espera: Este estado é alcançado quando a resolução de aquisição não é directa. Pode precisar do agendador para executar, um componente a ser fabricado...\n"
+"* Disponível: Quando os produtos são reservados, está definido para 'Disponível'.\n"
+"* Feito: Quando o carregamento é processado, o estado está 'Feito'."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_location__usage
@@ -123,11 +140,19 @@ msgid ""
 "* Production: Virtual counterpart location for production operations: this location consumes the raw material and produces finished products\n"
 "* Transit Location: Counterpart location that should be used in inter-company or inter-warehouses operations"
 msgstr ""
+"* Localização do fornecedor: Localização virtual que representa a localização de origem dos produtos vindos dos seus fornecedores\n"
+"* Ver: Localização virtual utilizada para criar uma estrutura hierárquica para o seu armazém, agregando as suas localizações de crianças ; não pode conter directamente os produtos\n"
+"* Localização interna: Localizações físicas dentro dos seus próprios armazéns,\n"
+"* Localização do cliente: Localização virtual que representa a localização de destino dos produtos enviados aos seus clientes.\n"
+"* Perda de inventário: Localização virtual que serve como contrapartida para operações de inventário utilizadas para corrigir níveis de estoque (Inventários físicos)\n"
+"* Aquisições: Localização virtual que serve como contrapartida temporária para operações de suprimento quando a fonte (fornecedor ou produção) ainda não é conhecida. Esse local deve estar vazio quando o escalonador de suprimentos tiver terminado de funcionar.\n"
+"* Produção: Local virtual para as operações de produção: este local consome a matéria-prima e produz produtos acabados.\n"
+"* Localização de trânsito: Localização de contra-partida que deve ser utilizada em operações interempresariais ou entre armazéns"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_stock_rule
 msgid ", max:"
-msgstr ""
+msgstr ", max:"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.exception_on_picking
@@ -154,12 +179,13 @@ msgid ""
 "<br>A need is created in <b>%s</b> and a rule will be triggered to fulfill "
 "it."
 msgstr ""
+"<br>Uma necessidade é criada <b>%s</b> e uma regra será ativada para preenche-la."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_move_view_kanban
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_inventory_kanban
 msgid "<i class=\"fa fa-clock-o\" role=\"img\" aria-label=\"Date\" title=\"Date\"/>"
-msgstr ""
+msgstr "<i class=\"fa fa-clock-o\" role=\"img\" aria-label=\"Data\" title=\"Data\"/>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_scrap_view_kanban
@@ -167,11 +193,13 @@ msgid ""
 "<i class=\"fa fa-clock-o\" role=\"img\" aria-label=\"Expected date\" "
 "title=\"Expected date\"/>"
 msgstr ""
+"<i class=\"fa fa-clock-o\" role=\"img\" aria-label=\"Data Prevista\" "
+"title=\"Data Prevista\"/>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_picking_type_kanban
 msgid "<i class=\"fa fa-ellipsis-v\" role=\"img\" aria-label=\"Manage\" title=\"Manage\"/>"
-msgstr "<i class=\"fa fa-ellipsis-v\" role=\"img\" aria-label=\"Manage\" title=\"Manage\"/>"
+msgstr "<i class=\"fa fa-ellipsis-v\" role=\"img\" aria-label=\"Gerenciar\" title=\"Gerenciar\"/>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_picking
@@ -179,6 +207,8 @@ msgid ""
 "<i class=\"fa fa-exclamation-triangle\"/>\n"
 "                                All products could not be reserved. Click on the \"Check Availability\" button to try to reserve products"
 msgstr ""
+"<i class=\"fa fa-exclamation-triangle\"/>\n"
+"                                Todos os produtos não puderam ser reservados. Clique no botão \"Verificar Disponibilidade\" para tentar reservar os produtos"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_mrp_line
@@ -186,6 +216,8 @@ msgid ""
 "<i class=\"fa fa-fw fa-caret-right\" role=\"img\" aria-label=\"Unfold\" "
 "title=\"Unfold\"/>"
 msgstr ""
+"<i class=\"fa fa-fw fa-caret-right\" role=\"img\" aria-label=\"Desdobrar\" "
+"title=\"Desdobrar\"/>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_inventory_form
@@ -225,7 +257,7 @@ msgstr "<span class=\"o_stat_text\">Na Mão</span>"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
 msgid "<span class=\"o_stat_text\">Operations</span>"
-msgstr ""
+msgstr "<span class=\"o_stat_text\">Operações</span>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_mrp_line
@@ -234,6 +266,9 @@ msgid ""
 "Report\" aria-label=\"Traceability Report\"><i class=\"fa fa-fw fa-level-up "
 "fa-rotate-270\"/></span>"
 msgstr ""
+"<span role=\"img\" class=\"o_stock_reports_stream\" title=\"Relatório de "
+"Rastreabilidade\" aria-label=\"Relatório de Rastreabilidade\"><i class=\"fa fa-fw fa-level-up "
+"fa-rotate-270\"/></span>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_picking
@@ -271,6 +306,8 @@ msgid ""
 "<strong>\n"
 "                                            Product Barcode</strong>"
 msgstr ""
+"<strong>\n"
+"                                            Código de Barras do Produto</strong>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.message_head
@@ -279,12 +316,15 @@ msgid ""
 "                The done move line has been corrected.\n"
 "            </strong>"
 msgstr ""
+"<strong>\n"
+"                A linha da movimentação concluída foi corrigida.\n"
+"            </strong>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_delivery_document
 #: model_terms:ir.ui.view,arch_db:stock.report_inventory
 msgid "<strong>Date</strong>"
-msgstr "Data:"
+msgstr "<strong>Data</strong>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_picking
@@ -304,23 +344,23 @@ msgstr "<strong>Localização</strong>"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_picking
 msgid "<strong>Lot/Serial Number</strong>"
-msgstr ""
+msgstr "<strong>Lote/Número de Série</strong>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_warehouse_orderpoint_kanban
 msgid "<strong>Max qty :</strong>"
-msgstr ""
+msgstr "<strong>Qty Máx :</strong>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_warehouse_orderpoint_kanban
 msgid "<strong>Min qty :</strong>"
-msgstr ""
+msgstr "<strong>Qty Mín :</strong>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_delivery_document
 #: model_terms:ir.ui.view,arch_db:stock.report_picking
 msgid "<strong>Order</strong>"
-msgstr ""
+msgstr "<strong>Pedido</strong>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_inventory
@@ -330,7 +370,7 @@ msgstr "<strong>Embalagem</strong>"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_track_confirmation
 msgid "<strong>Product(s) tracked: </strong>"
-msgstr ""
+msgstr "<strong>Produto(s) Rastreado(s): </strong>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_delivery_document
@@ -369,12 +409,12 @@ msgstr "<strong>Estado</strong>"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.message_head
 msgid "<strong>The initial demand has been updated.</strong>"
-msgstr ""
+msgstr "<strong>A demanda inicial foi atualizada.</strong>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_picking
 msgid "<strong>To</strong>"
-msgstr ""
+msgstr "<strong>Para</strong>"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_inventory
@@ -384,7 +424,7 @@ msgstr "<strong>Quantidade Total</strong>"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_package_destination_form_view
 msgid "<strong>Where do you want to send the products ?</strong>"
-msgstr ""
+msgstr "<strong>Para onde quer enviar estes produtos ?</strong>"
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:123
@@ -396,13 +436,13 @@ msgstr "Um pacote"
 #: code:addons/stock/models/stock_move_line.py:88
 #, python-format
 msgid "A done move line should never have a reserved quantity."
-msgstr ""
+msgstr "Uma linha de movimentação nunca deve ter uma quantidade reservada"
 
 #. module: stock
 #: code:addons/stock/models/stock_quant.py:80
 #, python-format
 msgid "A serial number should only be linked to a single product."
-msgstr ""
+msgstr "Um número de série deve ser conectado apenas a um único produto."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_product_product__type
@@ -413,11 +453,14 @@ msgid ""
 "A consumable product is a product for which stock is not managed.\n"
 "A service is a non-material product you provide."
 msgstr ""
+"Um produto armazenável é um produto para o qual você administra o estoque. A aplicação Inventário tem de ser instalada.\n"
+"Um produto consumível é um produto para o qual o stock não é gerido.\n"
+"Um serviço é um produto não-material que você fornece."
 
 #. module: stock
 #: model:res.groups,name:stock.group_warning_stock
 msgid "A warning can be set on a partner (Stock)"
-msgstr ""
+msgstr "Um aviso pode ser definido em um parceiro (Estoque)"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_rule__action
@@ -455,23 +498,24 @@ msgstr "Estado de Atividade"
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_production_lot_form
 msgid "Add a lot/serial number"
-msgstr ""
+msgstr "Adicione um lote/número de série"
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_location_form
 msgid "Add a new location"
-msgstr ""
+msgstr "Adicione uma nova localização"
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_routes_form
 msgid "Add a new route"
-msgstr ""
+msgstr "Adicione uma nova rota"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
 msgid ""
 "Add an internal note that will be printed on the Picking Operations sheet"
 msgstr ""
+"Adicione uma nota interna que será impressa na planilha de Operações de Coleta"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_res_config_settings__group_stock_adv_location
@@ -479,6 +523,8 @@ msgid ""
 "Add and customize route operations to process product moves in your warehouse(s): e.g. unload > quality control > stock for incoming products, pick > pack > ship for outgoing products. \n"
 " You can also set putaway strategies on warehouse locations in order to send incoming products into specific child locations straight away (e.g. specific bins, racks)."
 msgstr ""
+"Adicionar e personalizar operações de rota para processar movimentos de produtos no(s) seu(s) armazém(s): por exemplo, descarregar > controle de qualidade > estoque para entrada de produtos, picking > embalar > enviar para saída de produtos. \n"
+" Também é possível definir estratégias de entrada em depósito em locais de depósito, a fim de enviar imediatamente os produtos recebidos para locais específicos para crianças (por exemplo, caixas específicas, prateleiras)."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
@@ -489,6 +535,11 @@ msgid ""
 "strategies on warehouse locations in order to send incoming products into "
 "specific child locations straight away (e.g. specific bins, racks)."
 msgstr ""
+"Adicione e personalize operações de rota para processar movimentos de produtos no seu "
+"armazém(s): por exemplo, descarregar > controle de qualidade > estoque para entrada de produtos, "
+"pick > pack > enviar para produtos de saída. Você também pode definir a entrada em depósito "
+"estratégias sobre a localização de depósitos para enviar produtos recebidos para "
+"locais específicos para crianças de imediato (por exemplo, caixas específicas, prateleiras)."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
@@ -509,12 +560,12 @@ msgstr "Endereço"
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_rule__partner_address_id
 msgid "Address where goods should be delivered. Optional."
-msgstr ""
+msgstr "Endereço onde as mercadorias devem ser entregues. Opicional."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Advanced Scheduling"
-msgstr ""
+msgstr "Agendamento Avançada"
 
 #. module: stock
 #: selection:stock.move,procure_method:0
@@ -547,6 +598,8 @@ msgid ""
 "All items couldn't be shipped, the remaining ones will be shipped as soon as"
 " they become available."
 msgstr ""
+"Todos os itens não puderam ser enviados, os restantes serão enviados assim que"
+" eles tornam-se disponíveis."
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:113
@@ -564,6 +617,7 @@ msgstr "Todos os movimentos devolvidos"
 msgid ""
 "Allows to suggest the exact location (shelf) where to store the product."
 msgstr ""
+"Permite sugerir o local exato (prateleira) onde o produto é guardado"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_rule_form
@@ -596,6 +650,8 @@ msgid ""
 "Apply specific route(s) for the replenishment instead of product's default "
 "routes."
 msgstr ""
+"Aplique rota(s) específica(s) para o reabastecimento em vez das rotas padrão do "
+"produto."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_location_route_view_search
@@ -613,16 +669,18 @@ msgid ""
 "Are you sure you want to confirm this operation? This may lead to "
 "inconsistencies in your inventory."
 msgstr ""
+"Tem certeza que quer confirmar esta operação? Isto pode levar a "
+"inconsistências no seu inventário"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_overprocessed_transfer
 msgid "Are you sure you want to validate this picking?"
-msgstr ""
+msgstr "Tem certeza que quer validar esta coleta?"
 
 #. module: stock
 #: selection:stock.picking,move_type:0
 msgid "As soon as possible"
-msgstr ""
+msgstr "O mais rápido possível"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
@@ -686,13 +744,13 @@ msgstr "Produtos Disponíveis"
 #: model:ir.model.fields,field_description:stock.field_stock_move__backorder_id
 #: model:ir.model.fields,field_description:stock.field_stock_picking__backorder_id
 msgid "Back Order of"
-msgstr "Back Order de"
+msgstr "Pedido em Espera de"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__backorder_ids
 #: model_terms:ir.ui.view,arch_db:stock.stock_picking_type_kanban
 msgid "Back Orders"
-msgstr "Back Orders"
+msgstr "Pedidos em Espera"
 
 #. module: stock
 #: code:addons/stock/wizard/stock_backorder_confirmation.py:28
@@ -714,13 +772,13 @@ msgstr "Criação de Backorder"
 #: code:addons/stock/models/stock_picking.py:71
 #, python-format
 msgid "Backorder exists"
-msgstr "Backorder existe"
+msgstr "Existem pedidos em espera"
 
 #. module: stock
 #: model:ir.actions.act_window,name:stock.action_picking_tree_backorder
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_internal_search
 msgid "Backorders"
-msgstr "Backorders"
+msgstr "Pedidos em Espera"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_location__barcode
@@ -750,7 +808,7 @@ msgstr "Scanner de Código de Barras"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__module_stock_picking_batch
 msgid "Batch Pickings"
-msgstr ""
+msgstr "Coleta de Lote"
 
 #. module: stock
 #: selection:res.partner,picking_warn:0
@@ -813,7 +871,7 @@ msgstr "Desmarcando o campo Ativo, você pode esconder o local sem excluí-lo."
 #: model:product.product,name:stock.product_cable_management_box
 #: model:product.template,name:stock.product_cable_management_box_product_template
 msgid "Cable Management Box"
-msgstr ""
+msgstr "Caixa de Gerenciamento de Cabos"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_picking_calendar
@@ -830,7 +888,7 @@ msgstr "Não é possível localizar qualquer local de cliente ou fornecedor."
 #: code:addons/stock/models/stock_warehouse.py:256
 #, python-format
 msgid "Can't find any generic route %s."
-msgstr ""
+msgstr "Não foi possível encontrar nenhuma rota alternativa %s."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_scrap_form_view2
@@ -859,7 +917,7 @@ msgstr "Cancelado"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_internal_search
 msgid "Cancelled Moves"
-msgstr ""
+msgstr "Movimentações Canceladas"
 
 #. module: stock
 #: code:addons/stock/models/stock_move.py:277
@@ -868,6 +926,8 @@ msgid ""
 "Cannot set the done quantity from this stock move, work directly with the "
 "move lines."
 msgstr ""
+"Não é possível definir a quantidade feita a partir deste movimento de estoque, trabalhar diretamente com as "
+"linhas de movimento."
 
 #. module: stock
 #: selection:barcode.rule,type:0
@@ -898,12 +958,12 @@ msgstr "Alterar Quantidade do Produto"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Change must be higher than"
-msgstr ""
+msgstr "A mudança deve ser superior a"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move_line__move_id
 msgid "Change to a better name"
-msgstr ""
+msgstr "Mudar para um nome melhor"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
@@ -913,12 +973,12 @@ msgstr "Verificar Disponibilidade"
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking__has_packages
 msgid "Check the existence of destination packages on move lines"
-msgstr ""
+msgstr "Verifique a existência de pacotes de destino em linhas em movimento"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking__move_line_exist
 msgid "Check the existence of pack operation on the picking"
-msgstr ""
+msgstr "Verificar a existência de operação de embalagem na coleta"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_location__return_location
@@ -943,19 +1003,20 @@ msgstr "Quantidade Verificada"
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_quantity_history__date
 msgid "Choose a date to get the inventory at that date"
-msgstr ""
+msgstr "Escolha uma data para pegar o inventário na data"
 
 #. module: stock
 #: code:addons/stock/models/stock_picking.py:998
 #, python-format
 msgid "Choose destination location"
-msgstr ""
+msgstr "Escolha o local de destino"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_quantity_history__compute_at_date
 msgid ""
 "Choose to analyze the current inventory or from a specific date in the past."
 msgstr ""
+"Escolha analisar o inventário atual ou a partir de uma data específica no passado."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_quantity_history
@@ -1063,7 +1124,7 @@ msgstr "Confirmado"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__group_stock_tracking_owner
 msgid "Consignment"
-msgstr ""
+msgstr "Consignação"
 
 #. module: stock
 #: selection:product.template,type:0
@@ -1073,7 +1134,7 @@ msgstr "Consumível"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__consume_line_ids
 msgid "Consume Line"
-msgstr ""
+msgstr "Linha de Consumo"
 
 #. module: stock
 #: model:ir.model,name:stock.model_res_partner
@@ -1118,37 +1179,37 @@ msgstr ""
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__count_picking
 msgid "Count Picking"
-msgstr ""
+msgstr "Contagem de coleta"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__count_picking_backorders
 msgid "Count Picking Backorders"
-msgstr ""
+msgstr "Contagem de coleta de pedidos em espera"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__count_picking_draft
 msgid "Count Picking Draft"
-msgstr ""
+msgstr "Contagem de Rascunho de Coleta"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__count_picking_late
 msgid "Count Picking Late"
-msgstr ""
+msgstr "Contagem de Coleta Atrasada"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__count_picking_ready
 msgid "Count Picking Ready"
-msgstr ""
+msgstr "Contagem de Coleta Pronta"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__count_picking_waiting
 msgid "Count Picking Waiting"
-msgstr ""
+msgstr "Contagem de Coleta em Espera"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_template_property_form
 msgid "Counterpart Locations"
-msgstr ""
+msgstr "Locais de Contrapartida"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_backorder_confirmation
@@ -1170,7 +1231,7 @@ msgstr "Data de Criação"
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__picking_type_use_create_lots
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__use_create_lots
 msgid "Create New Lots/Serial Numbers"
-msgstr ""
+msgstr "Criar Novos Lotes/Números de Série"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_rule__procure_method
@@ -1178,6 +1239,8 @@ msgid ""
 "Create Procurement: A procurement will be created in the source location and the system will try to find a rule to resolve it. The available stock will be ignored.\n"
 "             Take from Stock: The products will be taken from the available stock."
 msgstr ""
+"Criar Compras: Será criado um suprimento no local de origem e o sistema tentará encontrar uma regra para resolvê-lo. O estoque disponível será ignorado."
+"             Tire do estoque: Os produtos serão retirados do estoque disponível."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_backorder_confirmation
@@ -1186,21 +1249,23 @@ msgid ""
 "                        products later. Do not create a backorder if you will not\n"
 "                        process the remaining products."
 msgstr ""
+"Crie um pedido em atraso se você espera processar os produtos restantes\n" 
+"mais tarde. Não crie um pedido em atraso se não vai processar os restantes produtos."
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_inventory_form
 msgid "Create a new inventory adjustment"
-msgstr ""
+msgstr "Criar um novo ajuste de Inventário"
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.stock_picking_type_action
 msgid "Create a new operation type"
-msgstr ""
+msgstr "Criar um novo tipó de operação"
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_package_view
 msgid "Create a new package"
-msgstr ""
+msgstr "Criar um novo pacote"
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.product_template_action_product
@@ -1210,17 +1275,17 @@ msgstr "Criar um novo produto"
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.stock_move_action
 msgid "Create a new stock movement"
-msgstr ""
+msgstr "Criar um novo movimento de estoque"
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_picking_tree
 msgid "Create a new stock operation"
-msgstr ""
+msgstr "Criar uma nova operação de estoque"
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_orderpoint_form
 msgid "Create a reordering rule"
-msgstr ""
+msgstr "Criar uma regra de reorganização"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_inventory__move_ids
@@ -1340,7 +1405,7 @@ msgstr "Quantidade Cumulativa"
 #. module: stock
 #: selection:stock.quantity.history,compute_at_date:0
 msgid "Current Inventory"
-msgstr ""
+msgstr "Inventório Atual"
 
 #. module: stock
 #: model:ir.actions.act_window,name:stock.location_open_quants
@@ -1358,10 +1423,10 @@ msgid ""
 "Otherwise, this includes goods stored in any Stock Location with 'internal' type."
 msgstr ""
 "Quantidade atual de produtos.\n"
-"Em um contexto com uma única Localização, isso inclui bens armazenados neste local, ou qualquer um de seus filhos.\n"
-"Em um contexto com um único depósito, isso inclui bens armazenados na localização deste Armazém, ou qualquer um de seus filhos.\n"
+"Em um contexto com uma única Localização, isso inclui mercadorias armazenadas neste local, ou qualquer um de seus filhos.\n"
+"Em um contexto com um único depósito, isso inclui mercadorias armazenadas na localização deste Armazém, ou qualquer um de seus filhos.\n"
 "Armazenados na Localização do Armazém desta Loja, ou qualquer um de seus filhos.\n"
-"Caso contrário, isso inclui bens armazenados em qualquer da localização com tipo 'interno'."
+"Caso contrário, isso inclui mercadorias armazenadas em qualquer da localização com tipo 'interno'."
 
 #. module: stock
 #: code:addons/stock/models/stock_picking.py:111
@@ -1417,12 +1482,12 @@ msgstr "Data Prevista"
 #. module: stock
 #: model:ir.model.fields,help:stock.field_product_replenish__date_planned
 msgid "Date at which the replenishment should take place."
-msgstr ""
+msgstr "Data em que o reabastecimento deve ser feito."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking__date_done
 msgid "Date at which the transfer has been processed or cancelled."
-msgstr ""
+msgstr "Data em que a transferência foi processada ou cancelada."
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__date_done
@@ -1508,6 +1573,8 @@ msgid ""
 "Define a minimum stock rule so that Odoo creates automatically requests for "
 "quotations or draft manufacturing orders to resupply your stock."
 msgstr ""
+"Defina uma regra de estoque mínimo para que Odoo crie automaticamente pedidos de "
+"cotações ou esboços de ordens de produção para reabastecer seu estoque."
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_picking_form
@@ -1521,12 +1588,12 @@ msgstr ""
 #: model_terms:ir.actions.act_window,help:stock.action_picking_type_list
 #: model_terms:ir.actions.act_window,help:stock.stock_picking_action_picking_type
 msgid "Define a new transfer"
-msgstr ""
+msgstr "Defina uma nova transferência"
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_warehouse_form
 msgid "Define a new warehouse"
-msgstr ""
+msgstr "Defina um novo arnazém"
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_location_form
@@ -1538,6 +1605,12 @@ msgid ""
 "            the stock operations like the manufacturing orders\n"
 "            consumptions, inventories, etc."
 msgstr ""
+"Definir suas localizações para refletir sua estrutura de depósito e\n"
+"            organização. A Odoo é capaz de gerir locais físicos (armazéns, \n"
+"            prateleiras, contentores, etc.), locais parceiros (clientes, \n"
+"            fornecedores) e locais virtuais que são a contrapartida de\n"
+"            as operações de estoque como os consumos das ordens de \n"
+"            fabricação, inventários, etc."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_location__removal_strategy_id
@@ -1560,25 +1633,25 @@ msgstr "Atraso"
 #. module: stock
 #: selection:stock.warehouse,delivery_steps:0
 msgid "Deliver goods directly (1 step)"
-msgstr ""
+msgstr "Entregar mercadorias diretamente (1 passo)"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:526
 #, python-format
 msgid "Deliver in 1 step (ship)"
-msgstr ""
+msgstr "Entregar em 1 passo (enviar)"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:526
 #, python-format
 msgid "Deliver in 2 steps (pick + ship)"
-msgstr ""
+msgstr "Entregar em 2 passos (coletar + enviar)"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:527
 #, python-format
 msgid "Deliver in 3 steps (pick + pack + ship)"
-msgstr ""
+msgstr "Entregar em 3 passos (coletar + embalar + enviar)"
 
 #. module: stock
 #: code:addons/stock/models/product.py:335
@@ -1602,7 +1675,7 @@ msgstr "Ordens de Entrega"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__group_stock_tracking_lot
 msgid "Delivery Packages"
-msgstr ""
+msgstr "Pacotes de Entrega"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse__delivery_route_id
@@ -1626,6 +1699,8 @@ msgid ""
 "Delivery lead time, in days. It's the number of days, promised to the "
 "customer, between the confirmation of the sales order and the delivery."
 msgstr ""
+"Prazo de entrega, em dias. É o número de dias, prometido ao"
+"cliente, entre a confirmação da ordem de venda e a entrega."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_product_product__route_ids
@@ -1634,6 +1709,8 @@ msgid ""
 "Depending on the modules installed, this will allow you to define the route "
 "of the product: whether it will be bought, manufactured, MTO, etc."
 msgstr ""
+"Dependendo dos módulos instalados, isto lhe permitirá definir a rota "
+"a rota do produto: se ele será comprado, fabricado, MTO, etc."
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__name
@@ -1643,23 +1720,23 @@ msgstr "Descrição"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_template_property_form
 msgid "Description for Delivery Orders"
-msgstr ""
+msgstr "Descrição para Pedidos de Entrega"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_template_property_form
 msgid "Description for Internal Transfers"
-msgstr ""
+msgstr "Descrição para Transferências Internas"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_template_property_form
 msgid "Description for Receipts"
-msgstr ""
+msgstr "DEscrição para Recibos"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_product__description_pickingout
 #: model:ir.model.fields,field_description:stock.field_product_template__description_pickingout
 msgid "Description on Delivery Orders"
-msgstr ""
+msgstr "DEscrição para Pedidos de entrega"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_product__description_picking
@@ -1671,7 +1748,7 @@ msgstr "Descrição em Coleta"
 #: model:ir.model.fields,field_description:stock.field_product_product__description_pickingin
 #: model:ir.model.fields,field_description:stock.field_product_template__description_pickingin
 msgid "Description on Receptions"
-msgstr ""
+msgstr "Descrição na Recepção"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_picking
@@ -1696,29 +1773,29 @@ msgstr "Local do Destino"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.message_body
 msgid "Destination Location:"
-msgstr ""
+msgstr "Local do Destino:"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__move_dest_ids
 #: model_terms:ir.ui.view,arch_db:stock.view_move_form
 msgid "Destination Moves"
-msgstr ""
+msgstr "Mudanças de Destino"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__result_package_id
 #: model_terms:ir.ui.view,arch_db:stock.view_move_line_form
 msgid "Destination Package"
-msgstr "Destino do pacote "
+msgstr "Destino do Pacote "
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.message_body
 msgid "Destination Package :"
-msgstr ""
+msgstr "Destino do Pacote :"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_package_destination__location_dest_id
 msgid "Destination location"
-msgstr ""
+msgstr "Local do Destino"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__route_ids
@@ -1730,12 +1807,12 @@ msgstr "Rota de destino"
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
 #, python-format
 msgid "Detailed Operations"
-msgstr ""
+msgstr "Operações Detalhadas"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__show_details_visible
 msgid "Details Visible"
-msgstr ""
+msgstr "Detalhes Visíveis"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_package_destination_form_view
@@ -1755,7 +1832,7 @@ msgstr "Produto Descontado"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__group_lot_on_delivery_slip
 msgid "Display Lots & Serial Numbers"
-msgstr ""
+msgstr "Exibir lotes e Números de Série"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_procurement_group__display_name
@@ -1802,7 +1879,7 @@ msgstr "Nome exibido"
 #. module: stock
 #: model:res.groups,name:stock.group_lot_on_delivery_slip
 msgid "Display Serial & Lot Number in Delivery Slips"
-msgstr ""
+msgstr "Exibir Número de Série e de Lote nas Guias de Remessa"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__qty_done
@@ -1831,7 +1908,7 @@ msgstr "Transferências Concluídas por Data"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Don’t propagate scheduling changes through chains of operations"
-msgstr ""
+msgstr "Não propague mudanças de programação através de cadeias de operações"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_inventory_filter
@@ -1864,7 +1941,7 @@ msgstr "Data Efetiva"
 #: model:ir.model.fields,help:stock.field_stock_move_line__tracking
 #: model:ir.model.fields,help:stock.field_stock_scrap__tracking
 msgid "Ensure the traceability of a storable product in your warehouse."
-msgstr ""
+msgstr "Garanta a rastreabilidade de um produto armazenável no seu armazém."
 
 #. module: stock
 #. openerp-web
@@ -1882,11 +1959,16 @@ msgid ""
 "            location to the Stock location. Each report can be performed on\n"
 "            physical, partner or virtual locations."
 msgstr ""
+"Cada operação de estoque em Odoo move os produtos de um\n"
+"            ocal para outro.Por exemplo, se o usuário receber produtos\n"
+"            de um fornecedor, Odoo moverá os produtos do local do fornecedor\n"
+"            para o local do Estoque. Cada relatório pode ser realizado em\n"
+"            locais físicos, parceiros ou virtuais."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.exception_on_picking
 msgid "Exception(s) occurred on the picking"
-msgstr ""
+msgstr "Exceção(ões) ocorreu(eram) na coleta"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.exception_on_picking
@@ -1922,7 +2004,7 @@ msgstr "Conector FedEx"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_package_destination__filtered_location
 msgid "Filtered Location"
-msgstr ""
+msgstr "Localização Filtrada"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.quant_search_view
@@ -1937,7 +2019,7 @@ msgstr "Fixo"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_putaway__product_location_ids
 msgid "Fixed Locations Per Product"
-msgstr ""
+msgstr "Localizações fixas por produto"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_putaway__fixed_location_ids
@@ -1952,7 +2034,7 @@ msgstr "Grupo de Aquisição previsto"
 #. module: stock
 #: model:ir.model,name:stock.model_stock_fixed_putaway_strat
 msgid "Fixed Putaway Strategy on Location"
-msgstr ""
+msgstr "Estratégia fixa de entrada em depósito no local"
 
 #. module: stock
 #. openerp-web
@@ -1998,9 +2080,9 @@ msgid ""
 "Otherwise, this includes goods stored in any Stock Location with 'internal' type."
 msgstr ""
 "Quantidade prevista (calculado como quantidade em mãos - Saída + Recebimento)\n"
-"Em um contexto com uma única Localização, isso inclui bens armazenados neste local, ou qualquer um de seus filhos.\n"
-"Em um contexto com um único depósito, isso inclui bens armazenados na localização deste Armazém, ou qualquer um de seus filhos.\n"
-"Caso contrário, isso inclui bens armazenados em qualquer localização com tipo 'interno'."
+"Em um contexto com uma única Localização, isso inclui mercadorias armazenadas neste local, ou qualquer um de seus filhos.\n"
+"Em um contexto com um único depósito, isso inclui mercadorias armazenadas na localização deste Armazém, ou qualquer um de seus filhos.\n"
+"Caso contrário, isso inclui mercadorias armazenadas em qualquer localização com tipo 'interno'."
 
 #. module: stock
 #: code:addons/stock/models/product.py:330
@@ -2023,7 +2105,7 @@ msgstr "De"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__show_reserved_availability
 msgid "From Supplier"
-msgstr ""
+msgstr "Do Fornecedor"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_location__complete_name
@@ -2068,12 +2150,12 @@ msgstr "Recebimentos Futuros"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Get a full traceability from vendors to customers"
-msgstr ""
+msgstr "Obter uma rastreabilidade completa dos fornecedores aos clientes"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Get informative or blocking warnings on partners"
-msgstr ""
+msgstr "Receba avisos informativos ou de bloqueio sobre os parceiros"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_fixed_putaway_strat__sequence
@@ -2112,7 +2194,7 @@ msgstr "Agrupar por..."
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__has_move_lines
 msgid "Has Move Lines"
-msgstr ""
+msgstr "Tem Linhas de Movimentação"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__move_line_exist
@@ -2122,23 +2204,23 @@ msgstr "Tem Operações de Pacote"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__has_packages
 msgid "Has Packages"
-msgstr ""
+msgstr "Tem Pacotes"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__has_scrap_move
 msgid "Has Scrap Moves"
-msgstr ""
+msgstr "Tem Movimentos de Sucata"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__has_tracking
 msgid "Has Tracking"
-msgstr ""
+msgstr "Tem Rastreamento"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_replenish__product_has_variants
 #: model:ir.model.fields,field_description:stock.field_stock_rules_report__product_has_variants
 msgid "Has variants"
-msgstr ""
+msgstr "Tem Variantes"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_location__posz
@@ -2152,6 +2234,9 @@ msgid ""
 "                purchase order or picking order they come from. You will find\n"
 "                the list of all products you are waiting for."
 msgstr ""
+"Aqui você pode receber produtos individuais, não importa\n"
+"                de que ordem de compra ou ordem de picking eles vêm. Você encontrará\n"
+"                a lista de todos os produtos que você está esperando."
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_procurement_group__id
@@ -2270,6 +2355,8 @@ msgid ""
 "If the inventory adjustment is not validated, date at which the theoritical quantities have been checked.\n"
 "If the inventory adjustment is validated, date at which the inventory adjustment has been validated."
 msgstr ""
+"Se o ajuste de estoque não for validado, data em que as quantidades teóricas foram verificadas."
+"Se o ajuste de estoque for validado, data em que o ajuste de estoque foi validado."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
@@ -2277,6 +2364,8 @@ msgid ""
 "If the picking is unlocked you can edit initial demand (for a draft picking)"
 " or done quantities (for a done picking)."
 msgstr ""
+"Se o picking estiver desbloqueado, é possível editar a demanda inicial (para um picking de rascunho)"
+" ou as quantidades já prontas (para um picking já feito)."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking_type__show_reserved
@@ -2284,6 +2373,8 @@ msgid ""
 "If this checkbox is ticked, Odoo will show which products are reserved "
 "(lot/serial number, source location, source package)."
 msgstr ""
+"Se esta caixa de seleção estiver marcada, Odoo mostrará quais produtos estão reservados "
+"(número de lote/série, localização da fonte, pacote fonte)."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__show_operations
@@ -2293,6 +2384,9 @@ msgid ""
 " operations. If not, the picking lines will represent an aggregate of "
 "detailed stock operations."
 msgstr ""
+"Se esta caixa de seleção estiver marcada, as linhas de coleta irão representar operações de estoque"
+" detalhadas. Caso contrário, as linhas de coleta representarão um agregado de"
+"operações de estoque detalhadas."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move_line__picking_type_use_create_lots
@@ -2301,6 +2395,8 @@ msgid ""
 "If this is checked only, it will suppose you want to create new Lots/Serial "
 "Numbers, so you can provide them in a text field. "
 msgstr ""
+"Se isso for verificado apenas, supõe-se que você queira criar novos Lotes/Números de "
+"Série, para que você possa fornecê-los em um campo de texto."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move_line__picking_type_use_existing_lots
@@ -2330,7 +2426,7 @@ msgstr ""
 #: model:ir.model.fields,help:stock.field_stock_picking__picking_type_entire_packs
 #: model:ir.model.fields,help:stock.field_stock_picking_type__show_entire_packs
 msgid "If ticked, you will be able to select entire packages to move"
-msgstr ""
+msgstr "Se selecionado, você poderá selecionar um packote inteiro para movimentar"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_rule__active
@@ -2373,7 +2469,7 @@ msgstr "Transferir imediatamente ?"
 #. module: stock
 #: selection:res.config.settings,module_procurement_jit:0
 msgid "Immediately after sales order confirmation"
-msgstr ""
+msgstr "Imediatamente após a confirmação do pedido de venda"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_inventory_filter
@@ -2389,7 +2485,7 @@ msgstr "No Tipo"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_inventory__exhausted
 msgid "Include Exhausted Products"
-msgstr ""
+msgstr "Incluir Produtos Esgotados"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_product__incoming_qty
@@ -2484,24 +2580,26 @@ msgid ""
 "Internal reference number in case it differs from the manufacturer's "
 "lot/serial number"
 msgstr ""
+"Número de referência interno no caso de ser diferente do número de "
+"lote/número de série do fabricante"
 
 #. module: stock
 #: code:addons/stock/models/product.py:254
 #, python-format
 msgid "Invalid domain left operand %s"
-msgstr ""
+msgstr "Domínio inválido operando à esquerda %s"
 
 #. module: stock
 #: code:addons/stock/models/product.py:256
 #, python-format
 msgid "Invalid domain operator %s"
-msgstr ""
+msgstr "Operador de domínio inválido %s"
 
 #. module: stock
 #: code:addons/stock/models/product.py:258
 #, python-format
 msgid "Invalid domain right operand %s"
-msgstr ""
+msgstr "Domínio inválido operando à diteira %s"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_inventory__location_id
@@ -2536,7 +2634,7 @@ msgstr "Inventários"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_inventory_filter
 msgid "Inventories Date"
-msgstr ""
+msgstr "Data dos Inventários"
 
 #. module: stock
 #: model:ir.actions.act_window,name:stock.quantsact
@@ -2582,7 +2680,7 @@ msgstr "Linha do Inventário"
 #. module: stock
 #: model:ir.actions.act_window,name:stock.action_inventory_line_tree
 msgid "Inventory Lines"
-msgstr ""
+msgstr "Linhas do Inventário"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_product__property_stock_inventory
@@ -2604,12 +2702,12 @@ msgstr "Perda de Inventário"
 #. module: stock
 #: model:ir.actions.act_window,name:stock.stock_picking_type_action
 msgid "Inventory Overview"
-msgstr ""
+msgstr "Visão Geral do Inventário"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_inventory_filter
 msgid "Inventory Product"
-msgstr ""
+msgstr "Inventário de Produto"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_inventory__name
@@ -2621,7 +2719,7 @@ msgstr "Referência de Inventário"
 #: model:ir.actions.act_window,name:stock.action_stock_quantity_history
 #: model:ir.ui.menu,name:stock.menu_valuation
 msgid "Inventory Report"
-msgstr ""
+msgstr "Relatório de Inventário"
 
 #. module: stock
 #: model:ir.model,name:stock.model_stock_location_route
@@ -2663,7 +2761,7 @@ msgstr "É um seguidor"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_package_level__is_fresh_package
 msgid "Is Fresh Package"
-msgstr ""
+msgstr "É um Pacote Novo"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__is_locked
@@ -2686,12 +2784,12 @@ msgstr "É um Local de Sucata?"
 #: model:ir.model.fields,field_description:stock.field_stock_move__is_initial_demand_editable
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__is_initial_demand_editable
 msgid "Is initial demand editable"
-msgstr ""
+msgstr "É uma demanda inicial editável"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__is_quantity_done_editable
 msgid "Is quantity done editable"
-msgstr ""
+msgstr "É uma quantidade concluída editável"
 
 #. module: stock
 #: code:addons/stock/models/stock_quant.py:261
@@ -2699,6 +2797,7 @@ msgstr ""
 msgid ""
 "It is not possible to reserve more products of %s than you have in stock."
 msgstr ""
+"Não é possível reservar mais produtos de %s do que você tem em estoque."
 
 #. module: stock
 #: code:addons/stock/models/stock_quant.py:266
@@ -2706,6 +2805,7 @@ msgstr ""
 msgid ""
 "It is not possible to unreserve more products of %s than you have in stock."
 msgstr ""
+"Não é possível conservar sem reservas mais produtos de %s do que os que você tem em estoque."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__product_packaging
@@ -2723,7 +2823,7 @@ msgstr "Especifica mercadorias para entregar parcialmente ou tudo de uma vez"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_lot_label
 msgid "LN/SN:"
-msgstr ""
+msgstr "NL/NS"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__last_done_picking
@@ -2893,7 +2993,7 @@ msgstr ""
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_stock_rule
 msgid "Legend"
-msgstr ""
+msgstr "Legenda"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_location__company_id
@@ -2910,12 +3010,12 @@ msgstr "Movimentos Vinculados"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_inventory_form
 msgid "List view of lines"
-msgstr ""
+msgstr "Visão de lista das linhas"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
 msgid "List view of operations"
-msgstr ""
+msgstr "Visão de lista das operações"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_location_form
@@ -2925,7 +3025,7 @@ msgstr "Localização"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_production_lot_form
 msgid "Locate"
-msgstr ""
+msgstr "Localizar"
 
 #. module: stock
 #: selection:barcode.rule,type:0
@@ -2952,7 +3052,7 @@ msgstr "Local"
 #. module: stock
 #: model:ir.actions.report,name:stock.action_report_location_barcode
 msgid "Location Barcode"
-msgstr ""
+msgstr "Código de Barras do Local"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_location__name
@@ -3010,12 +3110,12 @@ msgstr "Lote/Serie"
 #: model_terms:ir.ui.view,arch_db:stock.report_stock_body_print
 #: model_terms:ir.ui.view,arch_db:stock.report_stock_inventory
 msgid "Lot/Serial #"
-msgstr ""
+msgstr "Lote/Série #"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.message_body
 msgid "Lot/Serial :"
-msgstr ""
+msgstr "Lote/Série :"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_inventory_line__prod_lot_id
@@ -3028,42 +3128,42 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock.report_delivery_document
 #: model_terms:ir.ui.view,arch_db:stock.report_package_barcode
 msgid "Lot/Serial Number"
-msgstr "Lote/Número Serial "
+msgstr "Lote/Número de Série"
 
 #. module: stock
 #: model:ir.actions.report,name:stock.action_report_lot_label
 msgid "Lot/Serial Number (PDF)"
-msgstr ""
+msgstr "Lote/Número de Série (PDF)"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_inventory_tree
 msgid "Lot/Serial Number Inventory"
-msgstr ""
+msgstr "Inventário de Lote/Número de Série"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__lot_name
 msgid "Lot/Serial Number Name"
-msgstr ""
+msgstr "Nome do Lote/Número de Série"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__group_stock_production_lot
 msgid "Lots & Serial Numbers"
-msgstr ""
+msgstr "Lotes e Números de Série"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Lots &amp; Serial numbers will appear on the delivery slip"
-msgstr ""
+msgstr "Lotes &amp; Números de série aparecerão na guia de remessa"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__lots_visible
 msgid "Lots Visible"
-msgstr ""
+msgstr "Lotes Visíveis"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_track_confirmation
 msgid "Lots or serial numbers were not provided to tracked products"
-msgstr ""
+msgstr "Lotes ou números de série onde não é provido o rastreamento de produtos"
 
 #. module: stock
 #: model:ir.actions.act_window,name:stock.action_production_lot_form
@@ -3072,7 +3172,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock.view_production_lot_form_simple
 #: model_terms:ir.ui.view,arch_db:stock.view_production_lot_tree
 msgid "Lots/Serial Numbers"
-msgstr ""
+msgstr "Lotes/Números de Série"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse__mto_pull_id
@@ -3106,12 +3206,12 @@ msgstr "Gerenciar Lotes/Números de Série"
 #. module: stock
 #: model:res.groups,name:stock.group_stock_multi_locations
 msgid "Manage Multiple Stock Locations"
-msgstr ""
+msgstr "Gerenciar Vários Locais de Estoque"
 
 #. module: stock
 #: model:res.groups,name:stock.group_stock_multi_warehouses
 msgid "Manage Multiple Warehouses"
-msgstr ""
+msgstr "Gerenciar Vários Armazéns"
 
 #. module: stock
 #: model:res.groups,name:stock.group_tracking_lot
@@ -3126,12 +3226,12 @@ msgstr "Gerenciar Fluxos de Inventário"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Manage product packagings (e.g. pack of 6 bottles, box of 10 pieces)"
-msgstr ""
+msgstr "Gerenciar embalagens de produtos (por exemplo, embalagem de 6 garrafas, caixa de 10 peças)"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Manage several warehouses"
-msgstr ""
+msgstr "Gerenciar vários armazéns"
 
 #. module: stock
 #: model:res.groups,name:stock.group_stock_manager
@@ -3161,7 +3261,7 @@ msgstr "Manufatura"
 #. module: stock
 #: selection:stock.picking.type,code:0
 msgid "Manufacturing Operation"
-msgstr ""
+msgstr "Operação de Fabricação"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
@@ -3204,7 +3304,7 @@ msgstr "Método"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__propagation_minimum_delta
 msgid "Minimum Delta for Propagation"
-msgstr ""
+msgstr "Delta Mínimo para Propagação"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_company__propagation_minimum_delta
@@ -3254,7 +3354,7 @@ msgstr "Movimento"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_move_operations
 msgid "Move Detail"
-msgstr ""
+msgstr "Detalhes do Movimento"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__picking_type_entire_packs
@@ -3262,7 +3362,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock.field_stock_picking__picking_type_entire_packs
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__show_entire_packs
 msgid "Move Entire Packages"
-msgstr ""
+msgstr "Movimento de Pacotes Inteiros"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__move_line_ids
@@ -3274,7 +3374,7 @@ msgstr "Linha de Movimento"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__move_line_nosuggest_ids
 msgid "Move Line Nosuggest"
-msgstr ""
+msgstr "Mover Linha Sem Sugestão"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_move_line_form
@@ -3299,7 +3399,7 @@ msgstr ""
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__origin_returned_move_id
 msgid "Move that created the return move"
-msgstr ""
+msgstr "Movimento que criou o movimento de retorno"
 
 #. module: stock
 #: model:ir.actions.act_window,name:stock.act_product_stock_move_open
@@ -3318,16 +3418,19 @@ msgid ""
 " If none is given, the moves generated by stock rules will be grouped into "
 "one big picking."
 msgstr ""
+"Os movimentos criados através deste ponto de ordem serão colocados neste grupo de compras."
+" Se nenhum for dado, os movimentos gerados pelas regras de estoque serão agrupados em "
+"um grande grupo de coleta."
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__group_stock_adv_location
 msgid "Multi-Step Routes"
-msgstr ""
+msgstr "Rotas Multi-Passos"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__group_stock_multi_warehouses
 msgid "Multi-Warehouses"
-msgstr ""
+msgstr "Multi-Armazéns"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_internal_search
@@ -3346,7 +3449,7 @@ msgstr "Nome"
 #: model_terms:ir.ui.view,arch_db:stock.product_template_search_form_view_stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_product_search_form_view
 msgid "Negative Forecasted Quantity"
-msgstr ""
+msgstr "Quantidade Negativa Prevista"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.quant_search_view
@@ -3367,7 +3470,7 @@ msgstr "Novo"
 #: code:addons/stock/models/stock_picking.py:612
 #, python-format
 msgid "New Move:"
-msgstr ""
+msgstr "Novo Movimento:"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_change_product_qty__new_quantity
@@ -3400,7 +3503,7 @@ msgstr "Tipo da Próxima Atividade"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.exception_on_picking
 msgid "Next transfer(s) impacted:"
-msgstr ""
+msgstr "Próxima(s) transferência(s) impactada(s):"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_backorder_confirmation
@@ -3415,7 +3518,7 @@ msgstr "Sem Mensagem"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__use_propagation_minimum_delta
 msgid "No Rescheduling Propagation"
-msgstr ""
+msgstr "Sem Propagação de Reprogramação"
 
 #. module: stock
 #: selection:product.template,tracking:0
@@ -3425,7 +3528,7 @@ msgstr "Sem Rastreamento"
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.quantsact
 msgid "No inventory found"
-msgstr ""
+msgstr "Nenhum Inventário Encontrado"
 
 #. module: stock
 #: code:addons/stock/models/stock_move_line.py:408
@@ -3436,7 +3539,7 @@ msgstr "Não é permitido quantidades negativas"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_stock_inventory
 msgid "No operation made on this lot."
-msgstr ""
+msgstr "Nenhuma operação feita neste lote."
 
 #. module: stock
 #: code:addons/stock/models/stock_rule.py:305
@@ -3445,6 +3548,8 @@ msgid ""
 "No procurement rule found in location \"%s\" for product \"%s\".\n"
 " Check routes configuration."
 msgstr ""
+"Nenhuma regra de suprimento encontrada no local \"%s\" para o produto \"%s\".\n"
+"Verificar configuração de rotas."
 
 #. module: stock
 #: code:addons/stock/wizard/stock_picking_return.py:59
@@ -3453,12 +3558,14 @@ msgid ""
 "No products to return (only lines in Done state and not fully returned yet "
 "can be returned)."
 msgstr ""
+"Não há produtos a devolver (apenas as linhas no estado de Feito e ainda não totalmente devolvidas "
+"podem ser devolvidas)."
 
 #. module: stock
 #: code:addons/stock/models/stock_rule.py:172
 #, python-format
 msgid "No source location defined on stock rule: %s!"
-msgstr ""
+msgstr "Nenhum local de origem definido na regra de estoque: %s!"
 
 #. module: stock
 #: selection:stock.move,priority:0 selection:stock.picking,priority:0
@@ -3550,6 +3657,9 @@ msgid ""
 "                the vendor or the purchase order reference. Then you can confirm\n"
 "                all products received using the buttons on the right of each line."
 msgstr ""
+"Após receber um pedido, você pode filtrar com base no nome do\n"
+"                fornecedor ou na referência do pedido de compra. Depois é possível confirmar\n"
+"                todos os produtos recebidos usando os botões à direita de cada linha."
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:121
@@ -3567,7 +3677,7 @@ msgstr "Um proprietário só"
 #: code:addons/stock/models/stock_inventory.py:114
 #, python-format
 msgid "One product category"
-msgstr ""
+msgstr "Produto de uma categoria"
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:119
@@ -3596,7 +3706,7 @@ msgstr "Tipo de operação"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__return_picking_type_id
 msgid "Operation Type for Returns"
-msgstr ""
+msgstr "Tipo de Operações para Retornos"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_type_form
@@ -3604,12 +3714,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_type_tree
 #: model_terms:ir.ui.view,arch_db:stock.view_warehouse
 msgid "Operation Types"
-msgstr ""
+msgstr "Tipos de Operações"
 
 #. module: stock
 #: model:ir.actions.report,name:stock.action_report_picking_type_label
 msgid "Operation type (PDF)"
-msgstr ""
+msgstr "Tipo de Operação (PDF)"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__move_line_ids
@@ -3629,7 +3739,7 @@ msgstr "Tipos de Operações"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__move_line_ids_without_package
 msgid "Operations without package"
-msgstr ""
+msgstr "Operações sem pacote"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__partner_id
@@ -3682,7 +3792,7 @@ msgstr "Origem"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_move_form
 msgid "Origin Moves"
-msgstr ""
+msgstr "Movimentos de Origem"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__origin_returned_move_id
@@ -3692,7 +3802,7 @@ msgstr "Movimento de devolução de origem"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_return_picking__original_location_id
 msgid "Original Location"
-msgstr ""
+msgstr "Local Original"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__move_orig_ids
@@ -3714,7 +3824,7 @@ msgstr "Enviando"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse__delivery_steps
 msgid "Outgoing Shipments"
-msgstr ""
+msgstr "Remessas de saída"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:446
@@ -3736,7 +3846,7 @@ msgstr "Vencido"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_overprocessed_transfer__overprocessed_product_name
 msgid "Overprocessed Product Name"
-msgstr ""
+msgstr "Nome de Produto Super Processado"
 
 #. module: stock
 #: model:ir.ui.menu,name:stock.stock_picking_type_menu
@@ -3765,7 +3875,7 @@ msgstr "Proprietário"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.message_body
 msgid "Owner :"
-msgstr ""
+msgstr "Proprietário :"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_location__partner_id
@@ -3788,7 +3898,7 @@ msgstr "Qtd P&L"
 #: code:addons/stock/static/src/xml/stock_traceability_report_backend.xml:6
 #, python-format
 msgid "PRINT"
-msgstr ""
+msgstr "IMPRIMIR"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:742
@@ -3805,7 +3915,7 @@ msgstr "Tipo pacote"
 #. module: stock
 #: selection:stock.warehouse,delivery_steps:0
 msgid "Pack goods, send goods in output and then deliver (3 steps)"
-msgstr ""
+msgstr "Embalar as mercadorias, enviar as mercadorias e depois entregar (3 etapas)"
 
 #. module: stock
 #: selection:barcode.rule,type:0
@@ -3823,29 +3933,29 @@ msgstr "Pacote"
 #. module: stock
 #: model:ir.actions.report,name:stock.action_report_quant_package_barcode_small
 msgid "Package Barcode (PDF)"
-msgstr ""
+msgstr "Código de Barras do Pacote (PDF)"
 
 #. module: stock
 #: model:ir.actions.report,name:stock.action_report_quant_package_barcode
 msgid "Package Barcode with Content"
-msgstr ""
+msgstr "Código de Barras do Pacote com Conteúdo"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_package_barcode
 msgid "Package Content"
-msgstr ""
+msgstr "Conteúdo do Pacote"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__package_level_id
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__package_level_id
 #: model:ir.model.fields,field_description:stock.field_stock_picking__package_level_ids
 msgid "Package Level"
-msgstr ""
+msgstr "Nível do Pacote"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__package_level_ids_details
 msgid "Package Level Ids Details"
-msgstr ""
+msgstr "Detalhes dos Ids de Nível do Pacote"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.quant_package_search_view
@@ -3861,7 +3971,7 @@ msgstr "Referência pacote"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_package_barcode_small
 msgid "Package Reference:"
-msgstr ""
+msgstr "Referência do Pacote:"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_quant_package_form
@@ -3877,7 +3987,7 @@ msgstr "Tipo de package"
 #: model_terms:ir.ui.view,arch_db:stock.report_package_barcode
 #: model_terms:ir.ui.view,arch_db:stock.report_package_barcode_small
 msgid "Package Type:"
-msgstr ""
+msgstr "Tipo de Pacote:"
 
 #. module: stock
 #: model:ir.actions.act_window,name:stock.action_package_view
@@ -3935,7 +4045,7 @@ msgstr "Local Pai"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_location__parent_path
 msgid "Parent Path"
-msgstr ""
+msgstr "Caminho do Pai"
 
 #. module: stock
 #: selection:procurement.group,move_type:0
@@ -3962,7 +4072,7 @@ msgstr "Endereço de Parceiro"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_inventory_filter
 msgid "Physical Inventories by Date"
-msgstr ""
+msgstr "Estoques físicos por data"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:751
@@ -4000,7 +4110,7 @@ msgstr "Listas de Separação"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_quant_form
 msgid "Picking Moves"
-msgstr ""
+msgstr "Movimentos de Coleta"
 
 #. module: stock
 #: model:ir.actions.report,name:stock.action_report_picking
@@ -4057,7 +4167,7 @@ msgstr "Transferência Planejada"
 #: code:addons/stock/models/stock_picking.py:690
 #, python-format
 msgid "Please add some items to move."
-msgstr ""
+msgstr "Por favor, adicione alguns itens para mover."
 
 #. module: stock
 #: code:addons/stock/wizard/stock_picking_return.py:132
@@ -4068,22 +4178,22 @@ msgstr "Por favor espeficique pelo menos uma quantidade diferente de zero."
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.quant_search_view
 msgid "Positive Stock"
-msgstr ""
+msgstr "Estoque Positivo"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__product_packaging
 msgid "Preferred Packaging"
-msgstr ""
+msgstr "Embalagem Preferencial"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_replenish__route_ids
 msgid "Preferred Routes"
-msgstr "Rota Preferencial"
+msgstr "Rotas Preferencial"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__route_ids
 msgid "Preferred route"
-msgstr ""
+msgstr "Rota Preferencial"
 
 #. module: stock
 #: selection:barcode.rule,type:0
@@ -4119,17 +4229,17 @@ msgstr ""
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Process operations faster with barcodes"
-msgstr ""
+msgstr "Operações de processo mais rápidas com códigos de barras"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Process picking in batch per worker"
-msgstr ""
+msgstr "Processo de coleta em lote por trabalhador"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_overprocessed_transfer
 msgid "Processed more than initial demand"
-msgstr ""
+msgstr "Processado mais do que a demanda inicial"
 
 #. module: stock
 #: selection:stock.location,usage:0
@@ -4154,12 +4264,12 @@ msgstr "Grupo de Aquisição"
 #: model:ir.cron,cron_name:stock.ir_cron_scheduler_action
 #: model:ir.cron,name:stock.ir_cron_scheduler_action
 msgid "Procurement: run scheduler"
-msgstr ""
+msgstr "Aquisição: agendador de execução"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__produce_line_ids
 msgid "Produce Line"
-msgstr ""
+msgstr "Linha de Produção"
 
 #. module: stock
 #: code:addons/stock/models/product.py:350
@@ -4234,12 +4344,12 @@ msgstr "Movimentação de Produto"
 #: model_terms:ir.ui.view,arch_db:stock.product_form_view_procurement_button
 #: model_terms:ir.ui.view,arch_db:stock.product_template_form_view_procurement_button
 msgid "Product Moves"
-msgstr ""
+msgstr "Movimentações do Produto"
 
 #. module: stock
 #: model:ir.model,name:stock.model_stock_move_line
 msgid "Product Moves (Stock Move Line)"
-msgstr ""
+msgstr "Movimentações do Produto (Linha de Movimentação de Estoque)"
 
 #. module: stock
 #: model:ir.ui.menu,name:stock.menu_product_packagings
@@ -4256,7 +4366,7 @@ msgstr "Reposição de Produto"
 #: model:ir.actions.report,name:stock.action_report_stock_rule
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_rules_report
 msgid "Product Routes Report"
-msgstr ""
+msgstr "Relatório de Rotas do Produto"
 
 #. module: stock
 #: model:ir.model,name:stock.model_product_template
@@ -4270,7 +4380,7 @@ msgstr "Modelo de Produto"
 #: model:ir.model.fields,field_description:stock.field_product_replenish__product_tmpl_id
 #: model:ir.model.fields,field_description:stock.field_stock_rules_report__product_tmpl_id
 msgid "Product Tmpl"
-msgstr ""
+msgstr "Model de Produto"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_product__type
@@ -4299,11 +4409,13 @@ msgid ""
 "Product this lot/serial number contains. You cannot change it anymore if it "
 "has already been moved."
 msgstr ""
+"Produto que contém este número de lote/série. Não é mais possível modificá-lo se ele "
+"já tiver sido movido."
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__has_tracking
 msgid "Product with Tracking"
-msgstr ""
+msgstr "Produto com Rastreamento"
 
 #. module: stock
 #: selection:stock.location,usage:0
@@ -4351,7 +4463,7 @@ msgstr "Propagar cancelar e divisão"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_rule_form
 msgid "Propagation"
-msgstr ""
+msgstr "Propagação"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_rule__group_propagation_option
@@ -4361,17 +4473,17 @@ msgstr "Propagação de Grupo de Aquisições"
 #. module: stock
 #: selection:stock.rule,action:0
 msgid "Pull & Push"
-msgstr ""
+msgstr "Coletar e Enviar"
 
 #. module: stock
 #: selection:stock.rule,action:0
 msgid "Pull From"
-msgstr ""
+msgstr "Coletar de"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_stock_rule
 msgid "Pull Rule"
-msgstr ""
+msgstr "Regra de coleta"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_stock_rule
@@ -4381,7 +4493,7 @@ msgstr "Regra de envio"
 #. module: stock
 #: selection:stock.rule,action:0
 msgid "Push To"
-msgstr ""
+msgstr "Enviar para"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_fixed_putaway_strat__putaway_id
@@ -4397,23 +4509,23 @@ msgstr "Guardar Estratégia "
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
 msgid "Put in Pack"
-msgstr ""
+msgstr "Guardar em embalagem"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Put your products in packs (e.g. parcels, boxes) and track them"
-msgstr ""
+msgstr "Coloque os seus produtos em embalagens (por exemplo, pacotes, caixas) e rastreie-os "
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_fixed_putaway_strat_form
 #: model_terms:ir.ui.view,arch_db:stock.view_putaway
 msgid "Putaway"
-msgstr "Jogue fora "
+msgstr "Jogue fora"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_stock_rule
 msgid "Putaway:"
-msgstr ""
+msgstr "Jogue fora:"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse_orderpoint__qty_multiple
@@ -4441,7 +4553,7 @@ msgstr "Local do Controle de Qualidade"
 #: model:ir.model.fields,field_description:stock.field_stock_warn_insufficient_qty__quant_ids
 #: model:ir.model.fields,field_description:stock.field_stock_warn_insufficient_qty_scrap__quant_ids
 msgid "Quant"
-msgstr ""
+msgstr "Quant"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_replenish__quantity
@@ -4459,7 +4571,7 @@ msgstr "Quantidade"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.message_body
 msgid "Quantity :"
-msgstr ""
+msgstr "Quantidade :"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__quantity_done
@@ -4468,7 +4580,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock.view_move_line_tree
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_move_line_kanban
 msgid "Quantity Done"
-msgstr ""
+msgstr "Quantidade Concluída"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_warehouse_orderpoint_form
@@ -4499,7 +4611,7 @@ msgstr "A Quantidade não pode ser negativa"
 #: code:addons/stock/models/stock_move.py:643
 #, python-format
 msgid "Quantity decreased!"
-msgstr ""
+msgstr "Quantidade reduzida!"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__availability
@@ -4520,6 +4632,10 @@ msgid ""
 "In a context with a single Warehouse, this includes goods arriving to the Stock Location of this Warehouse, or any of its children.\n"
 "Otherwise, this includes goods arriving to any Stock Location with 'internal' type."
 msgstr ""
+"Quantidade de produtos de entrada planejada.\n"
+"Em um contexto com um único Local de Estoque, isso inclui as mercadorias que chegam a esse Local, ou qualquer um de seus filhos.\n"
+"Em um contexto com um único Depósito, isso inclui as mercadorias que chegam ao Local de Estoque deste Depósito, ou a qualquer um de seus filhos.\n"
+"Caso contrário, isso inclui as mercadorias que chegam a qualquer Local de Estoque com tipo 'interno'."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_product_product__outgoing_qty
@@ -4529,6 +4645,10 @@ msgid ""
 "In a context with a single Warehouse, this includes goods leaving the Stock Location of this Warehouse, or any of its children.\n"
 "Otherwise, this includes goods leaving any Stock Location with 'internal' type."
 msgstr ""
+"Quantidade de produtos de saída planejada.\n"
+"Em um contexto com um único Local de Estoque, isso inclui as mercadorias que saem desse Local, ou qualquer um de seus filhos.\n"
+"Em um contexto com um único Depósito, isso inclui as mercadorias que saem do Local de Estoque deste Depósito, ou a qualquer um de seus filhos.\n"
+"Caso contrário, isso inclui as mercadorias que saem de qualquer Local de Estoque com tipo 'interno'."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_quant__quantity
@@ -4545,6 +4665,8 @@ msgid ""
 "Quantity of reserved products in this quant, in the default unit of measure "
 "of the product"
 msgstr ""
+"Quantidade de produtos reservados nesta quantidade, na unidade de medida "
+"predefinida do produto"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__reserved_availability
@@ -4563,17 +4685,17 @@ msgstr "Quants"
 #: code:addons/stock/models/stock_quant.py:74
 #, python-format
 msgid "Quants cannot be created for consumables or services."
-msgstr ""
+msgstr "As quantidades não podem ser criadas para consumíveis ou serviços."
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__rate_picking_backorders
 msgid "Rate Picking Backorders"
-msgstr ""
+msgstr "Ordens de Coleta de Tarifas"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__rate_picking_late
 msgid "Rate Picking Late"
-msgstr ""
+msgstr "Tarifa de Coleta Atrasada"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_picking_type_kanban
@@ -4593,7 +4715,7 @@ msgstr "Quantidade real"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__product_qty
 msgid "Real Reserved Quantity"
-msgstr ""
+msgstr "Quantidade Real Reservada"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse__reception_route_id
@@ -4611,35 +4733,35 @@ msgstr "Recebimentos"
 #. module: stock
 #: selection:stock.warehouse,reception_steps:0
 msgid "Receive goods directly (1 step)"
-msgstr ""
+msgstr "Receber mercadoria diretamente (1 passo)"
 
 #. module: stock
 #: selection:stock.warehouse,reception_steps:0
 msgid "Receive goods in input and then stock (2 steps)"
-msgstr ""
+msgstr "Receber mercadorias na entrada e depois estocar (2 etapas)"
 
 #. module: stock
 #: selection:stock.warehouse,reception_steps:0
 msgid "Receive goods in input, then quality and then stock (3 steps)"
-msgstr ""
+msgstr "Receber mercadorias na entrada, depois qualidade e depois estoque (3 etapas)"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:524
 #, python-format
 msgid "Receive in 1 step (stock)"
-msgstr ""
+msgstr "Receber em 1 passo (estoque)"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:524
 #, python-format
 msgid "Receive in 2 steps (input + stock)"
-msgstr ""
+msgstr "Receber em 2 passos (entrada + estoque)"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:525
 #, python-format
 msgid "Receive in 3 steps (input + quality + stock)"
-msgstr ""
+msgstr "Receber em 3 passos (entrada + qualidade +estoque)"
 
 #. module: stock
 #: code:addons/stock/models/product.py:327
@@ -4687,13 +4809,13 @@ msgstr "Referência do documento"
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_receipt_picking_move
 msgid "Register a product receipt"
-msgstr ""
+msgstr "Registrar um recibo de produto"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_move_kandan
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
 msgid "Register lots, packs, location"
-msgstr ""
+msgstr "Registrar lotes, pacotes, locais"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_internal_search
@@ -4753,12 +4875,12 @@ msgstr "Pesquisar Regras Recompra"
 #: model_terms:ir.ui.view,arch_db:stock.product_product_view_form_easy_inherit_stock
 #: model_terms:ir.ui.view,arch_db:stock.product_template_form_view_procurement_button
 msgid "Replenish"
-msgstr "Reposição"
+msgstr "Reabastecimento"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_product_replenish
 msgid "Replenish wizard"
-msgstr ""
+msgstr "Assistente de Reabastecimento"
 
 #. module: stock
 #: model:ir.ui.menu,name:stock.menu_warehouse_report
@@ -4771,6 +4893,8 @@ msgid ""
 "Rescheduling applies to any chain of operations (e.g. Make To Order, Pick Pack Ship). In the case of MTO sales, a vendor delay (updated incoming date) impacts the expected delivery date to the customer. \n"
 " This option allows to not propagate the rescheduling if the change is not critical."
 msgstr ""
+"A reprogramação aplica-se a qualquer cadeia de operações (por exemplo, Faça a Encomenda, Coleta de Pacotes de Envio). No caso de vendas MTO, um atraso do fornecedor (data de entrada atualizada) afeta a data de entrega esperada para o cliente. \n"
+" Esta opção permite não propagar a reprogramação se a mudança não for crítica".
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
@@ -4780,6 +4904,10 @@ msgid ""
 " impacts the expected delivery date to the customer. This option allows to "
 "not propagate the rescheduling if the change is not critical."
 msgstr ""
+"A reprogramação aplica-se a qualquer cadeia de operações (por exemplo, Faça a Encomenda, Coleta de "
+"de Pacotes de Envio). No caso de vendas MTO, um atraso do fornecedor (data de entrada atualizada)"
+" afeta a data de entrega esperada para o cliente. Esta opção permite "
+"não propagar a reescalonamento se a mudança não for crítica."
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__module_procurement_jit
@@ -4789,7 +4917,7 @@ msgstr "Reserva"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.quant_search_view
 msgid "Reservations"
-msgstr ""
+msgstr "Reservas"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__product_uom_qty
@@ -4804,7 +4932,7 @@ msgstr "Reservado"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_quant__reserved_quantity
 msgid "Reserved Quantity"
-msgstr ""
+msgstr "Quantidade Reservada"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_res_config_settings__module_procurement_jit
@@ -4813,6 +4941,9 @@ msgid ""
 "is advised to better manage priorities in case of long customer lead times "
 "or/and frequent stock-outs."
 msgstr ""
+"A reserva manual de produtos em ordens de entrega ou através da execução do agendador "
+"é aconselhado a gerir melhor as prioridades em caso de longos prazos de entrega dos clientes "
+"ou/e frequentes rupturas de stock."
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_product__responsible_id
@@ -4829,12 +4960,12 @@ msgstr "Usuário Responsável"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_warehouse
 msgid "Resupply"
-msgstr ""
+msgstr "Reabastecimento"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse__resupply_wh_ids
 msgid "Resupply From"
-msgstr ""
+msgstr "Reabastecimento de"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse__resupply_route_ids
@@ -4844,7 +4975,7 @@ msgstr "Rotas de Reabastecimento"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_quantity_history
 msgid "Retrieve the Inventory Quantities"
-msgstr ""
+msgstr "Recuperar as Quantidades do Inventário"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
@@ -4865,13 +4996,13 @@ msgstr "Separação Devolvida"
 #. module: stock
 #: model:ir.model,name:stock.model_stock_return_picking_line
 msgid "Return Picking Line"
-msgstr ""
+msgstr "Linha de Coleta Devolvida"
 
 #. module: stock
 #: code:addons/stock/wizard/stock_picking_return.py:103
 #, python-format
 msgid "Return of %s"
-msgstr ""
+msgstr "Devolução de %s"
 
 #. module: stock
 #: code:addons/stock/wizard/stock_picking_return.py:153
@@ -4918,6 +5049,8 @@ msgid ""
 "Routes will be created automatically to resupply this warehouse from the "
 "warehouses ticked"
 msgstr ""
+"As rotas serão criadas automaticamente para reabastecer este armazém a partir dos "
+"armazéns selecionados"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_warehouse__resupply_route_ids
@@ -4931,7 +5064,7 @@ msgstr ""
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_rule__rule_message
 msgid "Rule Message"
-msgstr ""
+msgstr "Mensagem de Regra"
 
 #. module: stock
 #: model:ir.actions.act_window,name:stock.action_rules_form
@@ -4959,7 +5092,7 @@ msgstr "Executar Agendadores Manualmente"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_warehouse_orderpoint_form
 msgid "Run the scheduler"
-msgstr ""
+msgstr "Executar o Agendador"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_replenish__date_planned
@@ -4977,7 +5110,7 @@ msgstr "Data agendada para o processamento deste movimento"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_move_search
 msgid "Scheduled or processing date"
-msgstr ""
+msgstr "Agendado ou processando data"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking__scheduled_date
@@ -5021,7 +5154,7 @@ msgstr "Ordens de Sucata"
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_stock_scrap
 msgid "Scrap products"
-msgstr ""
+msgstr "Produtos Sucata"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__scrapped
@@ -5034,6 +5167,8 @@ msgid ""
 "Scrapping a product will remove it from your stock. The product will\n"
 "                end up in a scrap location that can be used for reporting purpose."
 msgstr ""
+"O sucateamento de um produto irá removê-lo do seu estoque. O produto acabará\n"
+"                em um local de sucata que pode ser usado para fins de relatório."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
@@ -5048,7 +5183,7 @@ msgstr "Pesquisar Inventário"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_inventory_line_search
 msgid "Search Inventory Lines"
-msgstr ""
+msgstr "Pesquisar Linhas do Inventário"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_rule_filter
@@ -5058,7 +5193,7 @@ msgstr "Procurar Aquisições"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_scrap_search_view
 msgid "Search Scrap"
-msgstr ""
+msgstr "Procurar Sucata"
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:116
@@ -5091,7 +5226,7 @@ msgstr "Vender e comprar produtos em unidades diferentes de medidas"
 #. module: stock
 #: selection:stock.warehouse,delivery_steps:0
 msgid "Send goods in output and then deliver (2 steps)"
-msgstr ""
+msgstr "Enviar a mercadoria e então entregar (2 passos)"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_location_route__sequence
@@ -5101,37 +5236,37 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock.stock_location_route_form_view
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_rule_form
 msgid "Sequence"
-msgstr "Seqüência"
+msgstr "Sequência"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:777
 #, python-format
 msgid "Sequence in"
-msgstr ""
+msgstr "Sequência em"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:797
 #, python-format
 msgid "Sequence internal"
-msgstr ""
+msgstr "Sequência interna"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:782
 #, python-format
 msgid "Sequence out"
-msgstr ""
+msgstr "Saída em Sequência"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:787
 #, python-format
 msgid "Sequence packing"
-msgstr ""
+msgstr "Embalagem Sequencial"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:792
 #, python-format
 msgid "Sequence picking"
-msgstr ""
+msgstr "Coleta Sequencial"
 
 #. module: stock
 #: selection:product.template,type:0
@@ -5141,12 +5276,12 @@ msgstr "Serviço"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Set Putaway Strategies on Locations"
-msgstr ""
+msgstr "Definir estratégias de entrada em depósito nos locais"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Set Warehouse Routes"
-msgstr ""
+msgstr "Definir Rotas de Armazéns"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_product_category__removal_strategy_id
@@ -5160,17 +5295,17 @@ msgstr ""
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Set expiration dates on lots &amp; serial numbers"
-msgstr ""
+msgstr "Definir datas de expiração em lotes &amp; números de série"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Set owner on stored products"
-msgstr ""
+msgstr "Definir proprietário em produtos armazenados"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Set product attributes (e.g. color, size) to manage variants"
-msgstr ""
+msgstr "Definir atributos do produto (por exemplo, cor, tamanho) para gerenciar variações"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_inventory_form
@@ -5201,7 +5336,7 @@ msgstr "Prateleiras (Y)"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_warehouse
 msgid "Shipments"
-msgstr ""
+msgstr "Envios"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
@@ -5220,6 +5355,9 @@ msgid ""
 " labels and request carrier picking at your warehouse to ship to the "
 "customer. Apply shipping connector from delivery methods."
 msgstr ""
+"Os conectores de envio permitem calcular custos de envio precisos, imprimir etiquetas"
+" de envio e solicitar ao transportador o picking no seu armazém para enviar ao "
+"cliente. Aplique o conector de envio a partir dos métodos de entrega."
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse__code
@@ -5234,49 +5372,49 @@ msgstr "Nome abreviado usado para identificar seu armazém"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__show_check_availability
 msgid "Show Check Availability"
-msgstr ""
+msgstr "Mostrar Disponibilidade de Cheques"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__show_operations
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__show_operations
 msgid "Show Detailed Operations"
-msgstr ""
+msgstr "Mostrar Operações Detalhadas"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_package_level__show_lots_m2o
 msgid "Show Lots M2O"
-msgstr ""
+msgstr "Mostrar Lotes M20"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_package_level__show_lots_text
 #: model:ir.model.fields,field_description:stock.field_stock_picking__show_lots_text
 msgid "Show Lots Text"
-msgstr ""
+msgstr "Mostrar Lotes de Texto"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__show_mark_as_todo
 msgid "Show Mark As Todo"
-msgstr ""
+msgstr "Mostrar Marcação como 'A Fazer'"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__show_operations
 msgid "Show Operations"
-msgstr ""
+msgstr "Mostrar Operações"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__show_reserved
 msgid "Show Reserved"
-msgstr ""
+msgstr "Mostrar Reservados"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse__show_resupply
 msgid "Show Resupply"
-msgstr ""
+msgstr "Mostrar Reabastecimento"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__show_validate
 msgid "Show Validate"
-msgstr ""
+msgstr "Mostrar Validação"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_internal_search
@@ -5287,7 +5425,7 @@ msgstr ""
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_rules_report__warehouse_ids
 msgid "Show the routes that apply on selected warehouses."
-msgstr ""
+msgstr "Mostrar as rotas que se aplicam aos armazéns selecionados "
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__string_availability_info
@@ -5302,6 +5440,8 @@ msgid ""
 "Some products of the inventory adjustment are tracked. Are you sure you "
 "don't want to specify a serial or lot number for them?"
 msgstr ""
+"Alguns produtos do ajuste de inventário são rastreados. Tem certeza que "
+"não quer especificar um número de série ou lote para eles?"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_picking
@@ -5329,7 +5469,7 @@ msgstr "Local de Origem"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.message_body
 msgid "Source Location:"
-msgstr ""
+msgstr "Local de Origem:"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__package_id
@@ -5340,7 +5480,7 @@ msgstr "Fonte de Pacotes"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.message_body
 msgid "Source Package :"
-msgstr ""
+msgstr "Pacote de Origem"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_inventory__lot_id
@@ -5369,6 +5509,7 @@ msgstr ""
 msgid ""
 "Specify Product Category to focus your inventory on a particular Category."
 msgstr ""
+"Especifique a Categoria do Produto para focar seu inventário em uma Categoria particular."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_inventory__product_id
@@ -5423,7 +5564,7 @@ msgstr "Estoque"
 #. module: stock
 #: model:ir.model,name:stock.model_report_stock_forecast
 msgid "Stock Forecast Report"
-msgstr ""
+msgstr "Relatório de Previsão de Estoque"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_inventory
@@ -5496,17 +5637,17 @@ msgstr "Estoque em Mãos"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_scrap_form_view
 msgid "Stock Operation"
-msgstr ""
+msgstr "Operação de Estoque"
 
 #. module: stock
 #: model:ir.model,name:stock.model_stock_package_destination
 msgid "Stock Package Destination"
-msgstr ""
+msgstr "Destino do Pacote do Estoque"
 
 #. module: stock
 #: model:ir.model,name:stock.model_stock_package_level
 msgid "Stock Package Level"
-msgstr ""
+msgstr "Nivel do Pacote do Estoque"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_partner__picking_warn
@@ -5519,43 +5660,43 @@ msgstr "Separação de Estoque"
 #: model:ir.model.fields,field_description:stock.field_product_product__stock_quant_ids
 #: model_terms:ir.ui.view,arch_db:stock.stock_quant_view_graph
 msgid "Stock Quant"
-msgstr ""
+msgstr "Quantidade de Estoque"
 
 #. module: stock
 #: model:ir.model,name:stock.model_stock_quantity_history
 msgid "Stock Quantity History"
-msgstr ""
+msgstr "Histórico de Quantidade do Estoque"
 
 #. module: stock
 #: model:ir.model,name:stock.model_stock_rule
 #: model:ir.model.fields,field_description:stock.field_stock_move__rule_id
 msgid "Stock Rule"
-msgstr ""
+msgstr "Regra de Estoque"
 
 #. module: stock
 #: model:ir.actions.act_window,name:stock.action_stock_rules_report
 msgid "Stock Rules Report"
-msgstr ""
+msgstr "Relatório de Regras de Estoque"
 
 #. module: stock
 #: model:ir.model,name:stock.model_stock_rules_report
 msgid "Stock Rules report"
-msgstr ""
+msgstr "Relatório de Regras de Estoque"
 
 #. module: stock
 #: model:ir.model,name:stock.model_stock_track_confirmation
 msgid "Stock Track Confirmation"
-msgstr ""
+msgstr "Confirmação da Pista de Estoque"
 
 #. module: stock
 #: model:ir.model,name:stock.model_stock_track_line
 msgid "Stock Track Line"
-msgstr ""
+msgstr "Linha de Pista de Estoque"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__move_ids_without_package
 msgid "Stock moves not in package"
-msgstr ""
+msgstr "Movimentos de estoque não em pacote"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_move_search
@@ -5576,7 +5717,7 @@ msgstr "Movimentos de Estoque que foram processados"
 #. module: stock
 #: model:ir.model,name:stock.model_report_stock_report_stock_rule
 msgid "Stock rule report"
-msgstr ""
+msgstr "Relatório de regra de estoque"
 
 #. module: stock
 #: selection:product.template,type:0
@@ -5586,7 +5727,7 @@ msgstr "Produto"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__group_stock_multi_locations
 msgid "Storage Locations"
-msgstr ""
+msgstr "Locais de Armazenamento"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_res_config_settings__group_stock_multi_locations
@@ -5595,6 +5736,8 @@ msgid ""
 "Store products in specific locations of your warehouse (e.g. bins, racks) "
 "and to track inventory accordingly."
 msgstr ""
+"Armazene os produtos em locais específicos do seu armazém (por exemplo, caixas, racks) "
+"e para rastrear o inventário de acordo."
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_location_route__supplied_wh_id
@@ -5645,6 +5788,8 @@ msgid ""
 "Technical field used to compute whether the check availability button should"
 " be shown."
 msgstr ""
+"Campo técnico usado para calcular se o botão de verificação de disponibilidade deve"
+" ser mostrado."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking__show_mark_as_todo
@@ -5652,11 +5797,13 @@ msgid ""
 "Technical field used to compute whether the mark as todo button should be "
 "shown."
 msgstr ""
+"Campo técnico utilizado para calcular se a marca como botão a fazer deve ser "
+"mostrada."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking__show_validate
 msgid "Technical field used to compute whether the validate should be shown."
-msgstr ""
+msgstr "Campo técnico utilizado para calcular se a validação deve ser mostrada."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__restrict_partner_id
@@ -5682,23 +5829,23 @@ msgstr ""
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move_line__produce_line_ids
 msgid "Technical link to see which line was produced with this. "
-msgstr ""
+msgstr "Ligação técnica para ver que linha foi produzida com isto. "
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move_line__consume_line_ids
 msgid "Technical link to see who consumed what. "
-msgstr ""
+msgstr "Ligação técnica para ver quem consumiu o quê. "
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__product_tmpl_id
 msgid "Technical: used in views"
-msgstr ""
+msgstr "Técnico: usado em Visões"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_product_product__stock_move_ids
 #: model:ir.model.fields,help:stock.field_product_product__stock_quant_ids
 msgid "Technical: used to compute quantities."
-msgstr ""
+msgstr "Técnico: usado para calcular quantidades."
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_change_product_qty__product_tmpl_id
@@ -5712,6 +5859,9 @@ msgid ""
 " With 'Automatic No Step Added', the location is replaced in the original "
 "move."
 msgstr ""
+"O valor 'Operação Manual' criará um movimento de estoque após o atual."
+" Com a opção 'Sem acréscimo automático de etapas', a localização é substituída na movimentação "
+"original."
 
 #. module: stock
 #: code:addons/stock/models/stock_picking.py:824
@@ -5720,6 +5870,8 @@ msgid ""
 "The backorder <a href=# data-oe-model=stock.picking data-oe-id=%d>%s</a> has"
 " been created."
 msgstr ""
+"O pedido em atraso <a href=# data-oe-model=stock.picking data-oe-id=%d>%s</a>"
+" foi criado."
 
 #. module: stock
 #: sql_constraint:stock.location:0
@@ -5740,7 +5892,7 @@ msgstr "A combinação de número de série e do produto deve ser única!"
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_warehouse__company_id
 msgid "The company is automatically set from your user preferences."
-msgstr ""
+msgstr "A empresa é automaticamente definida a partir das suas preferências de utilizador."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_rule__delay
@@ -5748,6 +5900,8 @@ msgid ""
 "The expected date of the created transfer will be computed based on this "
 "delay."
 msgstr ""
+"A data esperada da transferência criada será calculada com base neste "
+"atraso."
 
 #. module: stock
 #: sql_constraint:stock.warehouse:0
@@ -5762,6 +5916,10 @@ msgid ""
 "                On the operation type you could e.g. specify if packing is needed by default,\n"
 "                if it should show the customer."
 msgstr ""
+"O sistema de tipo de operação permite atribuir a cada operação\n"
+"                de estoque um tipo específico que alterará suas visões de acordo.\n"
+"                No tipo de operação você poderia, por exemplo, especificar se a embalagem é necessária por padrão,\n"
+"                se ela deve mostrar ao cliente."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_quant__package_id
@@ -5774,6 +5932,8 @@ msgid ""
 "The parent location that includes this location. Example : The 'Dispatch "
 "Zone' is the 'Gate 1' parent location."
 msgstr ""
+"A localização dos pais que inclui esta localização. Exemplo : A 'Zona de "
+"Expedição' é a localização pai 'Portão 1'."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_warehouse_orderpoint__qty_multiple
@@ -5781,11 +5941,13 @@ msgid ""
 "The procurement quantity will be rounded up to this multiple.  If it is 0, "
 "the exact quantity will be used."
 msgstr ""
+"A quantidade de suprimento será arredondada para este múltiplo.  Se for 0, "
+"a quantidade exata será usada."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_warn_insufficient_qty_form_view
 msgid "The product"
-msgstr ""
+msgstr "O Produto"
 
 #. module: stock
 #: code:addons/stock/models/stock_move_line.py:377
@@ -5797,6 +5959,11 @@ msgid ""
 "                                   rounding precision of your unit of "
 "measure."
 msgstr ""
+"A quantidade feita para o produto \"%s\" não respeita a precisão de "
+"arredondamento                                   definida na unidade de medida "
+"\"%s\". Por favor, altere a quantidade feita ou"
+"                                   a precisão de arredondamento da sua unidade de "
+"medida."
 
 #. module: stock
 #: code:addons/stock/models/stock_move.py:284
@@ -5815,6 +5982,8 @@ msgid ""
 "The rules defined per product will be applied before the rules defined per "
 "product category."
 msgstr ""
+"As regras definidas por produto serão aplicadas antes das regras definidas por "
+"categoria de produto."
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:160
@@ -5822,24 +5991,25 @@ msgstr ""
 msgid ""
 "The selected inventory options are not coherent, the package doesn't exist."
 msgstr ""
+"As opções de inventário selecionadas não são coerentes, o pacote não existe."
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:156
 #, python-format
 msgid "The selected lot number doesn't exist."
-msgstr ""
+msgstr "O número de lote selecionado não existe."
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:158
 #, python-format
 msgid "The selected owner doesn't have the proprietary of that product."
-msgstr ""
+msgstr "O proprietário selecionado não tem a propriedade desse produto."
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:154
 #, python-format
 msgid "The selected product doesn't belong to that owner.."
-msgstr ""
+msgstr "O produto selecionado não pertece a aquele dono.."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_res_partner__property_stock_customer
@@ -5847,13 +6017,14 @@ msgstr ""
 msgid ""
 "The stock location used as destination when sending goods to this contact."
 msgstr ""
+"O local de estoque usado como destino ao enviar mercadorias para este contato."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_res_partner__property_stock_supplier
 #: model:ir.model.fields,help:stock.field_res_users__property_stock_supplier
 msgid ""
 "The stock location used as source when receiving goods from this contact."
-msgstr ""
+msgstr "O local do estoque usado como fonte ao receber mercadorias deste contato."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move_line__picking_id
@@ -5863,7 +6034,7 @@ msgstr "A operação de estoque onde a embalagem tenha sido feita"
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__rule_id
 msgid "The stock rule that created this stock move"
-msgstr ""
+msgstr "A regra de estoque que criou este movimento de estoque"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_procurement_compute_wizard
@@ -5871,6 +6042,8 @@ msgid ""
 "The stock will be reserved for operations waiting for availability and the "
 "reordering rules will be triggered."
 msgstr ""
+"O estoque será reservado para operações à espera de disponibilidade e as "
+"regras de reordenação serão acionadas."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_rule__propagate_warehouse_id
@@ -5891,7 +6064,7 @@ msgstr "Quantidade Teórica"
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.stock_move_line_action
 msgid "There's no product move yet"
-msgstr ""
+msgstr "Não existe movimentos de produtos ainda"
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.quantsact
@@ -5915,6 +6088,10 @@ msgid ""
 "routes put another location. If it is empty, it will check for the customer "
 "location on the partner. "
 msgstr ""
+"Este é o local de destino predefinido quando se cria uma coleta manualmente"
+"com este tipo de operação. É possível, no entanto, alterá-la ou que as "
+"rotas coloquem outro local. Se estiver vazio, irá verificar a localização "
+"do cliente no parceiro."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking_type__default_location_src_id
@@ -5924,6 +6101,10 @@ msgid ""
 "put another location. If it is empty, it will check for the supplier "
 "location on the partner. "
 msgstr ""
+"Este é o local de origem padrão quando se cria um picking manualmente com "
+"este tipo de operação. É possível, no entanto, alterá-la ou que as rotas "
+"coloquem outro local. Se estiver vazio, irá verificar a localização "
+"do fornecedor no parceiro. "
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_production_lot_form
@@ -5931,6 +6112,8 @@ msgid ""
 "This is the list of all the production lots you recorded. When\n"
 "            you select a lot, you can get the traceability of the products contained in lot."
 msgstr ""
+"Esta é a lista de todos os lotes de produção que você gravou. Quando\n"
+"            você seleciona um lote, você pode obter a rastreabilidade dos produtos contidos no lote."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_quant__owner_id
@@ -5957,7 +6140,7 @@ msgstr ""
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_inventory_form
 msgid "This is used to correct the product quantities you have in stock."
-msgstr ""
+msgstr "Isto é usado para corrigir as quantidades de produtos que você tem em estoque."
 
 #. module: stock
 #: code:addons/stock/models/stock_location.py:83
@@ -5965,12 +6148,13 @@ msgstr ""
 msgid ""
 "This location's usage cannot be changed to view as it contains products."
 msgstr ""
+"O uso deste local não pode ser alterado para visualização, pois ele contém produtos."
 
 #. module: stock
 #: code:addons/stock/models/stock_move_line.py:74
 #, python-format
 msgid "This lot %s is incompatible with this product %s"
-msgstr ""
+msgstr "Este lote %s é incompativel com este produto %s"
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.stock_move_action
@@ -5986,7 +6170,7 @@ msgstr ""
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_template_property_form
 msgid "This note will show up on delivery orders."
-msgstr ""
+msgstr "Esta nota aparecerá nas ordens de entrega."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_template_property_form
@@ -5994,6 +6178,8 @@ msgid ""
 "This note will show up on internal transfer orders (e.g. where to pick the "
 "product in the warehouse)."
 msgstr ""
+"Esta nota aparecerá nas ordens de transferência interna (por exemplo, onde recolher o "
+"produto no armazém)."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_template_property_form
@@ -6001,6 +6187,8 @@ msgid ""
 "This note will show up on receipt orders (e.g. where to store the product in"
 " the warehouse)."
 msgstr ""
+"Esta nota aparecerá nas ordens de recepção (por exemplo, onde armazenar o produto"
+" no armazém)."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_return_picking_form
@@ -6048,6 +6236,8 @@ msgid ""
 "This user will be responsible of the next activities related to logistic "
 "operations for this product."
 msgstr ""
+"Este utilizador será responsável pelas próximas actividades relacionadas com as operações "
+"logísticas deste produto."
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__location_dest_id
@@ -6069,7 +6259,7 @@ msgstr "A Fazer"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_picking_type_kanban
 msgid "To Process"
-msgstr ""
+msgstr "A Processar"
 
 #. module: stock
 #: selection:stock.picking,activity_state:0
@@ -6110,7 +6300,7 @@ msgstr "Rastreabilidade"
 #: model_terms:ir.ui.view,arch_db:stock.view_production_lot_form
 #, python-format
 msgid "Traceability Report"
-msgstr ""
+msgstr "Relatório de Rastreamento"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_res_config_settings__module_product_expiry
@@ -6118,6 +6308,8 @@ msgid ""
 "Track following dates on lots & serial numbers: best before, removal, end of life, alert. \n"
 " Such dates are set automatically at lot/serial number creation based on values set on the product (in days)."
 msgstr ""
+"Acompanhe as seguintes datas em lotes e números de série: melhor antes, remoção, fim de vida, alerta. \n"
+" Essas datas são definidas automaticamente na criação do lote/número de série com base nos valores definidos no produto (em dias)".
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
@@ -6126,27 +6318,30 @@ msgid ""
 " life, alert. Such dates are set automatically at lot/serial number creation"
 " based on values set on the product (in days)."
 msgstr ""
+"Acompanhe as seguintes datas em lotes e números de série: melhor antes, remoção, fim de "
+" vida, alerta. Essas datas são definidas automaticamente na criação do lote/número de série"
+" com base nos valores definidos no produto (em dias)."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Track product location in your warehouse"
-msgstr ""
+msgstr "Rastreie a localização do produto no seu armazém"
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:173
 #, python-format
 msgid "Tracked Products in Inventory Adjustment"
-msgstr ""
+msgstr "Produtos Rastreados no Ajuste de Estoques"
 
 #. module: stock
 #: selection:stock.track.line,tracking:0
 msgid "Tracked by lot"
-msgstr ""
+msgstr "Rastreado por Lote"
 
 #. module: stock
 #: selection:stock.track.line,tracking:0
 msgid "Tracked by serial number"
-msgstr ""
+msgstr "Rastreado por número de série"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_product__tracking
@@ -6161,7 +6356,7 @@ msgstr "Acompanhamento"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_track_confirmation__tracking_line_ids
 msgid "Tracking Line"
-msgstr ""
+msgstr "linha de acompanhamento"
 
 #. module: stock
 #: model:ir.model,name:stock.model_stock_picking
@@ -6177,7 +6372,7 @@ msgstr "Endereço de Destino da Transferência"
 #. module: stock
 #: model:ir.model,name:stock.model_stock_overprocessed_transfer
 msgid "Transfer Over Processed Stock"
-msgstr ""
+msgstr "Transferência Sobre Estoque Processado"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__picking_id
@@ -6205,7 +6400,7 @@ msgstr "Localização transitoria "
 #: model_terms:ir.ui.view,arch_db:stock.report_stock_rule
 #: selection:stock.rule,procure_method:0
 msgid "Trigger Another Rule"
-msgstr ""
+msgstr "Acionar outra regra"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_barcode_rule__type
@@ -6241,7 +6436,7 @@ msgstr "Desdobrar"
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_production_lot__name
 msgid "Unique Lot/Serial Number"
-msgstr ""
+msgstr "Número de Lote/Série Único"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_move_picking_form
@@ -6284,7 +6479,7 @@ msgstr "Unidade de Medida"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Units Of Measure"
-msgstr ""
+msgstr "Unidades de Medida"
 
 #. module: stock
 #: model:ir.ui.menu,name:stock.menu_stock_unit_measure_stock
@@ -6299,13 +6494,13 @@ msgstr "Unidades de Medida"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_replenish__product_uom_id
 msgid "Unity of measure"
-msgstr ""
+msgstr "Unidade de Medida"
 
 #. module: stock
 #: code:addons/stock/models/stock_picking.py:885
 #, python-format
 msgid "Unknow stream."
-msgstr ""
+msgstr "Corrente desconhecida."
 
 #. module: stock
 #: code:addons/stock/models/stock_quant.py:348
@@ -6351,17 +6546,17 @@ msgstr "Falta de reserva"
 #: model_terms:ir.ui.view,arch_db:stock.stock_inventory_line_tree2
 #: model_terms:ir.ui.view,arch_db:stock.view_inventory_form
 msgid "UoM"
-msgstr "UoM"
+msgstr "UdM"
 
 #. module: stock
 #: model:ir.ui.menu,name:stock.menu_stock_uom_categ_form_action
 msgid "UoM Categories"
-msgstr ""
+msgstr "Categorias de UdM"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_inventory_line__product_uom_category_id
 msgid "Uom category"
-msgstr ""
+msgstr "Categoria da UdM"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_change_product_quantity
@@ -6379,7 +6574,7 @@ msgstr "Atualizar Qtd em Mãos"
 #: code:addons/stock/models/product.py:563
 #, python-format
 msgid "Update quantity on hand"
-msgstr ""
+msgstr "Atualizar quantidade em mãos"
 
 #. module: stock
 #: selection:stock.move,priority:0 selection:stock.picking,priority:0
@@ -6390,7 +6585,7 @@ msgstr "Urgente"
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__picking_type_use_existing_lots
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__use_existing_lots
 msgid "Use Existing Lots/Serial Numbers"
-msgstr ""
+msgstr "Usar Números de Lote/Série Existentes"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_product_replenish
@@ -6406,7 +6601,7 @@ msgstr ""
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "Use your own routes and putaway strategies"
-msgstr ""
+msgstr "Use as suas próprias rotas e estratégias de entrada em depósito"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking_type__sequence
@@ -6538,7 +6733,7 @@ msgstr "Configuração do Armazém"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse__warehouse_count
 msgid "Warehouse Count"
-msgstr ""
+msgstr "Contagem do Armazém"
 
 #. module: stock
 #: model:ir.ui.menu,name:stock.menu_warehouse_config
@@ -6569,12 +6764,12 @@ msgstr "Armazéns"
 #. module: stock
 #: model:ir.model,name:stock.model_stock_warn_insufficient_qty
 msgid "Warn Insufficient Quantity"
-msgstr ""
+msgstr "Advertir Quantidade Insuficiente"
 
 #. module: stock
 #: model:ir.model,name:stock.model_stock_warn_insufficient_qty_scrap
 msgid "Warn Insufficient Scrap Quantity"
-msgstr ""
+msgstr "Advertir Quantidade de Sucata Insuficiente"
 
 #. module: stock
 #: code:addons/stock/models/stock_move_line.py:129
@@ -6603,7 +6798,7 @@ msgstr "Aviso"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__group_warning_stock
 msgid "Warnings for Stock"
-msgstr ""
+msgstr "Avisos para Estoque"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__website_message_ids
@@ -6638,7 +6833,7 @@ msgstr ""
 #. module: stock
 #: selection:stock.picking,move_type:0
 msgid "When all products are ready"
-msgstr ""
+msgstr "Quando todos os produtos estiverem prontos"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_location_route__product_selectable
@@ -6665,6 +6860,8 @@ msgid ""
 "When products are needed in <b>%s</b>, <br/> <b>%s</b> are created from "
 "<b>%s</b> to fulfill the need."
 msgstr ""
+"Quando os produtos são necessários em <b>%s</b>, <br/> <b>%s</b> são criados a partir de "
+"<b>%s</b> para satisfazer a necessidade."
 
 #. module: stock
 #: code:addons/stock/models/stock_rule.py:114
@@ -6673,6 +6870,8 @@ msgid ""
 "When products arrive in <b>%s</b>, <br/> <b>%s</b> are created to send them "
 "in <b>%s</b>."
 msgstr ""
+"Quando os produtos chegam em <b>%s</b>, <br/> <b>%s</b> são criados para enviá-los "
+"em <b>%s</b>."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking__is_locked
@@ -6680,6 +6879,8 @@ msgid ""
 "When the picking is not done this allows changing the initial demand. When "
 "the picking is done this allows changing the done quantities."
 msgstr ""
+"Quando a colheita não é feita, isso permite alterar a demanda inicial. Quando "
+"o picking é feito, isto permite alterar as quantidades feitas."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_warehouse_orderpoint__product_min_qty
@@ -6709,11 +6910,13 @@ msgid ""
 "When ticked, if the move is splitted or cancelled, the next move will be "
 "too."
 msgstr ""
+"Quando marcado, se a movimentação for dividida ou cancelada, a próxima movimentação será "
+"também."
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__additional
 msgid "Whether the move was added after the picking's confirmation"
-msgstr ""
+msgstr "Se a mudança foi adicionada após a confirmação da coleta"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_return_picking_line__wizard_id
@@ -6729,6 +6932,9 @@ msgid ""
 "if some stock moves have already been created with that number. This would "
 "lead to inconsistencies in your stock."
 msgstr ""
+"Não é permitido alterar o produto ligado a um número de série ou de lote "
+"se alguns movimentos de estoque já tiverem sido criados com esse número. Isto seria "
+"levam a inconsistências no seu estoque."
 
 #. module: stock
 #: code:addons/stock/models/stock_production_lot.py:36
@@ -6738,6 +6944,9 @@ msgid ""
 "type. To change this, go on the operation type and tick the box \"Create New"
 " Lots/Serial Numbers\"."
 msgstr ""
+"Você não tem permissão para criar um lote ou número de série com esta operação "
+"tipo. Para alterar isso, vá para o tipo de operação e marque a caixa Criar novo"
+" Lotes/Números de série."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_package_destination_form_view
@@ -6745,6 +6954,8 @@ msgid ""
 "You are trying to put products going to different locations into the same "
 "package"
 msgstr ""
+"Você está a tentar colocar produtos que vão para locais diferentes no mesmo "
+"pacote"
 
 #. module: stock
 #: code:addons/stock/models/stock_move.py:668
@@ -6756,6 +6967,11 @@ msgid ""
 "valuate your stock or change its rounding precision to a smaller value "
 "(example: 0.00001)."
 msgstr ""
+"Você está usando uma unidade de medida menor que a que você está usando em ordem "
+"para estocar o seu produto. Isto pode levar a um problema de arredondamento no caso de reserva. "
+"quantidade. Deve-se usar a menor unidade de medida possível para "
+"avaliar o seu stock ou alterar a sua precisão de arredondamento para um valor menor "
+"(exemplo: 0,00001)."
 
 #. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_routes_form
@@ -6765,6 +6981,10 @@ msgid ""
 "                routes can be assigned to a product, a product category or be fixed\n"
 "                on procurement or sales order."
 msgstr ""
+"Você pode definir aqui as principais rotas que percorrem\n"
+"                os seus armazéns e que definem os fluxos dos seus produtos. Estas\n"
+"                rotas podem ser atribuídas a um produto, a uma categoria de produto ou ser fixas\n"
+"                em compras ou ordens do cliente."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_inventory_form
@@ -6779,6 +6999,9 @@ msgid ""
 "stock move. If you need to change the type, you should first unreserve the "
 "stock move."
 msgstr ""
+"Não é possível alterar o tipo de produto que está actualmente reservado em um "
+"movimento de estoque. Se você precisar mudar o tipo, você deve primeiro deixar de reservar o "
+"movimento de estoque."
 
 #. module: stock
 #: code:addons/stock/models/stock_move_line.py:338
@@ -6787,18 +7010,20 @@ msgid ""
 "You can not delete product moves if the picking is done. You can only "
 "correct the done quantities."
 msgstr ""
+"Não é possível eliminar os movimentos do produto se o picking for feito. Você só pode "
+"corrigir as quantidades feitas."
 
 #. module: stock
 #: code:addons/stock/models/stock_move_line.py:147
 #, python-format
 msgid "You can not enter negative quantities."
-msgstr ""
+msgstr "Não é possível entrar quantidades negativas."
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:426
 #, python-format
 msgid "You can only adjust storable products."
-msgstr ""
+msgstr "Só é possível ajustar produtos armazenáveis"
 
 #. module: stock
 #: code:addons/stock/models/stock_move.py:1149
@@ -6810,7 +7035,7 @@ msgstr "Você só pode apagar movimento provisórios"
 #: code:addons/stock/models/stock_move_line.py:140
 #, python-format
 msgid "You can only process 1.0 %s of products with unique serial number."
-msgstr ""
+msgstr "Você só pode processar 1,0 %s dos produtos com um número de série único."
 
 #. module: stock
 #: code:addons/stock/models/stock_move.py:1014
@@ -6827,6 +7052,8 @@ msgid ""
 "You cannot change the location type or its use as a scrap location as there "
 "are products reserved in this location. Please unreserve the products first."
 msgstr ""
+"Não é possível modificar o tipo de local ou seu uso como local de sucata, pois "
+"há produtos reservados nesse local. Por favor, não reserve os produtos primeiro."
 
 #. module: stock
 #: code:addons/stock/models/product.py:647
@@ -6835,6 +7062,8 @@ msgid ""
 "You cannot change the ratio of this unit of mesure as some products with "
 "this UoM have already been moved or are currently reserved."
 msgstr ""
+"Não é possível alterar a proporção desta unidade de medida, uma vez que alguns produtos com "
+"esta UdM já foram movidos ou estão actualmente reservados."
 
 #. module: stock
 #: code:addons/stock/models/product.py:536
@@ -6844,18 +7073,21 @@ msgid ""
 "this product. If you want to change the unit of measure, you should rather "
 "archive this product and create a new one."
 msgstr ""
+"Não é possível modificar a unidade de medida, pois já existem movimentos de estoque para "
+"este produto. Se você quiser mudar a unidade de medida, é melhor "
+"arquivar este produto e criar um novo"."
 
 #. module: stock
 #: code:addons/stock/models/stock_scrap.py:76
 #, python-format
 msgid "You cannot delete a scrap which is done."
-msgstr ""
+msgstr "Não é possível deletar uma sucata que está concluida"
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:105
 #, python-format
 msgid "You cannot delete a validated inventory adjustement."
-msgstr ""
+msgstr "Não é possível deletar um ajuste de estoque validado."
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:415
@@ -6866,6 +7098,10 @@ msgid ""
 "Please first validate the first inventory adjustment before creating another"
 " one."
 msgstr ""
+"Você não pode ter dois ajustes de estoque no estado 'Em andamento' com o "
+"mesmo produto (%s), mesmo local, mesmo pacote, mesmo dono e mesmo lote. "
+"Por favor, primeiro valide o primeiro ajuste de estoque antes de criar"
+" outro."
 
 #. module: stock
 #: code:addons/stock/models/stock_move.py:1134
@@ -6874,6 +7110,8 @@ msgid ""
 "You cannot move the same package content more than once in the same transfer"
 " or split the same package into two location."
 msgstr ""
+"Você não pode mover o mesmo conteúdo de pacote mais de uma vez na mesma transferência"
+" ou dividir o mesmo pacote em dois locais."
 
 #. module: stock
 #: code:addons/stock/models/stock_move.py:339
@@ -6882,6 +7120,8 @@ msgid ""
 "You cannot perform the move because the unit of measure has a different "
 "category as the product unit of measure."
 msgstr ""
+"Não é possível executar a mudança porque a unidade de medida tem uma categoria "
+"diferente como a unidade de medida do produto."
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:186
@@ -6905,7 +7145,7 @@ msgstr ""
 #: code:addons/stock/models/stock_move.py:1176
 #, python-format
 msgid "You cannot split a stock move that has been set to 'Done'."
-msgstr ""
+msgstr "Não se pode dividir um movimento de estoque que tenha sido definido como 'Feito'."
 
 #. module: stock
 #: code:addons/stock/models/stock_quant.py:86
@@ -6914,12 +7154,14 @@ msgid ""
 "You cannot take products from or deliver products to a location of type "
 "\"view\"."
 msgstr ""
+"Você não pode levar produtos de ou entregar produtos para um local do tipo"
+"\"visão\"."
 
 #. module: stock
 #: code:addons/stock/models/stock_move.py:501
 #, python-format
 msgid "You cannot unreserve a stock move that has been set to 'Done'."
-msgstr ""
+msgstr "Você não pode deixar de reservar um movimento de estoque que tenha sido definido como 'Feito'."
 
 #. module: stock
 #: code:addons/stock/models/stock_move_line.py:122
@@ -6929,6 +7171,8 @@ msgid ""
 "You cannot use the same serial number twice. Please correct the serial "
 "numbers encoded."
 msgstr ""
+"Não se pode usar o mesmo número de série duas vezes. Por favor, corrija os números de "
+"série codificados."
 
 #. module: stock
 #: code:addons/stock/models/stock_picking.py:698
@@ -6937,6 +7181,8 @@ msgid ""
 "You cannot validate a transfer if no quantites are reserved nor done. To "
 "force the transfer, switch in edit more and encode the done quantities."
 msgstr ""
+"Não é possível validar uma transferência se nenhuma quantidade for reservada ou feita. Para "
+"forçar a transferência, mude para editar mais e codificar as quantidades feitas."
 
 #. module: stock
 #: code:addons/stock/wizard/stock_picking_return.py:112
@@ -6944,6 +7190,7 @@ msgstr ""
 msgid ""
 "You have manually created product lines, please delete them to proceed."
 msgstr ""
+"Você criou manualmente linhas de produtos, por favor, apague-as para prosseguir."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_immediate_transfer
@@ -6965,6 +7212,8 @@ msgid ""
 "You have processed more than what was initially\n"
 "                    planned for the product"
 msgstr ""
+"Foi processado mais do que foi inicialmente\n"
+"                    planejado para o produto"
 
 #. module: stock
 #: code:addons/stock/models/product.py:307
@@ -6982,6 +7231,7 @@ msgstr ""
 msgid ""
 "You have to define a groupby and sorted method and pass them as arguments."
 msgstr ""
+"É necessário definir um método de agrupado por grupo e ordenado e passá-los como argumentos."
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:911
@@ -6990,43 +7240,45 @@ msgid ""
 "You have to select a product unit of measure that is in the same category "
 "than the default unit of measure of the product"
 msgstr ""
+"É necessário selecionar uma unidade de medida do produto que esteja na mesma categoria "
+"que a unidade de medida padrão do produto"
 
 #. module: stock
 #: code:addons/stock/models/stock_location.py:109
 #, python-format
 msgid "You have to set a name for this location."
-msgstr ""
+msgstr "É necessário definir um nome para este local."
 
 #. module: stock
 #: code:addons/stock/wizard/stock_picking_return.py:47
 #, python-format
 msgid "You may only return Done pickings."
-msgstr ""
+msgstr "Apenas coletas Concluídas devem ser retornadas."
 
 #. module: stock
 #: code:addons/stock/wizard/stock_picking_return.py:38
 #, python-format
 msgid "You may only return one picking at a time."
-msgstr ""
+msgstr "Apenas uma coleta por vez deve ser retornada."
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:22
 #, python-format
 msgid "You must define a warehouse for the company: %s."
-msgstr ""
+msgstr "É necessário definir um armazém para a empresa: %s."
 
 #. module: stock
 #: code:addons/stock/models/stock_picking.py:1045
 #, python-format
 msgid "You must first set the quantity you will put in the pack."
-msgstr ""
+msgstr "É necessário definir a quantidade que será colocado na embalagem."
 
 #. module: stock
 #: code:addons/stock/models/stock_move_line.py:406
 #: code:addons/stock/models/stock_picking.py:712
 #, python-format
 msgid "You need to supply a Lot/Serial number for product %s."
-msgstr ""
+msgstr "Você precisa fornecer um número de lote/ série para o produto %s."
 
 #. module: stock
 #: code:addons/stock/models/product.py:394
@@ -7036,11 +7288,13 @@ msgid ""
 "You still have some active reordering rules on this product. Please archive "
 "or delete them first."
 msgstr ""
+"Você ainda tem algumas regras de reordenação ativas neste produto. Por favor, arquive-as "
+"ou apague-as primeiro."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_stock_rule
 msgid "]<br/>min:"
-msgstr ""
+msgstr "]<br/>min:"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_change_product_quantity
@@ -7067,7 +7321,7 @@ msgstr "dias"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.res_config_settings_view_form
 msgid "days to be propagated"
-msgstr ""
+msgstr "dias a serem propagados"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_inventory_form
@@ -7093,7 +7347,7 @@ msgstr "em"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_warn_insufficient_qty_form_view
 msgid "is not available in sufficient quantity"
-msgstr ""
+msgstr "não está disponivel em quantidade suficiente"
 
 #. module: stock
 #: model:product.product,uom_name:stock.product_cable_management_box
@@ -7106,7 +7360,7 @@ msgstr "kg"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_warehouse_orderpoint_form
 msgid "manually to trigger the reordering rules right now."
-msgstr ""
+msgstr "manualmente para acionar as regras de reordenação agora mesmo."
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.exception_on_picking
@@ -7116,7 +7370,7 @@ msgstr "de"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.exception_on_picking
 msgid "processed instead of"
-msgstr ""
+msgstr "processado em vez de"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_inventory_form
@@ -7127,4 +7381,4 @@ msgstr "⇒ Definir quantidades para 0"
 #: code:addons/stock/models/stock_move_line.py:223
 #, python-format
 msgid "Changing the product is only allowed in 'Draft' state."
-msgstr ""
+msgstr "Mudar o produto só é permitido no estado 'Rascunho'."


### PR DESCRIPTION
# Descrição

[IMP] Traduz módulo "stock" do core

# Informações adicionais

[T3974](https://multi.multidadosti.com.br/web#id=4383&view_type=form&model=project.task&action=323&active_id=61)