### PR TITLE
T5404 - Lançamentos de diário incorretos com imposto 'Incluído no Preço'

### DIFF
--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -138,8 +138,8 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueSe
         pricelist = current_website.get_current_pricelist()
         (self.env['product.pricelist'].search([]) - pricelist).write({'active': False})
         # Add 10% tax on product
-        tax10 = self.env['account.tax'].create({'name': "Test tax 10", 'amount': 10, 'price_include': True, 'amount_type': 'percent'})
-        tax0 = self.env['account.tax'].create({'name': "Test tax 0", 'amount': 0, 'price_include': True, 'amount_type': 'percent'})
+        tax10 = self.env['account.tax'].create({'name': "Test tax 10", 'amount': 10, 'price_include': True, 'amount_type': 'division'})
+        tax0 = self.env['account.tax'].create({'name': "Test tax 0", 'amount': 0, 'price_include': True, 'amount_type': 'division'})
 
         test_product = self.env['product.template'].create({
             'name': 'Test Product',


### PR DESCRIPTION
# Descrição

* [FIX] Corrige tipo da taxa de acordo com o 'price_include'

Para usar 'price_include' temos que usar o calculo do tipo 'division'. O tipo de calculo 'percent' é usado apenas quando o 'price_include' é falso.

# Informações adicionais

Dados da tarefa: [T5404](https://multi.multidadosti.com.br/web#id=5813&action=323&active_id=61&model=project.task&view_type=form&menu_id=)
