### PR TITLE
T5327 - erro de permissão ao criar anotação de projeto

### DIFF
--- a/addons/note/__manifest__.py
+++ b/addons/note/__manifest__.py
@@ -13,7 +13,7 @@
         'mail',
     ],
     'data': [
-        'security/note_security.xml',
+        # 'security/note_security.xml',
         'security/ir.model.access.csv',
         'data/mail_activity_data.xml',
         'data/note_data.xml',

--- a/addons/note/models/note.py
+++ b/addons/note/models/note.py
@@ -41,7 +41,7 @@ class Note(models.Model):
         return self.env['note.stage'].search([('user_id', '=', self.env.uid)], limit=1)
 
     name = fields.Text(compute='_compute_name', string='Note Summary', store=True)
-    user_id = fields.Many2one('res.users', string='Owner', default=lambda self: self.env.uid)
+    user_id = fields.Many2one('res.users', string='Owner', default=lambda self: self.env.uid, track_visibility='always')
     memo = fields.Html('Note Content')
     sequence = fields.Integer('Sequence')
     stage_id = fields.Many2one('note.stage', compute='_compute_stage_id',

--- a/addons/note/security/note_security.xml
+++ b/addons/note/security/note_security.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0"?>
 <odoo>
+
+    <!-- Este arquivo foi removido do __manifest__.py
+    porque as regras abaixo impediam o uso da model de
+    notes (trocar usuario da nota, criar notas e atribui-las a outros usuarios)
+    conforme a necessidade do cliente -->
+
     <record id="note_note_rule_global" model="ir.rule">
         <field name="name">Only followers can access a sticky notes</field>
         <field name="model_id" ref="model_note_note"/>


### PR DESCRIPTION
# Descrição

- [FIX] Corrige erro de permissão ao atribuir uma anotação a outra pessoa

# Informações adicionais

- [T5327](https://multi.multidadosti.com.br/web?#id=5736&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/611)
