### PR TITLE
T5386 - Erro ao importar XML de compras

### DIFF
--- a/odoo/tools/mimetypes.py
+++ b/odoo/tools/mimetypes.py
@@ -107,6 +107,8 @@ def _check_svg(data):
     """This simply checks the existence of the opening and ending SVG tags"""
     if b'<svg' in data and b'/svg>' in data:
         return 'image/svg+xml'
+    else:
+        return 'application/xml'
 
 
 # for "master" formats with many subformats, discriminants is a list of


### PR DESCRIPTION
# Descrição

[FIX] Adiciona tipo arquivo XML, separado do SVG modulo 'tools'
- Adiciona ELSE na verificação da tag <svg para diferenciar arquivos
  XML normais (tipo de NF) do XML do tipo SVG.

# Informações adicionais

Dados da tarefa: [T5386](https://multi.multidadosti.com.br/web#id=5795&model=project.task&view_type=form&menu_id=)


