### PR TITLE
T5135 - Lista de Atividades não grava prioridade

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -107,7 +107,7 @@
                             <field name="type" invisible="1"/>
                         </group>
                         <group>
-                            <field name="priority" widget="priority"/>
+                            <field name="priority" widget="priority" force_save="1"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                         </group>
                     </group>
@@ -256,7 +256,7 @@
                                 <div class="o_row">
                                     <field name="planned_revenue"/>
                                 </div>
-                                <field name="priority" widget="priority"/>
+                                <field name="priority" widget="priority" force_save="1"/>
                             </group>
                         </group>
                         <footer>
@@ -304,7 +304,7 @@
                         <field name="planned_revenue" widget="monetary" options="{'currency_field': 'company_currency'}"/>
                         <field name="company_currency" invisible="1"/>
                         <field name="company_id" invisible="1"/>
-                        <field name="priority" nolabel="1" widget="priority"/>
+                        <field name="priority" nolabel="1" widget="priority" force_save="1"/>
                     </group>
                 </form>
             </field>
@@ -557,7 +557,7 @@
                                 <field name="team_id" widget="selection"/>
                             </group>
                             <group>
-                                <field name="priority" widget="priority"/>
+                                <field name="priority" widget="priority" force_save="1"/>
                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                                 <field name="lost_reason" attrs="{'invisible': [('active', '=', True)]}"/>
                                 <field name="date_conversion" invisible="1"/>


### PR DESCRIPTION
# Descrição

[IMP] Adiciona "force_save" XML/Field "priority" modulo "crm"
- Adiciona no XML a tag force_save, para forçar a gravação do campo
  priority, pois em algumas situações ele fica readonly e assim bloqueia
  a gravação.

# Informações adicionais

Dados da tarefa: [T5135](https://github.com/multidadosti-erp/odoo/compare/develop...multidadosti-erp:develop-T5135?expand=1)

PR(s) relacionado(s) (se houver): [570](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/570)
