### PR TITLE
T4999 - Abrir a tela de reunião como formulario atualmente o sistema a abre como dialogo

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -270,7 +270,7 @@
         <field name="arch" type="xml">
             <calendar string="Meetings" date_start="start" date_stop="stop" date_delay="duration" all_day="allday"
                 readonly_form_view_id="%(calendar.view_calendar_event_form_popup)s"
-                event_open_popup="true"
+                event_open_popup="false"
                 event_limit="3"
                 color="partner_id">
                 <field name="name"/>


### PR DESCRIPTION
# Descrição

- [IMP] Desabilita a função de abrir o formulário como popup

# Informações adicionais

- [T4999](https://multi.multidadosti.com.br/web?#id=5408&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)