### PR TITLE
Corrige erro de português na mensagem de erro

### DIFF
--- a/odoo/addons/base/i18n/pt_BR.po
+++ b/odoo/addons/base/i18n/pt_BR.po
@@ -10809,7 +10809,7 @@ msgstr "Antes do valor"
 msgid ""
 "Before clicking on 'Change Password', you have to write a new password."
 msgstr ""
-"Antes de clivar em 'Mudar Senha', você deve escrever uma nova senha"
+"Antes de clicar em 'Mudar Senha', você deve escrever uma nova senha."
 
 #. module: base
 #: model:res.country,name:base.by


### PR DESCRIPTION
# Descrição

- [IMP] Corrige erro de português de 'clivar' para 'clicar'

# Informações adicionais

- [T4855](https://multi.multidadosti.com.br/web?#id=5264&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)