### PR TITLE
T3998-Acertar Tradução modulo 'Sale' Odoo 12

### DIFF
--- a/addons/sale/i18n/pt_BR.po
+++ b/addons/sale/i18n/pt_BR.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * sale
-# 
+#
 # Translators:
 # Cezar José Sant Anna Junior <cezar.santanna@gmail.com>, 2018
 # Gideoni Silva <gd.willian@gmail.com>, 2018
@@ -29,7 +29,7 @@
 # Luiz Carareto Alonso <Luiz.cararetoalonso@gmail.com>, 2019
 # Ramiro Pereira de Magalhães <ramiro.p.magalhaes@gmail.com>, 2019
 # Diego Bittencourt <diegomb86@gmail.com>, 2019
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -2339,7 +2339,7 @@ msgstr "Vender pedido"
 #: code:addons/sale/controllers/portal.py:201
 #, python-format
 msgid "Order is not in a state requiring customer signature."
-msgstr "A encomenda não está num estado que exija a assinatura do cliente."
+msgstr "O pedido não está em um estado que exija assinatura do cliente."
 
 #. module: sale
 #: code:addons/sale/controllers/portal.py:215


### PR DESCRIPTION
# Descrição

[MIG] Acerta tradução pt_br modulo 'sale' Odoo 12

# Informações adicionais

[T3998](https://multi.multidadosti.com.br/web?#id=4407&view_type=form&model=project.task&action=323&active_id=61)