### PR TITLE
T4985 - Melhorar a Visualização da Agenda das Fono (Ativiidade) vs Calendário

### DIFF
--- a/addons/web/static/src/xml/web_calendar.xml
+++ b/addons/web/static/src/xml/web_calendar.xml
@@ -15,12 +15,13 @@
     <t t-name="calendar-box">
         <t t-set="color" t-value="widget.getColor(event.color_index)"/>
         <div t-att-style="typeof color === 'string' ? ('background-color:'+color)+';' : ''" t-attf-class="#{record.is_highlighted ? 'o_event_hightlight' : ''} #{typeof color === 'number' ? 'o_calendar_color_'+color : ''}">
-            <div class="fc-time"/>
+            <!-- <div class="fc-time"/> Removido para aproveitar espaço de linhas -->
             <div class="o_fields">
                 <t t-foreach="widget.displayFields" t-as="name">
                     <div t-attf-class="o_field_#{name} o_field_type_#{fields[name].type}">
                         <t t-if="widget.displayFields[name].avatar_field">
                             <t t-if="!isMobile"><t t-esc="fields[name].string"/>:</t>
+                            <t t-if="!isMobile"><t t-esc="format(record, name)"/></t>
                             <div class="o_calendar_avatars float-right">
                                 <t t-foreach="widget.getAvatars(record, name, widget.displayFields[name].avatar_field).slice(0,3)" t-as="image"><t t-raw="image"/></t>
                                 <span t-if="record[name].length - 3 > 0">+<t t-esc="record[name].length - 3"/></span>


### PR DESCRIPTION
# Descrição
[IMP] Atualiza visão padrão do calendario no modulo 'web'

- Remove linha dos horários, com o objetivo de otimizar o espaço
  utilizado pelos cards das agendas, seguindo inclusive o padrão
  do outlook e thunderbird.

- Adiciona ao widget de image também o texto do campo, facilitando
  a identificação quando utilizado.

# Informações adicionais

Dados da tarefa: [T4985](https://multi.multidadosti.com.br/web?#id=5394&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s): [609](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/609)


Antes:
![image](https://user-images.githubusercontent.com/7175315/100677486-dee34e80-3349-11eb-9d10-b1eea80f9b34.png)


Depois:

![image](https://user-images.githubusercontent.com/7175315/100677394-afccdd00-3349-11eb-9aab-3ba60b0fb3a4.png)


