### PR TITLE
T4672 - Adicionar no Odoo - MultiCompany nos Filtros para os Usuários

### DIFF
--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -182,7 +182,9 @@
             <field name="name">user rule</field>
             <field name="model_id" ref="model_res_users"/>
             <field eval="True" name="global"/>
-            <field name="domain_force">[('company_ids','child_of',[user.company_id.id])]</field>
+            <!-- Substituido domain original para resolver o Multi-Compay
+                <field name="domain_force">[('company_ids','child_of',[user.company_id.id])]</field> -->
+            <field name="domain_force">[('company_ids','in',user.company_ids.ids)]</field>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
# Descrição

[IMP] Substitui Regra MultiCompany padrão do Odoo para 'res_users'

# Informações adicionais

[T4672](https://multi.multidadosti.com.br/web?#id=5081&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)