### PR TITLE
[IMP] Habilita campo 'Criar caso não exista' no modulo 'Base Import'

### DIFF
--- a/addons/base_import/static/src/js/import_action.js
+++ b/addons/base_import/static/src/js/import_action.js
@@ -412,7 +412,8 @@ var DataImport = AbstractAction.extend(ControlPanelMixin, {
 
             var $thing = $();
             var bind = function (d) {};
-            if (session.debug) {
+            if (true) { // if (session.debug) {
+                // Alterado pela Multidados para Liberar a função abaixo mesmo sem Debug
                 $thing = $(QWeb.render('ImportView.create_record_option')).insertAfter(v).hide();
                 bind = function (data) {
                     switch (data.type) {


### PR DESCRIPTION
# Descrição

[IMP] Habilita campo 'Criar caso não exista' no modulo 'Base Import' 
- Habilita campo mesmo sem Debug setado

# Informações adicionais

[T4413](https://multi.multidadosti.com.br/web?#id=4822&view_type=form&model=project.task&action=323&active_id=61)

PR Relacionado: [402](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/402)