### PR TITLE
[FIX] Adiciona acesso total a 'ir.model' para evitar erros de permssão

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1037,7 +1037,7 @@ class IrModelConstraint(models.Model):
         for data in self.sorted(key='id', reverse=True):
             name = tools.ustr(data.name)
             if data.model.model in self.env:
-                table = self.env[data.model.model]._table    
+                table = self.env[data.model.model]._table
             else:
                 table = data.model.model.replace('.', '_')
             typ = data.type
@@ -1255,7 +1255,7 @@ class IrModelAccess(models.Model):
     @api.model
     @tools.ormcache_context('self._uid', 'model', 'mode', 'raise_exception', keys=('lang',))
     def check(self, model, mode='read', raise_exception=True):
-        if self._uid == 1:
+        if self._uid == 1 or model == 'ir.model':
             # User root have all accesses
             return True
 
@@ -1447,7 +1447,7 @@ class IrModelData(models.Model):
 
     @api.model
     def xmlid_to_object(self, xmlid, raise_if_not_found=False):
-        """ Return a Model object, or ``None`` if ``raise_if_not_found`` is 
+        """ Return a Model object, or ``None`` if ``raise_if_not_found`` is
         set
         """
         t = self.xmlid_to_res_model_res_id(xmlid, raise_if_not_found)
@@ -1599,11 +1599,11 @@ class IrModelData(models.Model):
         ``ids`` along with their corresponding database backed (including
         dropping tables, columns, FKs, etc, as long as there is no other
         ir.model.data entry holding a reference to them (which indicates that
-        they are still owned by another module). 
+        they are still owned by another module).
         Attempts to perform the deletion in an appropriate order to maximize
         the chance of gracefully deleting all records.
         This step is performed as part of the full uninstallation of a module.
-        """ 
+        """
         if not (self._uid == SUPERUSER_ID or self.env.user.has_group('base.group_system')):
             raise AccessError(_('Administrator access is required to uninstall a module'))
 


### PR DESCRIPTION
# Descrição

[FIX] Adiciona acesso total a 'ir.model' para evitar erros de permssão

- Adiciona "or model == 'ir.model'" ao IF para dar acesso total,
  para corrigir o problema de acesso de permissão do Odoo na model
  'ir.model'

# Informações adicionais

Alteração para corrigir a Produção até descobrirmos o que realmente aconteceu.