### PR TITLE
T5262 - Erro: Não está deixando cadastrar KIT de Serviço

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1163,3 +1163,9 @@ class ProductTemplate(models.Model):
             'label': _('Import Template for Products'),
             'template': '/product/static/xls/product_template.xls'
         }]
+
+    @api.onchange('type')
+    def _onchange_type(self):
+        """ Base onchange method
+        """
+        pass

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -157,6 +157,7 @@ class ProductTemplate(models.Model):
     @api.onchange('type')
     def _onchange_type(self):
         """ Force values to stay consistent with integrity constraints """
+        super(ProductTemplate, self)._onchange_type()
         if self.type == 'consu':
             if not self.invoice_policy:
                 self.invoice_policy = 'order'


### PR DESCRIPTION
# Descrição


[IMP] Adiciona '_onchange_type' modulo 'product'
- Adiciona Metodo base _onchange_type para futuras heranças

[IMP] Adiciona super metodo '_onchange_type' modulo 'sale' 
- Adiciona o metodo 'Super' para chamar o metodo Base do modulo
  'Product'

Obs.: Isso para Corrigir as Heranças do Campo: 'Type'

# Informações adicionais

Dados da tarefa: [T5262](https://multi.multidadosti.com.br/web?debug#id=5671&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [595](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/595)
