### PR TITLE
T5219 - Erro no Odoo: Ao Adicionar um Field Selection ADD sem dados Anteriores

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2018,7 +2018,10 @@ class Selection(Field):
             if 'selection_add' in field.args:
                 # use an OrderedDict to update existing values
                 selection_add = field.args['selection_add']
-                self.selection = list(OrderedDict(self.selection + selection_add).items())
+                if not self.selection:
+                    self.selection = list(OrderedDict(selection_add).items())
+                else:
+                    self.selection = list(OrderedDict(self.selection + selection_add).items())
 
     def _description_selection(self, env):
         """ return the selection list (pairs (value, label)); labels are


### PR DESCRIPTION
# Descrição

[IMP] Adiciona IF para evitar erro nos Fields.py
- Adiciona verificação para Adicionar Dados nos campos do Tipo 'selection'
  Evitando assim problemas no Odoo.

# Informações adicionais

Dados da tarefa: [T5219](https://multi.multidadosti.com.br/web?#id=5628&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

