### PR TITLE
T5327 - erro ao criar nota

### DIFF
--- a/addons/note/models/note.py
+++ b/addons/note/models/note.py
@@ -41,7 +41,7 @@ class Note(models.Model):
         return self.env['note.stage'].search([('user_id', '=', self.env.uid)], limit=1)
 
     name = fields.Text(compute='_compute_name', string='Note Summary', store=True)
-    user_id = fields.Many2one('res.users', string='Owner', default=lambda self: self.env.uid)
+    user_id = fields.Many2one('res.users', string='Owner', default=lambda self: self.env.uid, track_visibility='always')
     memo = fields.Html('Note Content')
     sequence = fields.Integer('Sequence')
     stage_id = fields.Many2one('note.stage', compute='_compute_stage_id',

--- a/addons/note/security/note_security.xml
+++ b/addons/note/security/note_security.xml
@@ -12,7 +12,7 @@
     <record id="note_note_create_unlink_global" model="ir.rule">
         <field name="name">note: create / unlink: responsible</field>
         <field name="model_id" ref="model_note_note"/>
-        <field name="domain_force">[('user_id', '=', user.id)]</field>
+        <field name="domain_force">[(1, '=', 1)]</field>
         <field name="global" eval="True"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_read" eval="False"/>


### PR DESCRIPTION
# Descrição

- [FIX] Corrige erro de permissão ao atribuir uma anotação a outra pessoa

# Informações adicionais

- [T5327](https://multi.multidadosti.com.br/web?#id=5736&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR Adicional:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/610)
