### PR TITLE
T4765 - Erro: Não deixa confirmar Pedido/Orçamento com Produto para Venda

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -305,13 +305,20 @@ class ProcurementGroup(models.Model):
         values.setdefault('priority', '1')
         values.setdefault('date_planned', fields.Datetime.now())
         rule = self._get_rule(product_id, location_id, values)
-        if not rule:
+
+        # Multidados: Adicionado if product_id.type == 'product'
+        # Pois somente Product controla Estoque e Contém Regra de Estoque
+        if not rule and product_id.type == 'product':
             raise UserError(_('No procurement rule found in location "%s" for product "%s".\n Check routes configuration.') % (location_id.display_name, product_id.display_name))
-        action = 'pull' if rule.action == 'pull_push' else rule.action
-        if hasattr(rule, '_run_%s' % action):
-            getattr(rule, '_run_%s' % action)(product_id, product_qty, product_uom, location_id, name, origin, values)
-        else:
-            _logger.error("The method _run_%s doesn't exist on the procument rules" % action)
+
+        # Somente entra se tiver uma Rule Definida
+        if rule:
+            action = 'pull' if rule.action == 'pull_push' else rule.action
+            if hasattr(rule, '_run_%s' % action):
+                getattr(rule, '_run_%s' % action)(product_id, product_qty, product_uom, location_id, name, origin, values)
+            else:
+                _logger.error("The method _run_%s doesn't exist on the procument rules" % action)
+
         return True
 
     @api.model


### PR DESCRIPTION
# Descrição

[FIX] Adiciona IF = 'product' para Regra de Stock modulo 'stock'
- Adicionado if product_id.type == 'product' para verificação da regra
  do Estoque (Compra ou Transferência)

  Obs.: Isso porque o type = 'consu' não controla saldo de Estoque, então
        não precisa verificar a regra.

# Informações adicionais

[T4765](https://multi.multidadosti.com.br/web?debug=#id=5174&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

