### PR TITLE
T5559 - Acertar a tela do POS que não mostra todos os produtos no Filtro

### DIFF
--- a/addons/point_of_sale/i18n/pt_BR.po
+++ b/addons/point_of_sale/i18n/pt_BR.po
@@ -1,49 +1,23 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * point_of_sale
-#
-# Translators:
-# Munique Shih <muniqueshih@hotmail.com>, 2018
-# Diego Bittencourt <diegomb86@gmail.com>, 2018
-# Rodrigo de Almeida Sottomaior Macedo <rmsolucoeseminformatica@protonmail.com>, 2018
-# Cesar Silveira <cesar.consultant@gmail.com>, 2018
-# falexandresilva <falexandresilva@gmail.com>, 2018
-# Ademílson F. Tonato <apraqueisso@gmail.com>, 2018
-# Hildeberto Abreu Magalhães <hildeberto@gmail.com>, 2018
-# danimaribeiro <danimaribeiro@gmail.com>, 2018
-# Martin Trigaux, 2018
-# Mateus Lopes <mateus1@gmail.com>, 2018
-# Luiz Carlos de Lima <luiz.carlos@akretion.com.br>, 2018
-# Caio Leonardo Mendes de Sousa <caleozao@gmail.com>, 2018
-# André Augusto Firmino Cordeiro <a.cordeito@gmail.com>, 2018
-# Pablo Valentini <pablondrina@gmail.com>, 2018
-# Silmar <pinheirosilmar@gmail.com>, 2018
-# Gabriel Bortolotto Contesotto <gabrielbortolotto@gmail.com>, 2019
-# Luiz Carareto Alonso <Luiz.cararetoalonso@gmail.com>, 2019
-# Ramiro Pereira de Magalhães <ramiro.p.magalhaes@gmail.com>, 2019
-# grazziano <gra.negocia@gmail.com>, 2019
-# Fernando Colus <fcolus1@gmail.com>, 2020
-# Maurício Liell <mauricio@liell.com.br>, 2020
-# Vanderlei P. Romera <vanderleiromera@gmail.com>, 2020
-# Marcel Savegnago <marcel.savegnago@gmail.com>, 2021
+#	* point_of_sale
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-14 07:33+0000\n"
-"PO-Revision-Date: 2018-08-24 09:22+0000\n"
-"Last-Translator: Marcel Savegnago <marcel.savegnago@gmail.com>, 2021\n"
-"Language-Team: Portuguese (Brazil) (https://www.transifex.com/odoo/teams/41243/pt_BR/)\n"
+"POT-Creation-Date: 2021-07-13 17:22+0000\n"
+"PO-Revision-Date: 2021-07-13 17:22+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: pt_BR\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:910
-#: code:addons/point_of_sale/models/pos_order.py:922
+#: code:addons/point_of_sale/models/pos_order.py:1058
+#: code:addons/point_of_sale/models/pos_order.py:1070
 #, python-format
 msgid " REFUND"
 msgstr "DEVOLUÇÃO"
@@ -56,36 +30,33 @@ msgstr "R$ 3,12"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
-#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
 msgid "$ 4.40"
 msgstr "R$ 4,40"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
-#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
 msgid "$ 4.50"
 msgstr "R$ 4,50"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
-#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
 msgid "$ 8.50"
 msgstr "R$ 8,50"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1477
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1478
 #, python-format
 msgid "% discount"
 msgstr "% desconto"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1606
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1646
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1607
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1647
 #, python-format
 msgid "&nbsp;"
-msgstr "&nbsp;"
+msgstr ""
 
 #. module: point_of_sale
 #: code:addons/point_of_sale/models/pos_order.py:89
@@ -121,12 +92,8 @@ msgstr ""
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_partner_pos_kanban
-msgid ""
-"<i class=\"fa fa-fw fa-shopping-bag\" role=\"img\" aria-label=\"Shopping "
-"cart\" title=\"Shopping cart\"/>"
+msgid "<i class=\"fa fa-fw fa-shopping-bag\" role=\"img\" aria-label=\"Shopping cart\" title=\"Shopping cart\"/>"
 msgstr ""
-"<i class=\"fa fa-fw fa-shopping-bag\" role=\"img\" aria-label=\"Shopping "
-"cart\" title=\"Shopping cart\"/>"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_order_kanban
@@ -137,14 +104,8 @@ msgstr "<i class=\"fa fa-money\" role=\"img\" aria-label=\"Amount\" title=\"Amou
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/tour.js:24
 #, python-format
-msgid ""
-"<p>Click to start the point of sale interface. It <b>runs on tablets</b>, "
-"laptops, or industrial hardware.</p><p>Once the session launched, the system"
-" continues to run without an internet connection.</p>"
-msgstr ""
-"<p>Inicia a interface do ponto de venda. Ela <b>opera em tablets</b>, "
-"laptops, ou em dispositivos industriais.</p><p>Após o início da sessão, o "
-"sistema continua operante mesmo desconectado da Internet.</p>"
+msgid "<p>Click to start the point of sale interface. It <b>runs on tablets</b>, laptops, or industrial hardware.</p><p>Once the session launched, the system continues to run without an internet connection.</p>"
+msgstr "<p>Inicia a interface do ponto de venda. Ela <b>opera em tablets</b>, laptops, ou em dispositivos industriais.</p><p>Após o início da sessão, o sistema continua operante mesmo desconectado da Internet.</p>"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
@@ -163,22 +124,14 @@ msgstr "<span class=\"o_form_label\">Métodos de pagamento</span>"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_open_statement
-msgid ""
-"<span class=\"o_form_label\">The system will open all cash registers, so "
-"that you can start recording payments. We suggest you to control the opening"
-" balance of each register, using their CashBox tab.</span>"
-msgstr ""
-"<span class=\"o_form_label\">O sistema abrirá todas as caixas registradoras,"
-" para que você possa começar a registrar os pagamentos. Sugerimos que você "
-"controle o saldo de abertura de cada registro, usando sua guia Caixa.</span>"
+msgid "<span class=\"o_form_label\">The system will open all cash registers, so that you can start recording payments. We suggest you to control the opening balance of each register, using their CashBox tab.</span>"
+msgstr "<span class=\"o_form_label\">O sistema abrirá todas as caixas registradoras, para que você possa começar a registrar os pagamentos. Sugerimos que você controle o saldo de abertura de cada registro, usando sua guia Caixa.</span>"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_session_form
-msgid ""
-"<span class=\"o_stat_text\">Put</span>\n"
+msgid "<span class=\"o_stat_text\">Put</span>\n"
 "                                <span class=\"o_stat_text\">Money In</span>"
-msgstr ""
-"<span class=\"o_stat_text\">Reforçar</span>\n"
+msgstr "<span class=\"o_stat_text\">Reforçar</span>\n"
 "  <span class=\"o_stat_text\">Caixa</span>"
 
 #. module: point_of_sale
@@ -193,11 +146,9 @@ msgstr "<span class=\"o_stat_text\">Definir saldo de abertura</span>"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_session_form
-msgid ""
-"<span class=\"o_stat_text\">Take</span>\n"
+msgid "<span class=\"o_stat_text\">Take</span>\n"
 "                                <span class=\"o_stat_text\">Money Out</span>"
-msgstr ""
-"<span class=\"o_stat_text\">Sangrar</span>\n"
+msgstr "<span class=\"o_stat_text\">Sangrar</span>\n"
 "  <span class=\"o_stat_text\">Caixa</span>"
 
 #. module: point_of_sale
@@ -207,37 +158,47 @@ msgstr "<span class=\"oe_inline\"><b>Saltar a tela de previsão</b></span>"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
-#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
 msgid "<span class=\"pos-change_amount\">$ 0.86</span>"
 msgstr "<span class=\"pos-change_amount\">R$ 0,86</span>"
 
 #. module: point_of_sale
-#: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
 #: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "<span class=\"pos-change_amount\">R$ 0,86</span>"
+msgstr ""
+
+#. module: point_of_sale
+#: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
 msgid "<span class=\"pos-change_title\">Change</span>"
 msgstr "<span class=\"pos-change_title\">Troco</span>"
+
+#. module: point_of_sale
+#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "<span class=\"pos-change_title\">Troco</span>"
+msgstr ""
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
 #: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
 msgid "<span class=\"total-amount-formatting\">TOTAL</span>"
-msgstr "<span class=\"total-amount-formatting\">TOTAL</span>"
+msgstr ""
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
-#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
 msgid "<span id=\"total-amount\" class=\"pos_total-amount\">$ 469.14</span>"
 msgstr "<span id=\"total-amount\" class=\"pos_total-amount\">R$ 469,14</span>"
 
 #. module: point_of_sale
-#: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
 #: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "<span id=\"total-amount\" class=\"pos_total-amount\">R$ 469,14</span>"
+msgstr ""
+
+#. module: point_of_sale
+#: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
 msgid "<span>$ 470.00</span>"
 msgstr "<span>R$ 470,00</span>"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
-#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
 msgid "<span>Cash (USD):</span>"
 msgstr "<span>Dinheiro (BRL):</span>"
 
@@ -247,9 +208,19 @@ msgid "<span>Cash Balance</span>"
 msgstr "<span>Saldo em dinheiro</span>"
 
 #. module: point_of_sale
+#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "<span>Dinheiro (BRL):</span>"
+msgstr ""
+
+#. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_config_kanban
 msgid "<span>Last Closing Date</span>"
 msgstr "<span>Ultimo Fechamento</span>"
+
+#. module: point_of_sale
+#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "<span>R$ 470,00</span>"
+msgstr ""
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_config_kanban
@@ -308,42 +279,32 @@ msgstr "= Saldo Final Teórico"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2035
+#: code:addons/point_of_sale/static/src/js/screens.js:2126
 #, python-format
 msgid "? Clicking \"Confirm\" will validate the payment."
 msgstr "? Clicar em  \"Confirmar\" vai validar o pagamento."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1275
+#: code:addons/point_of_sale/static/src/js/screens.js:1334
 #, python-format
 msgid "A Customer Name Is Required"
 msgstr "Um Nome de Cliente é Necessário"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_res_users__pos_security_pin
-msgid ""
-"A Security PIN used to protect sensible functionality in the Point of Sale"
-msgstr ""
-"Um PIN de segurança usado para proteger funções sensíveis no Ponto de Venda"
+msgid "A Security PIN used to protect sensible functionality in the Point of Sale"
+msgstr "Um PIN de segurança usado para proteger funções sensíveis no Ponto de Venda"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__uuid
-msgid ""
-"A globally unique identifier for this pos configuration, used to prevent "
-"conflicts in client-generated data."
-msgstr ""
-"Um identificador global para esta configuração do POS é usado para evitar "
-"conflitos entre informações geradas nos clientes."
+msgid "A globally unique identifier for this pos configuration, used to prevent conflicts in client-generated data."
+msgstr "Um identificador global para esta configuração do POS é usado para evitar conflitos entre informações geradas nos clientes."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_session__login_number
-msgid ""
-"A sequence number that is incremented each time a user resumes the pos "
-"session"
-msgstr ""
-"Um número sequencial que é incrementado cada vez que um usuário retoma a "
-"sessão pdv"
+msgid "A sequence number that is incremented each time a user resumes the pos session"
+msgstr "Um número sequencial que é incrementado cada vez que um usuário retoma a sessão pdv"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_session__sequence_number
@@ -352,12 +313,8 @@ msgstr "Um número sequencial que é incrementado com cada ordem"
 
 #. module: point_of_sale
 #: model_terms:ir.actions.act_window,help:point_of_sale.action_pos_session
-msgid ""
-"A session is a period of time, usually one day, during which you sell "
-"through the Point of Sale."
-msgstr ""
-"Uma sessão é um período de tempo, normalmente de 1 dia, durante o qual "
-"ocorrem vendas no Ponto de Venda."
+msgid "A session is a period of time, usually one day, during which you sell through the Point of Sale."
+msgstr "Uma sessão é um período de tempo, normalmente de 1 dia, durante o qual ocorrem vendas no Ponto de Venda."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_order__sequence_number
@@ -376,10 +333,10 @@ msgstr "Um pequeno texto que é inserido no começo (cabeçalho) do recibo"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1645
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1646
 #, python-format
 msgid "ABC"
-msgstr "ABC"
+msgstr ""
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.res_config_settings_view_form
@@ -414,7 +371,7 @@ msgstr "Ativo"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1885
+#: code:addons/point_of_sale/static/src/js/screens.js:1981
 #, python-format
 msgid "Add Tip"
 msgstr "Incluir gorjeta"
@@ -455,26 +412,16 @@ msgid "Alias"
 msgstr "Apelido"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_config.py:244
+#: code:addons/point_of_sale/models/pos_config.py:247
 #, python-format
-msgid ""
-"All available pricelists must be in the same currency as the company or as "
-"the Sales Journal set on this point of sale if you use the Accounting "
-"application."
-msgstr ""
-"Todas as listas de preços disponíveis devem estar na mesma moeda que a da "
-"companhia ou que a do diário de vendas deste ponto de venda se a aplicação "
-"de Contabilidade estiver em uso."
+msgid "All available pricelists must be in the same currency as the company or as the Sales Journal set on this point of sale if you use the Accounting application."
+msgstr "Todas as listas de preços disponíveis devem estar na mesma moeda que a da companhia ou que a do diário de vendas deste ponto de venda se a aplicação de Contabilidade estiver em uso."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_config.py:250
+#: code:addons/point_of_sale/models/pos_config.py:253
 #, python-format
-msgid ""
-"All payment methods must be in the same currency as the Sales Journal or the"
-" company currency if that is not set."
-msgstr ""
-"Todos os métodos de pagamento devem estar na mesma moeda do diário de vendas"
-" ou da moeda da companhia, se isso não estiver configurado."
+msgid "All payment methods must be in the same currency as the Sales Journal or the company currency if that is not set."
+msgstr "Todos os métodos de pagamento devem estar na mesma moeda do diário de vendas ou da moeda da companhia, se isso não estiver configurado."
 
 #. module: point_of_sale
 #: model:ir.actions.act_window,name:point_of_sale.action_pos_all_sales_lines
@@ -498,6 +445,7 @@ msgid "Amount"
 msgstr "Montante"
 
 #. module: point_of_sale
+#: model:ir.model.fields,field_description:point_of_sale.field_account_bank_statement_import_journal_creation__amount_authorized_diff
 #: model:ir.model.fields,field_description:point_of_sale.field_account_journal__amount_authorized_diff
 msgid "Amount Authorized Difference"
 msgstr "Diferença de Valor Autorizado"
@@ -509,14 +457,10 @@ msgstr "Quantidade Total"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/models.js:1244
+#: code:addons/point_of_sale/static/src/js/models.js:1268
 #, python-format
-msgid ""
-"An error occurred when loading product prices. Make sure all pricelists are "
-"available in the POS."
-msgstr ""
-"Um erro ao carregar as listas de preços. Tenha certeza que todas as listas "
-"de preços"
+msgid "An error occurred when loading product prices. Make sure all pricelists are available in the POS."
+msgstr "Um erro ao carregar as listas de preços. Tenha certeza que todas as listas de preços"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__name
@@ -531,7 +475,7 @@ msgstr "Outra sessão já está aberta para esse ponto de venda."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2027
+#: code:addons/point_of_sale/static/src/js/screens.js:2118
 #, python-format
 msgid "Are you sure that the customer wants to  pay"
 msgstr "Você tem certeza que os clientes querem pagar"
@@ -602,7 +546,7 @@ msgstr "Voltar"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/xml/pos.xml:179
 #: code:addons/point_of_sale/static/src/xml/pos.xml:625
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1192
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1193
 #, python-format
 msgid "Backspace"
 msgstr "Retrocesso"
@@ -645,7 +589,7 @@ msgstr "Regra de Código de Barras"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1345
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1346
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__barcode_scanner
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
 #, python-format
@@ -664,7 +608,7 @@ msgstr "Conta &amp; Recibo"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:964
+#: code:addons/point_of_sale/static/src/js/screens.js:1023
 #, python-format
 msgid "Button"
 msgstr "Botão"
@@ -676,7 +620,7 @@ msgstr "Enviar as impressões pelo Hardware Proxy"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:847
+#: code:addons/point_of_sale/static/src/xml/pos.xml:848
 #, python-format
 msgid "CHANGE"
 msgstr "TROCO"
@@ -684,12 +628,12 @@ msgstr "TROCO"
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/xml/pos.xml:479
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1062
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1079
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1108
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1125
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1145
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1197
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1063
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1080
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1109
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1126
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1146
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1198
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_details_wizard
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_open_statement
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_payment
@@ -698,13 +642,19 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: point_of_sale
-#: selection:pos.order,state:0 selection:report.pos.order,state:0
+#: selection:pos.order,state:0
+#: selection:report.pos.order,state:0
 msgid "Cancelled"
 msgstr "Cancelado"
 
 #. module: point_of_sale
+#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "Caneta do quadro branco"
+msgstr ""
+
+#. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2016
+#: code:addons/point_of_sale/static/src/js/screens.js:2107
 #, python-format
 msgid "Cannot return change without a cash payment method"
 msgstr "Não é possível dar troco sem usar método de pagamento em dinheiro"
@@ -720,7 +670,7 @@ msgid "Cash Box Out"
 msgstr "Sacar"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_session.py:318
+#: code:addons/point_of_sale/models/pos_session.py:324
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__cash_control
 #, python-format
 msgid "Cash Control"
@@ -770,11 +720,9 @@ msgstr "Categorias"
 
 #. module: point_of_sale
 #: model_terms:ir.actions.act_window,help:point_of_sale.product_pos_category_action
-msgid ""
-"Categories are used to browse your products through the\n"
+msgid "Categories are used to browse your products through the\n"
 "                touchscreen interface."
-msgstr ""
-"Categorias são usadas para procurar por produtos através da\n"
+msgstr "Categorias são usadas para procurar por produtos através da\n"
 "interface para telas sensíveis a toque."
 
 #. module: point_of_sale
@@ -798,11 +746,6 @@ msgid "Category used in the Point of Sale."
 msgstr "Categoria usada no ponto de venda."
 
 #. module: point_of_sale
-#: model:pos.category,name:point_of_sale.pos_category_chairs
-msgid "Chairs"
-msgstr "Cadeiras"
-
-#. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/xml/pos.xml:552
 #, python-format
@@ -818,14 +761,14 @@ msgstr "Alterar vendedor"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1220
+#: code:addons/point_of_sale/static/src/js/screens.js:1279
 #, python-format
 msgid "Change Customer"
 msgstr "Alterar Cliente"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1885
+#: code:addons/point_of_sale/static/src/js/screens.js:1981
 #, python-format
 msgid "Change Tip"
 msgstr "Alterar gorjeta"
@@ -833,8 +776,8 @@ msgstr "Alterar gorjeta"
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/xml/pos.xml:708
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1535
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1696
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1536
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1697
 #, python-format
 msgid "Change:"
 msgstr "Troco:"
@@ -842,9 +785,7 @@ msgstr "Troco:"
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_product_product__to_weight
 #: model:ir.model.fields,help:point_of_sale.field_product_template__to_weight
-msgid ""
-"Check if the product should be weighted using the hardware scale "
-"integration."
+msgid "Check if the product should be weighted using the hardware scale integration."
 msgstr "Marque se o produto deve ser pesado usando a integração com balança."
 
 #. module: point_of_sale
@@ -856,10 +797,8 @@ msgstr "Marque se este produto deve aparecer no Ponto de Venda."
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_uom_category__is_pos_groupable
 #: model:ir.model.fields,help:point_of_sale.field_uom_uom__is_pos_groupable
-msgid ""
-"Check if you want to group products of this category in point of sale orders"
-msgstr ""
-"Marque para agrupar produtos desta categoria nos pedidos do Ponto de Vendas."
+msgid "Check if you want to group products of this category in point of sale orders"
+msgstr "Marque para agrupar produtos desta categoria nos pedidos do Ponto de Vendas."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__cash_control
@@ -867,26 +806,19 @@ msgid "Check the amount of the cashbox at opening and closing."
 msgstr "Verifica o montante do caixa na abertura e fechamento."
 
 #. module: point_of_sale
+#: model:ir.model.fields,help:point_of_sale.field_account_bank_statement_import_journal_creation__journal_user
 #: model:ir.model.fields,help:point_of_sale.field_account_journal__journal_user
-msgid ""
-"Check this box if this journal define a payment method that can be used in a"
-" point of sale."
-msgstr ""
-"Marque esta caixa se esta revista definir um método de pagamento que pode "
-"ser usado no ponto de venda."
+msgid "Check this box if this journal define a payment method that can be used in a point of sale."
+msgstr "Marque esta caixa se esta revista definir um método de pagamento que pode ser usado no ponto de venda."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__group_by
-msgid ""
-"Check this if you want to group the Journal Items by Product while closing a"
-" Session."
-msgstr ""
-"Marque para agrupar itens do diário por produtos durante o encerramento de "
-"uma sessão."
+msgid "Check this if you want to group the Journal Items by Product while closing a Session."
+msgstr "Marque para agrupar itens do diário por produtos durante o encerramento de uma sessão."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2076
+#: code:addons/point_of_sale/static/src/js/screens.js:222
 #, python-format
 msgid "Check your internet connection and try again."
 msgstr "Verifique a sua conexão à Internet e tente novamente."
@@ -903,12 +835,8 @@ msgstr "Escolha uma lista de preços para este Ponto de Venda."
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
-msgid ""
-"Choose a specific tax regime at the order depending on the kind of customer "
-"(tax exempt, onsite vs. takeaway, etc.)."
-msgstr ""
-"Escolha um regime de taxas específico para o pedido dependendo do tipo de "
-"cliente (isenção de taxas, consumo no local vs. para viagem, etc.)."
+msgid "Choose a specific tax regime at the order depending on the kind of customer (tax exempt, onsite vs. takeaway, etc.)."
+msgstr "Escolha um regime de taxas específico para o pedido dependendo do tipo de cliente (isenção de taxas, consumo no local vs. para viagem, etc.)."
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
@@ -960,6 +888,7 @@ msgstr "Alerta da tela do cliente"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/chrome.js:824
 #: code:addons/point_of_sale/static/src/js/chrome.js:832
+#: code:addons/point_of_sale/static/src/js/chrome.js:838
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_config_kanban
 #, python-format
 msgid "Close"
@@ -972,7 +901,7 @@ msgstr "Fechado e Lançado"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/gui.js:346
+#: code:addons/point_of_sale/static/src/js/gui.js:350
 #, python-format
 msgid "Closing ..."
 msgstr "Fechando ..."
@@ -1009,33 +938,25 @@ msgstr "Configuração"
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
 msgid "Configuration for journal entries of PoS orders"
-msgstr ""
-"Configuração para as entradas de diário contábil dos pedidod feitos no PdV."
+msgstr "Configuração para as entradas de diário contábil dos pedidod feitos no PdV."
 
 #. module: point_of_sale
 #: model_terms:ir.actions.act_window,help:point_of_sale.action_pos_config_kanban
-msgid ""
-"Configure at least one Point of Sale to be able to sell through the PoS "
-"interface."
-msgstr ""
-"Configure ao menos um Ponto de Venda para poder vender através da interface "
-"de PdV."
+msgid "Configure at least one Point of Sale to be able to sell through the PoS interface."
+msgstr "Configure ao menos um Ponto de Venda para poder vender através da interface de PdV."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/chrome.js:832
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1059
+#: code:addons/point_of_sale/static/src/js/chrome.js:829
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1060
 #, python-format
 msgid "Confirm"
 msgstr "Confirmar"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
-msgid ""
-"Connect devices to your PoS (ticket printer, barcode scanner, scale, etc.)"
-msgstr ""
-"Ligue dispositivos ao seu PdV (impressora de tíquetes, leitor de código de "
-"barras, balança, etc.)"
+msgid "Connect devices to your PoS (ticket printer, barcode scanner, scale, etc.)"
+msgstr "Ligue dispositivos ao seu PdV (impressora de tíquetes, leitor de código de barras, balança, etc.)"
 
 #. module: point_of_sale
 #. openerp-web
@@ -1059,11 +980,6 @@ msgid "Connecting to the IoT Box"
 msgstr "Conectando-se à IoT Box"
 
 #. module: point_of_sale
-#: model:ir.model,name:point_of_sale.model_res_partner
-msgid "Contact"
-msgstr "Contato"
-
-#. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_session_form
 msgid "Continue Selling"
 msgstr "Continuar Vendendo"
@@ -1075,7 +991,7 @@ msgstr "Controlar a abertura e fechamento da caixa registradora"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1378
+#: code:addons/point_of_sale/static/src/js/screens.js:1443
 #, python-format
 msgid "Could Not Read Image"
 msgstr "Não foi possível ler a Imagem"
@@ -1124,11 +1040,6 @@ msgid "Created on"
 msgstr "Criado em"
 
 #. module: point_of_sale
-#: selection:barcode.rule,type:0
-msgid "Credit Card"
-msgstr "Cartão de Crédito"
-
-#. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.res_config_settings_view_form
 msgid "Credit Card Reader"
 msgstr "Leitor de cartão de crédito"
@@ -1156,7 +1067,7 @@ msgstr "Estado da sessão atual"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1896
+#: code:addons/point_of_sale/static/src/js/screens.js:1992
 #: code:addons/point_of_sale/static/src/xml/pos.xml:141
 #: code:addons/point_of_sale/static/src/xml/pos.xml:145
 #: code:addons/point_of_sale/static/src/xml/pos.xml:671
@@ -1179,8 +1090,8 @@ msgid "Customer Facing Display"
 msgstr "Tela voltada ao cliente"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:586
-#: code:addons/point_of_sale/models/pos_order.py:637
+#: code:addons/point_of_sale/models/pos_order.py:719
+#: code:addons/point_of_sale/models/pos_order.py:773
 #, python-format
 msgid "Customer Invoice"
 msgstr "Fatura de Cliente"
@@ -1202,7 +1113,7 @@ msgstr "Painel"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1335
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1336
 #, python-format
 msgid "Debug Window"
 msgstr "Janela de depuração"
@@ -1234,6 +1145,7 @@ msgid "Default Pricelist"
 msgstr "Lista de preço padrão"
 
 #. module: point_of_sale
+#: model:ir.model.fields,field_description:point_of_sale.field_contact_config_settings__sale_tax_id
 #: model:ir.model.fields,field_description:point_of_sale.field_res_config_settings__sale_tax_id
 msgid "Default Sale Tax"
 msgstr "Imposto de vendas padrão"
@@ -1260,12 +1172,8 @@ msgstr "Definir nova categoria"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__barcode_nomenclature_id
-msgid ""
-"Defines what kind of barcodes are available and how they are assigned to "
-"products, customers and cashiers."
-msgstr ""
-"Define quais tipos de códigos de barras estão disponíveis e como eles são "
-"atribuídos a produtos, clientes e caixas."
+msgid "Defines what kind of barcodes are available and how they are assigned to products, customers and cashiers."
+msgstr "Define quais tipos de códigos de barras estão disponíveis e como eles são atribuídos a produtos, clientes e caixas."
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_report_pos_order__delay_validation
@@ -1276,15 +1184,15 @@ msgstr "Adiar Validação"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/xml/pos.xml:576
 #: code:addons/point_of_sale/static/src/xml/pos.xml:589
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1393
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1405
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1394
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1406
 #, python-format
 msgid "Delete"
 msgstr "Excluir"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1355
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1356
 #, python-format
 msgid "Delete Paid Orders"
 msgstr "Excluir pedidos pagos"
@@ -1298,7 +1206,7 @@ msgstr "Excluir pedidos pagos?"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1356
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1357
 #, python-format
 msgid "Delete Unpaid Orders"
 msgstr "Excluir pedidos com pagamento pendente"
@@ -1312,36 +1220,22 @@ msgstr "Excluir pedidos com pagamento pendente?"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1436
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1437
 #, python-format
 msgid "Delete order"
 msgstr "Excluir pedido"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1223
+#: code:addons/point_of_sale/static/src/js/screens.js:1282
 #, python-format
 msgid "Deselect Customer"
 msgstr "Desmarque Cliente"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
-#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
-#: model:product.product,name:point_of_sale.desk_organizer
-#: model:product.template,name:point_of_sale.desk_organizer_product_template
 msgid "Desk Organizer"
 msgstr "Organizador de mesa"
-
-#. module: point_of_sale
-#: model:product.product,name:point_of_sale.desk_pad
-#: model:product.template,name:point_of_sale.desk_pad_product_template
-msgid "Desk Pad"
-msgstr "Almofada de Mesa"
-
-#. module: point_of_sale
-#: model:pos.category,name:point_of_sale.pos_category_desks
-msgid "Desks"
-msgstr "Mesas"
 
 #. module: point_of_sale
 #. openerp-web
@@ -1356,10 +1250,14 @@ msgid "Difference"
 msgstr "Diferença"
 
 #. module: point_of_sale
+#: code:addons/point_of_sale/models/pos_order.py:527
+#, python-format
+msgid "Difference at closing PoS session"
+msgstr "Diferença ao encerrar a PoS session"
+
+#. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_session__cash_register_difference
-msgid ""
-"Difference between the theoretical closing balance and the real closing "
-"balance."
+msgid "Difference between the theoretical closing balance and the real closing balance."
 msgstr "Diferença entre o saldo previsto e o saldo real."
 
 #. module: point_of_sale
@@ -1398,9 +1296,9 @@ msgstr "Aviso de Desconto"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:790
-#: code:addons/point_of_sale/static/src/xml/pos.xml:929
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1507
+#: code:addons/point_of_sale/static/src/xml/pos.xml:791
+#: code:addons/point_of_sale/static/src/xml/pos.xml:930
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1508
 #, python-format
 msgid "Discount:"
 msgstr "Desconto:"
@@ -1412,14 +1310,14 @@ msgstr "Produto Descontado"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:856
+#: code:addons/point_of_sale/static/src/xml/pos.xml:857
 #, python-format
 msgid "Discounts"
 msgstr "Descontos"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1336
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1337
 #, python-format
 msgid "Dismiss"
 msgstr "Dispensar"
@@ -1454,9 +1352,7 @@ msgstr "Mostra Imagens das categorias de produtos"
 #: code:addons/point_of_sale/models/digest.py:16
 #, python-format
 msgid "Do not have access, skip this data for user's digest email"
-msgstr ""
-"Se não tem acesso, pule esses dados para o e-mail com o Resumo do Usuário "
-"(User´s Digest)"
+msgstr "Se não tem acesso, pule esses dados para o e-mail com o Resumo do Usuário"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_open_statement
@@ -1465,12 +1361,8 @@ msgstr "Você deseja abrir a caixa registradora?"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
-msgid ""
-"Don't turn this option on if you take orders on smartphones or tablets. Such"
-" devices already benefit from a native keyboard."
-msgstr ""
-"Não acione esta opção se você toma pedidos em dispositivos como celulares ou"
-" tablets que dispõem de um teclado nativo."
+msgid "Don't turn this option on if you take orders on smartphones or tablets. Such devices already benefit from a native keyboard."
+msgstr "Não acione esta opção se você toma pedidos em dispositivos como celulares ou tablets que dispõem de um teclado nativo."
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_order_filter
@@ -1479,37 +1371,35 @@ msgstr "Concluído"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__iface_vkeyboard
-msgid ""
-"Don’t turn this option on if you take orders on smartphones or tablets. \n"
+msgid "Don’t turn this option on if you take orders on smartphones or tablets. \n"
 " Such devices already benefit from a native keyboard."
-msgstr ""
-"Não acione esta opção se você toma pedidos em dispositivos como celulares ou tablets.\n"
+msgstr "Não acione esta opção se você toma pedidos em dispositivos como celulares ou tablets.\n"
 "Eles já dispõem de um teclado nativo."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1023
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1024
 #, python-format
 msgid "Download"
 msgstr "Download"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1358
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1359
 #, python-format
 msgid "Download Paid Orders"
 msgstr "Baixar pedidos pagos"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1360
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1361
 #, python-format
 msgid "Download Unpaid Orders"
 msgstr "Baixar Pedidos não pagos"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1020
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1021
 #, python-format
 msgid "Download error"
 msgstr "Erro no download"
@@ -1530,7 +1420,7 @@ msgstr "Editar"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1338
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1339
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__iface_electronic_scale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
 #, python-format
@@ -1547,14 +1437,14 @@ msgstr "E-mail"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1998
+#: code:addons/point_of_sale/static/src/js/screens.js:2089
 #, python-format
 msgid "Empty Order"
 msgstr "Ordem vazia"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:453
+#: code:addons/point_of_sale/static/src/js/screens.js:512
 #, python-format
 msgid "Empty Serial/Lot Number"
 msgstr "Número de série / lote vazio"
@@ -1562,9 +1452,7 @@ msgstr "Número de série / lote vazio"
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__iface_scan_via_proxy
 msgid "Enable barcode scanning with a remotely connected barcode scanner."
-msgstr ""
-"Habilita a leitura de código de barras com um leitor de código de barras "
-"conectado remotamente."
+msgstr "Habilita a leitura de código de barras com um leitor de código de barras conectado remotamente."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__iface_electronic_scale
@@ -1605,36 +1493,28 @@ msgstr "Erro! Você não pode criar categorias recursivas."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1307
+#: code:addons/point_of_sale/static/src/js/screens.js:1369
 #, python-format
 msgid "Error: Could not Save Changes"
 msgstr "Erro : Não foi possível salvar as alterações"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/models.js:244
+#: code:addons/point_of_sale/static/src/js/models.js:257
 #, python-format
-msgid ""
-"Error: The Point of Sale User must belong to the same company as the Point "
-"of Sale. You are probably trying to load the point of sale as an "
-"administrator in a multi-company setup, with the administrator account set "
-"to the wrong company."
-msgstr ""
-"Erro: O Ponto de Venda usuário deve pertencer à mesma empresa como o Ponto "
-"de Venda . Você provavelmente está tentando carregar o ponto de venda como "
-"um administrador em uma configuração de multi- empresa, com a conta de "
-"administrador definida para a empresa errada ."
+msgid "Error: The Point of Sale User must belong to the same company as the Point of Sale. You are probably trying to load the point of sale as an administrator in a multi-company setup, with the administrator account set to the wrong company."
+msgstr "Erro: O Ponto de Venda usuário deve pertencer à mesma empresa como o Ponto de Venda . Você provavelmente está tentando carregar o ponto de venda como um administrador em uma configuração de multi- empresa, com a conta de administrador definida para a empresa errada ."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1357
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1358
 #, python-format
 msgid "Export Paid Orders"
 msgstr "Exportar pedidos pagos"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1359
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1360
 #, python-format
 msgid "Export Unpaid Orders"
 msgstr "Exportar pedidos por pagar"
@@ -1646,7 +1526,7 @@ msgstr "Informações Adicionais"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1211
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1212
 #, python-format
 msgid "Finished Importing Orders"
 msgstr "Importação de pedidos concluída"
@@ -1690,18 +1570,8 @@ msgstr "Gerar referencias dos seus pedidos"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
-msgid ""
-"Get one journal item per product rather than one journal item per receipt "
-"line. This works for any anonymous order. If the customer is set on the "
-"order, one journal item is created for each receipt line. This option is "
-"recommended for an easy review of your journal entries when managing lots of"
-" orders."
-msgstr ""
-"Obtenha um item de diário por produto em vez de um item de diário por linha "
-"de recibo. Isso funciona para qualquer pedido anônimo. Se o cliente estiver "
-"definido no pedido, um item de diário será criado para cada linha de "
-"recebimento. Esta opção é recomendada para uma revisão fácil de suas "
-"entradas de diário ao gerenciar muitos pedidos."
+msgid "Get one journal item per product rather than one journal item per receipt line. This works for any anonymous order. If the customer is set on the order, one journal item is created for each receipt line. This option is recommended for an easy review of your journal entries when managing lots of orders."
+msgstr "Obtenha um item de diário por produto em vez de um item de diário por linha de recibo. Isso funciona para qualquer pedido anônimo. Se o cliente estiver definido no pedido, um item de diário será criado para cada linha de recebimento. Esta opção é recomendada para uma revisão fácil de suas entradas de diário ao gerenciar muitos pedidos."
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
@@ -1711,9 +1581,7 @@ msgstr "Beneficio Fidelidade, Amostra Grátis, Etc"
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_category__sequence
 msgid "Gives the sequence order when displaying a list of product categories."
-msgstr ""
-"Define a ordem de apresentação quando mostrar a lista de categorias de "
-"produtos."
+msgstr "Define a ordem de apresentação quando mostrar a lista de categorias de produtos."
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__module_pos_discount
@@ -1748,14 +1616,14 @@ msgstr "Falha na conexão HTTPS com IoT Box"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1375
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1373
 #, python-format
 msgid "Hardware Events"
 msgstr "Eventos do Equipamento"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1370
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1368
 #, python-format
 msgid "Hardware Status"
 msgstr "Situação do Hardware"
@@ -1796,14 +1664,14 @@ msgstr "Início"
 #: model:ir.model.fields,field_description:point_of_sale.field_report_point_of_sale_report_saledetails__id
 #: model:ir.model.fields,field_description:point_of_sale.field_report_pos_order__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/popups.js:115
 #, python-format
 msgid "IMPORTANT: Bug Report From Odoo Point Of Sale"
-msgstr "IMPORTANTE: Relatório de Erros do Odoo - Ponto de Venda"
+msgstr "IMPORTANTE: Relatório de Erros do MultiERP - Ponto de Venda"
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__proxy_ip
@@ -1813,14 +1681,8 @@ msgstr "Endereço IP"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__use_existing_lots
-msgid ""
-"If this is checked, you will be able to choose the Lots/Serial Numbers. You "
-"can also decide to not put lots in this operation type.  This means it will "
-"create stock with no lot or not put a restriction on the lot taken. "
-msgstr ""
-"Se isto estiver marcado, possibilita a escolha de Números de Lote/Série. "
-"Pode também decidir não colocar lotes neste tipo de operação. Isto significa"
-" que irá criar estoque sem lote ou não impor uma restrição no lote retirado."
+msgid "If this is checked, you will be able to choose the Lots/Serial Numbers. You can also decide to not put lots in this operation type.  This means it will create stock with no lot or not put a restriction on the lot taken. "
+msgstr "Se isto estiver marcado, possibilita a escolha de Números de Lote/Série. Pode também decidir não colocar lotes neste tipo de operação. Isto significa que irá criar estoque sem lote ou não impor uma restrição no lote retirado."
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_category__image
@@ -1829,7 +1691,7 @@ msgstr "Imagem"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1361
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1362
 #, python-format
 msgid "Import Orders"
 msgstr "Importar Pedidos"
@@ -1846,7 +1708,7 @@ msgid "In Progress"
 msgstr "Em Andamento"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:568
+#: code:addons/point_of_sale/models/pos_order.py:701
 #, python-format
 msgid "In order to delete a sale, it must be new or cancelled."
 msgstr "Para excluir uma venda, ela precisa ser nova ou ser cancelada."
@@ -1869,6 +1731,7 @@ msgid "Initial Category"
 msgstr "Categoria inicial"
 
 #. module: point_of_sale
+#: model:ir.model.fields,field_description:point_of_sale.field_contact_config_settings__module_pos_mercury
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__module_pos_mercury
 #: model:ir.model.fields,field_description:point_of_sale.field_res_config_settings__module_pos_mercury
 msgid "Integrated Card Payments"
@@ -1886,7 +1749,7 @@ msgstr "Anotações Internas"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1273
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1274
 #, python-format
 msgid "Invalid product lot"
 msgstr "Lote de produto inválido"
@@ -1913,10 +1776,16 @@ msgid "Invoice Journal"
 msgstr "Diário da fatura"
 
 #. module: point_of_sale
+#: model:ir.model,name:point_of_sale.model_account_invoice_line
+msgid "Invoice Line"
+msgstr "Linha da Fatura"
+
+#. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_report_pos_order__invoiced
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_order_filter
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_report_pos_order_search
-#: selection:pos.order,state:0 selection:report.pos.order,state:0
+#: selection:pos.order,state:0
+#: selection:report.pos.order,state:0
 msgid "Invoiced"
 msgstr "Faturado"
 
@@ -1949,12 +1818,8 @@ msgstr "Funciona como uma conta padrão para debitar valores"
 #. module: point_of_sale
 #: code:addons/point_of_sale/models/account_tax.py:23
 #, python-format
-msgid ""
-"It is forbidden to modify a tax used in a POS order not posted. You must "
-"close the POS sessions before modifying the tax."
-msgstr ""
-"É proibido modificar um imposto usado em um pedido de PDV não lançado. Você "
-"deve fechar as sessões de PDV antes de modificar o imposto."
+msgid "It is forbidden to modify a tax used in a POS order not posted. You must close the POS sessions before modifying the tax."
+msgstr "É proibido modificar um imposto usado em um pedido de PDV não lançado. Você deve fechar as sessões de PDV antes de modificar o imposto."
 
 #. module: point_of_sale
 #: model:ir.model,name:point_of_sale.model_account_journal
@@ -1971,12 +1836,6 @@ msgstr "Lançamento de Diário"
 #: model:ir.model.fields,field_description:point_of_sale.field_digest_digest__kpi_pos_total_value
 msgid "Kpi Pos Total Value"
 msgstr "Valor total Pos Kpi"
-
-#. module: point_of_sale
-#: model:product.product,name:point_of_sale.led_lamp
-#: model:product.template,name:point_of_sale.led_lamp_product_template
-msgid "LED Lamp"
-msgstr "Lâmpada LED"
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__iface_big_scrollbars
@@ -2037,15 +1896,8 @@ msgstr "Última atualização em"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
-#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
 msgid "Led Lamp"
 msgstr "Lâmpada Led"
-
-#. module: point_of_sale
-#: model:product.product,name:point_of_sale.letter_tray
-#: model:product.template,name:point_of_sale.letter_tray_product_template
-msgid "Letter Tray"
-msgstr "Bandeja de letras"
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order_line__name
@@ -2060,7 +1912,7 @@ msgstr "Lista de Caixas Registradoras"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/models.js:532
+#: code:addons/point_of_sale/static/src/js/models.js:545
 #: code:addons/point_of_sale/static/src/xml/pos.xml:38
 #, python-format
 msgid "Loading"
@@ -2088,8 +1940,8 @@ msgstr "Logar como Gerente"
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/xml/pos.xml:8
-#: code:addons/point_of_sale/static/src/xml/pos.xml:736
-#: code:addons/point_of_sale/static/src/xml/pos.xml:901
+#: code:addons/point_of_sale/static/src/xml/pos.xml:737
+#: code:addons/point_of_sale/static/src/xml/pos.xml:902
 #, python-format
 msgid "Logo"
 msgstr "Logotipo"
@@ -2106,7 +1958,7 @@ msgstr "Nome do Lote"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/models.js:2383
+#: code:addons/point_of_sale/static/src/js/models.js:2421
 #, python-format
 msgid "Lot/Serial Number(s) Required"
 msgstr "Número (s) de série / lote necessários"
@@ -2127,10 +1979,9 @@ msgid "Loyalty program to use for this point of sale."
 msgstr "Programa de lealdade a usar neste ponto de venda."
 
 #. module: point_of_sale
-#: model:product.product,name:point_of_sale.magnetic_board
-#: model:product.template,name:point_of_sale.magnetic_board_product_template
-msgid "Magnetic Board"
-msgstr "Placa Magnética"
+#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "Lâmpada Led"
+msgstr ""
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_payment
@@ -2139,28 +1990,15 @@ msgstr "Realizar Pagamento"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__available_pricelist_ids
-msgid ""
-"Make several pricelists available in the Point of Sale. You can also apply a"
-" pricelist to specific customers from their contact form (in Sales tab). To "
-"be valid, this pricelist must be listed here as an available pricelist. "
-"Otherwise the default pricelist will apply."
-msgstr ""
-"Disponibiliza várias listas de preços no Ponto de Vendas. Possibilita "
-"aplicar uma lista de preços a um cliente específico a partir de seu "
-"formulário de contato (na ava de Vendas). Para ser válida, uma lista de "
-"preços deve estar constar aqui como uma lista de preços disponível. Senão a "
-"lista de preços padrão vigorará."
+msgid "Make several pricelists available in the Point of Sale. You can also apply a pricelist to specific customers from their contact form (in Sales tab). To be valid, this pricelist must be listed here as an available pricelist. Otherwise the default pricelist will apply."
+msgstr "Disponibiliza várias listas de preços no Ponto de Vendas. Possibilita aplicar uma lista de preços a um cliente específico a partir de seu formulário de contato (na ava de Vendas). Para ser válida, uma lista de preços deve estar constar aqui como uma lista de preços disponível. Senão a lista de preços padrão vigorará."
 
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/models.js:144
 #, python-format
-msgid ""
-"Make sure you are using IoT Box v18.12 or higher. Navigate to %s to accept "
-"the certificate of your IoT Box."
-msgstr ""
-"Certifique-se de usar o IoT Box v18.12 ou superior. Navegue até %spara "
-"aceitar o certificado da sua IoT Box."
+msgid "Make sure you are using IoT Box v18.12 or higher. Navigate to %s to accept the certificate of your IoT Box."
+msgstr "Certifique-se de usar o IoT Box v18.12 ou superior. Navegue até %spara aceitar o certificado da sua IoT Box."
 
 #. module: point_of_sale
 #: model:res.groups,name:point_of_sale.group_pos_manager
@@ -2174,14 +2012,8 @@ msgstr "Imagem de tamanho Médio"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_category__image_medium
-msgid ""
-"Medium-sized image of the category. It is automatically resized as a "
-"128x128px image, with aspect ratio preserved. Use this field in form views "
-"or some kanban views."
-msgstr ""
-"Image médias da categoria. Ele é automaticamente redimensionada como uma "
-"imagem de 128x128px, com relação de aspecto preservado. Utilize este campo "
-"em vista de formulário ou algumas vistas kanban."
+msgid "Medium-sized image of the category. It is automatically resized as a 128x128px image, with aspect ratio preserved. Use this field in form views or some kanban views."
+msgstr "Image médias da categoria. Ele é automaticamente redimensionada como uma imagem de 128x128px, com relação de aspecto preservado. Utilize este campo em vista de formulário ou algumas vistas kanban."
 
 #. module: point_of_sale
 #. openerp-web
@@ -2191,26 +2023,23 @@ msgid "Method"
 msgstr "Método"
 
 #. module: point_of_sale
-#: model:pos.category,name:point_of_sale.pos_category_miscellaneous
-#: model:product.product,name:point_of_sale.product_product_consumable
-#: model:product.template,name:point_of_sale.product_product_consumable_product_template
-msgid "Miscellaneous"
-msgstr "Diversos"
-
-#. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
-#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
-#: model:product.product,name:point_of_sale.monitor_stand
-#: model:product.template,name:point_of_sale.monitor_stand_product_template
 msgid "Monitor Stand"
 msgstr "Suporte para monitor"
 
 #. module: point_of_sale
+#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "MultiERP Logo"
+msgstr "Logo MultiERP"
+
+#. module: point_of_sale
+#: model:ir.model.fields,field_description:point_of_sale.field_contact_config_settings__pos_sales_price
 #: model:ir.model.fields,field_description:point_of_sale.field_res_config_settings__pos_sales_price
 msgid "Multiple Product Prices"
 msgstr "Múltiplos preços por produto"
 
 #. module: point_of_sale
+#: selection:contact.config.settings,pos_pricelist_setting:0
 #: selection:res.config.settings,pos_pricelist_setting:0
 msgid "Multiple prices per product (e.g. customer segments, currencies)"
 msgstr "Múltiplos preços por produto(Ex.: segmentos de clientes, moedas)"
@@ -2245,7 +2074,8 @@ msgstr "Nome"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_order_filter
-#: selection:pos.order,state:0 selection:report.pos.order,state:0
+#: selection:pos.order,state:0
+#: selection:report.pos.order,state:0
 msgid "New"
 msgstr "Novo"
 
@@ -2256,16 +2086,10 @@ msgstr "Iniciar Venda"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1433
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1434
 #, python-format
 msgid "New order"
 msgstr "Novo pedido"
-
-#. module: point_of_sale
-#: model:product.product,name:point_of_sale.newspaper_rack
-#: model:product.template,name:point_of_sale.newspaper_rack_product_template
-msgid "Newspaper Rack"
-msgstr "Suporte de jornal"
 
 #. module: point_of_sale
 #. openerp-web
@@ -2275,7 +2099,7 @@ msgid "Next Order"
 msgstr "Próxima Ordem"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:1132
+#: code:addons/point_of_sale/models/pos_order.py:1281
 #, python-format
 msgid "No Taxes"
 msgstr "Sem taxas"
@@ -2283,11 +2107,8 @@ msgstr "Sem taxas"
 #. module: point_of_sale
 #: code:addons/point_of_sale/models/pos_order.py:147
 #, python-format
-msgid ""
-"No cash statement found for this session. Unable to record returned cash."
-msgstr ""
-"Nenhuma demonstração de caixa encontrada para esta sessão. Incapaz de gravar"
-" dinheiro devolvido."
+msgid "No cash statement found for this session. Unable to record returned cash."
+msgstr "Nenhuma demonstração de caixa encontrada para esta sessão. Incapaz de gravar dinheiro devolvido."
 
 #. module: point_of_sale
 #: code:addons/point_of_sale/report/pos_invoice.py:25
@@ -2303,11 +2124,9 @@ msgstr "Nenhum pedido encontrado"
 #. module: point_of_sale
 #: code:addons/point_of_sale/models/pos_session.py:192
 #, python-format
-msgid ""
-"No payment method configured! \n"
+msgid "No payment method configured! \n"
 "Either no Chart of Account is installed or no payment method is configured for this POS."
-msgstr ""
-"Nenhum método de pagamento configurado!\n"
+msgstr "Nenhum método de pagamento configurado!\n"
 "Nenhum plano de conta está instalado ou nenhum método de pagamento está configurado para este PDV."
 
 #. module: point_of_sale
@@ -2323,7 +2142,7 @@ msgstr "Nenhuma sessão encontrada."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2129
+#: code:addons/point_of_sale/static/src/js/screens.js:2193
 #: code:addons/point_of_sale/static/src/xml/pos.xml:361
 #, python-format
 msgid "None"
@@ -2346,42 +2165,41 @@ msgstr "Número da Impressão"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
-#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
 msgid "Odoo Logo"
-msgstr "Logo do Odoo"
+msgstr "Logo do MultiERP"
 
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/chrome.js:403
 #, python-format
 msgid "Offline"
-msgstr "Offline"
+msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/gui.js:328
+#: code:addons/point_of_sale/static/src/js/gui.js:336
 #, python-format
 msgid "Offline Orders"
 msgstr "Pedidos Offline"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:988
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1002
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1016
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1045
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1076
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1105
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1122
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1200
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1236
+#: code:addons/point_of_sale/static/src/xml/pos.xml:989
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1003
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1017
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1046
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1077
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1106
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1123
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1201
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1237
 #, python-format
 msgid "Ok"
-msgstr "Ok"
+msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:454
+#: code:addons/point_of_sale/static/src/js/screens.js:513
 #, python-format
 msgid "One or more product(s) required serial/lot number."
 msgstr "Um ou mais produtos(s) número de série/lote necessários."
@@ -2389,21 +2207,15 @@ msgstr "Um ou mais produtos(s) número de série/lote necessários."
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__restrict_price_control
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
-msgid ""
-"Only users with Manager access rights for PoS app can modify the product "
-"prices on orders."
-msgstr ""
-"Somente usuários com direitos de acesso de gerente para o aplicativo PoS "
-"podem modificar os preços dos produtos nos pedidos."
+msgid "Only users with Manager access rights for PoS app can modify the product prices on orders."
+msgstr "Somente usuários com direitos de acesso de gerente para o aplicativo PoS podem modificar os preços dos produtos nos pedidos."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1364
+#: code:addons/point_of_sale/static/src/js/screens.js:1429
 #, python-format
 msgid "Only web-compatible Image formats such as .png or .jpeg are supported"
-msgstr ""
-"Somente formatos de imagem compatível com a web, como .png ou .jpeg são "
-"suportadas"
+msgstr "Somente formatos de imagem compatível com a web, como .png ou .jpeg são suportadas"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_session_search
@@ -2418,7 +2230,7 @@ msgstr "Abrir Caixa Registradora"
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/xml/pos.xml:695
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1374
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1375
 #, python-format
 msgid "Open Cashbox"
 msgstr "Abrir Caixa Registradora"
@@ -2426,7 +2238,7 @@ msgstr "Abrir Caixa Registradora"
 #. module: point_of_sale
 #: model:ir.actions.client,name:point_of_sale.action_client_pos_menu
 msgid "Open POS Menu"
-msgstr "Abrir Menu do PDV"
+msgstr "Abrir Menu POS"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_open_statement
@@ -2494,8 +2306,8 @@ msgstr "Pedido"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/models.js:1958
-#: code:addons/point_of_sale/static/src/js/models.js:1998
+#: code:addons/point_of_sale/static/src/js/models.js:2013
+#: code:addons/point_of_sale/static/src/js/models.js:2053
 #, python-format
 msgid "Order "
 msgstr "Ordem"
@@ -2541,7 +2353,7 @@ msgid "Order Sequence Number"
 msgstr "Número de Sequência da Ordem"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:598
+#: code:addons/point_of_sale/models/pos_order.py:731
 #, python-format
 msgid "Order is not paid."
 msgstr "Pedido não está pago"
@@ -2553,7 +2365,7 @@ msgstr "Ordem de Linhas"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1352
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1353
 #: model:ir.actions.act_window,name:point_of_sale.act_pos_session_orders
 #: model:ir.actions.act_window,name:point_of_sale.action_pos_order_filtered
 #: model:ir.actions.act_window,name:point_of_sale.action_pos_pos_form
@@ -2574,12 +2386,17 @@ msgid "Orders Analysis"
 msgstr "Análise do Pedido"
 
 #. module: point_of_sale
+#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "Organizador de mesa"
+msgstr ""
+
+#. module: point_of_sale
 #: model:ir.actions.act_window,name:point_of_sale.account_journal_action_point_of_sale
 msgid "POS Journals"
 msgstr "Diários contábeis do PdV"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_config.py:348
+#: code:addons/point_of_sale/models/pos_config.py:351
 #, python-format
 msgid "POS Order %s"
 msgstr "Pedido do PdV %s"
@@ -2605,6 +2422,7 @@ msgid "POS Orders lines"
 msgstr "Ordens linhas POS"
 
 #. module: point_of_sale
+#: model:ir.model.fields,field_description:point_of_sale.field_contact_config_settings__pos_pricelist_setting
 #: model:ir.model.fields,field_description:point_of_sale.field_res_config_settings__pos_pricelist_setting
 msgid "POS Pricelists"
 msgstr "Listas de preço do PdV"
@@ -2616,7 +2434,7 @@ msgid "POS Sales"
 msgstr "Vendas do PdV"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_config.py:357
+#: code:addons/point_of_sale/models/pos_config.py:360
 #, python-format
 msgid "POS order line %s"
 msgstr "Linha de pedido de PDV%s"
@@ -2633,7 +2451,8 @@ msgstr "Pacote"
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order__amount_paid
-#: selection:pos.order,state:0 selection:report.pos.order,state:0
+#: selection:pos.order,state:0
+#: selection:report.pos.order,state:0
 msgid "Paid"
 msgstr "Pago"
 
@@ -2645,10 +2464,11 @@ msgstr "Categoria superior(pai)"
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/xml/pos.xml:335
+#: model:ir.model,name:point_of_sale.model_res_partner
 #: model_terms:ir.ui.view,arch_db:point_of_sale.report_statement
 #, python-format
 msgid "Partner"
-msgstr "Cliente"
+msgstr "Parceiro"
 
 #. module: point_of_sale
 #. openerp-web
@@ -2716,13 +2536,11 @@ msgstr "Terminal de Pagamento"
 
 #. module: point_of_sale
 #: model_terms:ir.actions.act_window,help:point_of_sale.action_account_journal_form
-msgid ""
-"Payment methods are defined by accounting journals having the\n"
+msgid "Payment methods are defined by accounting journals having the\n"
 "                field <i>PoS Payment Method</i> checked. In order to be useable\n"
 "                from the touchscreen interface, you must set the payment method\n"
 "                on the <i>Point of Sale</i> configuration."
-msgstr ""
-"Métodos de pagamento são definidos pelos diários contábeis que possuem\n"
+msgstr "Métodos de pagamento são definidos pelos diários contábeis que possuem\n"
 "o campo <i>Método de pagamento do PdV</i>marcado. Para ser usável a partir da interface sensível a toque, é necessário atribuir o método de pagamento na configuração do <i>Ponto de Venda</i>."
 
 #. module: point_of_sale
@@ -2741,7 +2559,7 @@ msgstr "Pagamentos"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:939
+#: code:addons/point_of_sale/static/src/xml/pos.xml:940
 #, python-format
 msgid "Payments:"
 msgstr "Pagamentos:"
@@ -2753,12 +2571,8 @@ msgstr "Por sessão"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_order__user_id
-msgid ""
-"Person who uses the cash register. It can be a reliever, a student or an "
-"interim employee."
-msgstr ""
-"A pessoa que usa a caixa registadora. Ele pode ser um apaziguador, um "
-"estudante ou um empregado interino."
+msgid "Person who uses the cash register. It can be a reliever, a student or an interim employee."
+msgstr "A pessoa que usa a caixa registadora. Ele pode ser um apaziguador, um estudante ou um empregado interino."
 
 #. module: point_of_sale
 #. openerp-web
@@ -2771,7 +2585,7 @@ msgstr "Telefone"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1453
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1454
 #, python-format
 msgid "Phone:"
 msgstr "Telefone:"
@@ -2800,33 +2614,33 @@ msgstr "Foto"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2045
+#: code:addons/point_of_sale/static/src/js/screens.js:2117
 #, python-format
 msgid "Please Confirm Large Amount"
 msgstr "Confirme a grande quantidade"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/models.js:1892
+#: code:addons/point_of_sale/static/src/js/models.js:1926
 #, python-format
 msgid "Please configure a payment method in your POS."
 msgstr "Por favor, configure um método de pagamento no seu PdV."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:374
+#: code:addons/point_of_sale/models/pos_order.py:371
 #, python-format
 msgid "Please define income account for this product: \"%s\" (id:%d)."
 msgstr "Por favor defina conta de recebimento para este produto: \"%s\" (id:%d)."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2094
+#: code:addons/point_of_sale/static/src/js/screens.js:210
 #, python-format
 msgid "Please print the invoice from the backend"
 msgstr "Por favor, imprima a fatura a partir da retaguarda"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:663
+#: code:addons/point_of_sale/models/pos_order.py:744
 #, python-format
 msgid "Please provide a partner for the sale."
 msgstr "Por favor informe um cliente para a venda"
@@ -2840,15 +2654,10 @@ msgstr "Favor selecionar um método de pagamento."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2067
+#: code:addons/point_of_sale/static/src/js/screens.js:202
 #, python-format
 msgid "Please select the Customer"
 msgstr "Favor selecionar o Cliente"
-
-#. module: point_of_sale
-#: model:product.category,name:point_of_sale.product_category_pos
-msgid "PoS"
-msgstr "PdV"
 
 #. module: point_of_sale
 #: model:ir.actions.act_window,name:point_of_sale.product_pos_category_action
@@ -2913,7 +2722,7 @@ msgstr "Configuração do Ponto de Vendas"
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_config_tree
 msgid "Point of Sale Configuration"
-msgstr "Configuração do Ponto de Vendas"
+msgstr "Configuração do ponto de venda"
 
 #. module: point_of_sale
 #: model:ir.model,name:point_of_sale.model_report_point_of_sale_report_saledetails
@@ -2955,7 +2764,7 @@ msgstr "Linhas de pedido de Ponto de Venda"
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_order_search
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_pos_form
 msgid "Point of Sale Orders"
-msgstr "Pedidos do Ponto de Vendas"
+msgstr "Pedidos do ponto de venda"
 
 #. module: point_of_sale
 #: model:ir.model,name:point_of_sale.model_report_pos_order
@@ -3019,7 +2828,7 @@ msgstr "Nome de usuário da sessão PdV"
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__is_posbox
 msgid "PosBox"
-msgstr "PosBox"
+msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
@@ -3030,7 +2839,8 @@ msgstr "Código Postal"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_order_filter
-#: selection:pos.order,state:0 selection:report.pos.order,state:0
+#: selection:pos.order,state:0
+#: selection:report.pos.order,state:0
 msgid "Posted"
 msgstr "Lançado"
 
@@ -3045,10 +2855,14 @@ msgid "Prefill amount paid with the exact due amount"
 msgstr "Preechen valor pago exatamente com o valor devido"
 
 #. module: point_of_sale
+#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "Preço"
+msgstr ""
+
+#. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/xml/pos.xml:173
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
-#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
 #, python-format
 msgid "Price"
 msgstr "Preço"
@@ -3064,6 +2878,7 @@ msgid "Price Unit"
 msgstr "Preço unitário"
 
 #. module: point_of_sale
+#: selection:contact.config.settings,pos_pricelist_setting:0
 #: selection:res.config.settings,pos_pricelist_setting:0
 msgid "Price computed from formulas (discounts, margins, roundings)"
 msgstr "Preço computado de fórmulas (descontos, margens, arredondamentos)"
@@ -3082,7 +2897,7 @@ msgstr "Produto Precificado"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2217
+#: code:addons/point_of_sale/static/src/js/screens.js:2281
 #: code:addons/point_of_sale/static/src/xml/pos.xml:388
 #: code:addons/point_of_sale/static/src/xml/pos.xml:461
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order__pricelist_id
@@ -3115,15 +2930,8 @@ msgstr "Imprimir"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:716
-#, python-format
-msgid "Print Invoice"
-msgstr "Imprimir Fatura"
-
-#. module: point_of_sale
-#. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:719
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1378
+#: code:addons/point_of_sale/static/src/xml/pos.xml:717
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1376
 #, python-format
 msgid "Print Receipt"
 msgstr "Imprimir Recibo"
@@ -3136,8 +2944,7 @@ msgstr "Imprimir faturar se o cliente requerer"
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
 msgid "Print receipts automatically once the payment is registered"
-msgstr ""
-"Imprime recibos automaticamente uma vez que o pagamento foi registrado"
+msgstr "Imprime recibos automaticamente uma vez que o pagamento foi registrado"
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__iface_print_via_proxy
@@ -3160,23 +2967,17 @@ msgstr "Erro de impressão :"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1580
+#: code:addons/point_of_sale/static/src/js/screens.js:1642
 #, python-format
 msgid "Printing is not supported on some android browsers"
 msgstr "A impressão não é suportada em alguns navegadores do Android."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1581
+#: code:addons/point_of_sale/static/src/js/screens.js:1643
 #, python-format
-msgid ""
-"Printing is not supported on some android browsers due to no default "
-"printing protocol is available. It is possible to print your tickets by "
-"making use of an IoT Box."
-msgstr ""
-"A impressão não é suportada em alguns navegadores do Android devido à "
-"indisponibilidade de protocolos de impressão padronizados. É possível "
-"imprimir seus tickets usando um IoT Box."
+msgid "Printing is not supported on some android browsers due to no default printing protocol is available. It is possible to print your tickets by making use of an IoT Box."
+msgstr "A impressão não é suportada em alguns navegadores do Android devido à indisponibilidade de protocolos de impressão padronizados. É possível imprimir seus tickets usando um IoT Box."
 
 #. module: point_of_sale
 #: model:ir.model,name:point_of_sale.model_product_product
@@ -3234,7 +3035,7 @@ msgstr "Variantes de Produto"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1247
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1248
 #, python-format
 msgid "Product image"
 msgstr "Imagem do produto"
@@ -3292,16 +3093,35 @@ msgid "Qty"
 msgstr "Qtd"
 
 #. module: point_of_sale
+#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "Quantidade"
+msgstr ""
+
+#. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order_line__qty
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
 #: model_terms:ir.ui.view,arch_db:point_of_sale.report_saledetails
-#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
 msgid "Quantity"
 msgstr "Quantidade"
 
 #. module: point_of_sale
+#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "R$ 4,40"
+msgstr ""
+
+#. module: point_of_sale
+#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "R$ 4,50"
+msgstr ""
+
+#. module: point_of_sale
+#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "R$ 8,50"
+msgstr ""
+
+#. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1376
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1377
 #, python-format
 msgid "Read Weighing Scale"
 msgstr "Leia escala de pesagem"
@@ -3346,14 +3166,14 @@ msgstr "Recuperar sessão"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1370
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1371
 #, python-format
 msgid "Refresh Display"
 msgstr "Atualizar exibição"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1100
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1101
 #, python-format
 msgid "Remove"
 msgstr "Remover"
@@ -3370,7 +3190,7 @@ msgstr "Reimprimir Recibo"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1342
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1343
 #, python-format
 msgid "Reset"
 msgstr "Redefinir"
@@ -3396,7 +3216,7 @@ msgid "Resume"
 msgstr "Continuar Vendendo"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:931
+#: code:addons/point_of_sale/models/pos_order.py:1079
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_pos_form
 #, python-format
 msgid "Return Products"
@@ -3471,14 +3291,14 @@ msgstr "Escala "
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1348
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1349
 #, python-format
 msgid "Scan"
 msgstr "Digitalizar"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1349
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1350
 #, python-format
 msgid "Scan EAN-13"
 msgstr "Scanear EAN-13"
@@ -3541,14 +3361,14 @@ msgstr "Escolha o usuário"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2205
+#: code:addons/point_of_sale/static/src/js/screens.js:2269
 #, python-format
 msgid "Select pricelist"
 msgstr "Escolha a lista de preços"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2140
+#: code:addons/point_of_sale/static/src/js/screens.js:2204
 #, python-format
 msgid "Select tax"
 msgstr "Selecione uma Posição Fiscal"
@@ -3566,7 +3386,7 @@ msgstr "Vender em várias moedas"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1026
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1027
 #, python-format
 msgid "Send by email"
 msgstr "Enviar por e-mail"
@@ -3583,27 +3403,27 @@ msgstr "Sequencia numerica "
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1099
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1100
 #, python-format
 msgid "Serial/Lot Number"
 msgstr "Lote/Número Serial "
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:768
+#: code:addons/point_of_sale/static/src/xml/pos.xml:769
 #, python-format
 msgid "Served by"
 msgstr "Servido por"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2080
+#: code:addons/point_of_sale/static/src/js/screens.js:229
 #, python-format
 msgid "Server Error"
 msgstr "Erro interno do servidor"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_config.py:461
+#: code:addons/point_of_sale/models/pos_config.py:466
 #: model:ir.model.fields,field_description:point_of_sale.field_account_bank_statement__pos_session_id
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_make_payment__session_id
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order__session_id
@@ -3620,7 +3440,7 @@ msgstr "ID da Sessão"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1225
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1226
 #, python-format
 msgid "Session ids:"
 msgstr "Ids de sessão:"
@@ -3659,7 +3479,7 @@ msgstr "Definir uma categoria inicial"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1341
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1342
 #, python-format
 msgid "Set Weight"
 msgstr "Configurar Peso"
@@ -3667,8 +3487,7 @@ msgstr "Configurar Peso"
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
 msgid "Set barcodes to scan products, customer cards, etc."
-msgstr ""
-"Definir um leito de código de barras para produtos, cartão cliente, etc"
+msgstr "Definir um leito de código de barras para produtos, cartão cliente, etc"
 
 #. module: point_of_sale
 #. openerp-web
@@ -3685,8 +3504,7 @@ msgstr "Atribuir múltiplos preços por produto, descontos automáticos, etc."
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
 msgid "Set shop-specific prices, seasonal discounts, etc."
-msgstr ""
-"Definir lista de preços especificos para revendas, descontos sazionais, etc"
+msgstr "Definir lista de preços especificos para revendas, descontos sazionais, etc"
 
 #. module: point_of_sale
 #. openerp-web
@@ -3704,7 +3522,7 @@ msgstr "Configurações"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1311
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1312
 #, python-format
 msgid "Shopping cart"
 msgstr "Carrinho de compras"
@@ -3734,52 +3552,28 @@ msgid "Slash"
 msgstr "Cortar"
 
 #. module: point_of_sale
-#: model:product.product,name:point_of_sale.small_shelf
-#: model:product.template,name:point_of_sale.small_shelf_product_template
-msgid "Small Shelf"
-msgstr "Prateleira Pequena"
-
-#. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_category__image_small
 msgid "Small-sized image"
 msgstr "Imagem pequena"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_category__image_small
-msgid ""
-"Small-sized image of the category. It is automatically resized as a 64x64px "
-"image, with aspect ratio preserved. Use this field anywhere a small image is"
-" required."
-msgstr ""
-"Imagem de tamanho pequeno da categoria. Ele é automaticamente redimensionada"
-" como uma imagem 64x64px, com relação de aspecto preservado. Utilize este "
-"campo em qualquer lugar uma imagem pequena for necessária."
+msgid "Small-sized image of the category. It is automatically resized as a 64x64px image, with aspect ratio preserved. Use this field anywhere a small image is required."
+msgstr "Imagem de tamanho pequeno da categoria. Ele é automaticamente redimensionada como uma imagem 64x64px, com relação de aspecto preservado. Utilize este campo em qualquer lugar uma imagem pequena for necessária."
 
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/gui.js:324
 #, python-format
-msgid ""
-"Some orders could not be submitted to the server due to configuration "
-"errors. You can exit the Point of Sale, but do not close the session before "
-"the issue has been resolved."
-msgstr ""
-"Alguns pedidos não puderam ser enviados ao servidor devido a erros de "
-"configuração. Você pode sair do Ponto de venda, mas não feche a sessão antes"
-" que o problema seja resolvido."
+msgid "Some orders could not be submitted to the server due to configuration errors. You can exit the Point of Sale, but do not close the session before the issue has been resolved."
+msgstr "Alguns pedidos não puderam ser enviados ao servidor devido a erros de configuração. Você pode sair do Ponto de venda, mas não feche a sessão antes que o problema seja resolvido."
 
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/gui.js:329
 #, python-format
-msgid ""
-"Some orders could not be submitted to the server due to internet connection "
-"issues. You can exit the Point of Sale, but do not close the session before "
-"the issue has been resolved."
-msgstr ""
-"Alguns pedidos não puderam ser enviados ao servidor devido a problemas de "
-"conexão com a Internet. Você pode sair do Ponto de venda, mas não feche a "
-"sessão antes que o problema seja resolvido."
+msgid "Some orders could not be submitted to the server due to internet connection issues. You can exit the Point of Sale, but do not close the session before the issue has been resolved."
+msgstr "Alguns pedidos não puderam ser enviados ao servidor devido a problemas de conexão com a Internet. Você pode sair do Ponto de venda, mas não feche a sessão antes que o problema seja resolvido."
 
 #. module: point_of_sale
 #: model:ir.model,name:point_of_sale.model_pos_pack_operation_lot
@@ -3846,11 +3640,11 @@ msgstr "Endereço"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:818
+#: code:addons/point_of_sale/static/src/xml/pos.xml:819
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order_line__price_subtotal_incl
 #, python-format
 msgid "Subtotal"
-msgstr "Subtotal"
+msgstr ""
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order_line__price_subtotal
@@ -3864,21 +3658,21 @@ msgstr "Subtotal sem desconto"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1492
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1493
 #, python-format
 msgid "Subtotal:"
-msgstr "Subtotal:"
+msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1217
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1218
 #, python-format
 msgid "Successfully  imported"
 msgstr "Importação concluída com sucesso"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1216
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1217
 #, python-format
 msgid "Successfully imported"
 msgstr "Importação concluída com sucesso"
@@ -3897,6 +3691,11 @@ msgstr "Soma dos Subtotais"
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_session_form
 msgid "Summary by Payment Methods"
 msgstr "Resumo por Métodos de Pagamento"
+
+#. module: point_of_sale
+#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
+msgid "Suporte para monitor"
+msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
@@ -3928,10 +3727,10 @@ msgstr "Erro de sincronização"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:831
+#: code:addons/point_of_sale/static/src/xml/pos.xml:832
 #, python-format
 msgid "TOTAL"
-msgstr "TOTAL"
+msgstr ""
 
 #. module: point_of_sale
 #: model:ir.actions.act_window,name:point_of_sale.action_pos_box_out
@@ -3940,8 +3739,8 @@ msgstr "Efetuar um Saque"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/models/pos_order.py:395
-#: code:addons/point_of_sale/static/src/js/screens.js:2159
+#: code:addons/point_of_sale/models/pos_order.py:415
+#: code:addons/point_of_sale/static/src/js/screens.js:2223
 #: model:ir.model,name:point_of_sale.model_account_tax
 #, python-format
 msgid "Tax"
@@ -4004,18 +3803,17 @@ msgstr "Impostos a aplicar"
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/screens.js:685
-#: code:addons/point_of_sale/static/src/xml/pos.xml:953
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1321
+#: code:addons/point_of_sale/static/src/xml/pos.xml:954
 #, python-format
 msgid "Taxes:"
 msgstr "Impostos:"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:748
+#: code:addons/point_of_sale/static/src/xml/pos.xml:749
 #, python-format
 msgid "Tel:"
-msgstr "Tel:"
+msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
@@ -4025,70 +3823,54 @@ msgid "Tendered"
 msgstr "Pago"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:351
+#: code:addons/point_of_sale/models/pos_order.py:352
 #, python-format
 msgid "The POS order must have lines when calling this method"
 msgstr "Este pedido do PDV deve ter linhas quando chamar este método"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1040
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1041
 #, python-format
-msgid ""
-"The Point of Sale could not find any product, client, employee\n"
+msgid "The Point of Sale could not find any product, client, employee\n"
 "                    or action associated with the scanned barcode."
-msgstr ""
-"O ponto de venda não poderia encontrar qualquer produto , cliente, employee\n"
+msgstr "O ponto de venda não poderia encontrar qualquer produto , cliente, employee\n"
 "ou ação associada com o código de barras digitalizado ."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_config.py:242
+#: code:addons/point_of_sale/models/pos_config.py:245
 #, python-format
 msgid "The default pricelist must be included in the available pricelists."
-msgstr ""
-"A lista de preços padrão deve constar entre as listas de preço disponíveis."
+msgstr "A lista de preços padrão deve constar entre as listas de preço disponíveis."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__proxy_ip
-msgid ""
-"The hostname or ip address of the hardware proxy, Will be autodetected if "
-"left empty."
-msgstr ""
-"O nome do hospedeiro ou endereço IP do proxy do equipamento. Será detectado "
-"automaticamente se deixado vazio."
+msgid "The hostname or ip address of the hardware proxy, Will be autodetected if left empty."
+msgstr "O nome do hospedeiro ou endereço IP do proxy do equipamento. Será detectado automaticamente se deixado vazio."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_config.py:232
+#: code:addons/point_of_sale/models/pos_config.py:235
 #, python-format
-msgid ""
-"The invoice journal and the point of sale must belong to the same company."
-msgstr ""
-"O diário da fatura e o ponto de venda devem pertencer à mesma companhia."
+msgid "The invoice journal and the point of sale must belong to the same company."
+msgstr "O diário da fatura e o ponto de venda devem pertencer à mesma companhia."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_config.py:248
+#: code:addons/point_of_sale/models/pos_config.py:251
 #, python-format
-msgid ""
-"The invoice journal must be in the same currency as the Sales Journal or the"
-" company currency if that is not set."
-msgstr ""
-"O diário de faturas deve estar na mesma moeda que o Diário de vendas ou a "
-"moeda da empresa, se isso não for definido."
+msgid "The invoice journal must be in the same currency as the Sales Journal or the company currency if that is not set."
+msgstr "O diário de faturas deve estar na mesma moeda que o Diário de vendas ou a moeda da empresa, se isso não for definido."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_session.py:284
+#: code:addons/point_of_sale/models/pos_session.py:290
 #, python-format
 msgid "The journal type for your payment method should be bank or cash."
-msgstr ""
-"O tipo de diário para seu método de pagamento deve ser banco ou dinheiro."
+msgstr "O tipo de diário para seu método de pagamento deve ser banco ou dinheiro."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_config.py:237
+#: code:addons/point_of_sale/models/pos_config.py:240
 #, python-format
-msgid ""
-"The method payments and the point of sale must belong to the same company."
-msgstr ""
-"A forma de pagamento e o ponto de venda devem pertencer à mesma empresa."
+msgid "The method payments and the point of sale must belong to the same company."
+msgstr "A forma de pagamento e o ponto de venda devem pertencer à mesma empresa."
 
 #. module: point_of_sale
 #: sql_constraint:pos.session:0
@@ -4103,48 +3885,36 @@ msgstr "O número de pedidos de ponto de vendas relacionados a este cliente"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2105
+#: code:addons/point_of_sale/static/src/js/screens.js:221
 #, python-format
 msgid "The order could not be sent"
 msgstr "A ordem não pôde ser enviada"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2116
+#: code:addons/point_of_sale/static/src/js/screens.js:235
 #, python-format
 msgid "The order could not be sent to the server due to an unknown error"
 msgstr "O pedido não foi enviado ao servidor devido a um erro desconhecido."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2095
+#: code:addons/point_of_sale/static/src/js/screens.js:211
 #, python-format
-msgid ""
-"The order has been synchronized earlier. Please make the invoice from the "
-"backend for the order: "
-msgstr ""
-"O pedido foi sincronizado anteriormente. Faça a fatura do backend para o "
-"pedido:"
+msgid "The order has been synchronized earlier. Please make the invoice from the backend for the order: "
+msgstr "O pedido foi sincronizado anteriormente. Faça a fatura do backend para o pedido:"
 
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/xml/pos.xml:715
 #, python-format
-msgid ""
-"The order has been synchronized earlier. To print the invoice please refer "
-"to the order in the backend"
-msgstr ""
-"O pedido foi sincronizado anteriormente. Para imprimir a fatura, consulte o "
-"pedido no backend"
+msgid "The order has been synchronized earlier. To print the invoice please refer to the order in the backend"
+msgstr "O pedido foi sincronizado anteriormente. Para imprimir a fatura, consulte o pedido no backend"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__iface_precompute_cash
-msgid ""
-"The payment input will behave similarily to bank payment input, and will be "
-"prefilled with the exact due amount."
-msgstr ""
-"A entrada de pagamento se comportará de maneira semelhante à entrada de "
-"pagamento bancário e será pré-preenchida com o valor exato devido."
+msgid "The payment input will behave similarily to bank payment input, and will be prefilled with the exact due amount."
+msgstr "A entrada de pagamento se comportará de maneira semelhante à entrada de pagamento bancário e será pré-preenchida com o valor exato devido."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_order__config_id
@@ -4154,22 +3924,13 @@ msgstr "O Ponto de Venda físico que você vai utilizar."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__iface_start_categ_id
-msgid ""
-"The point of sale will display this product category by default. If no "
-"category is specified, all available products will be shown."
-msgstr ""
-"O ponto de vendas apresentará esta categoria de produto por padrão. Se "
-"nenhuma categoria for especificada, todos os produtos disponíveis serão "
-"apresentados."
+msgid "The point of sale will display this product category by default. If no category is specified, all available products will be shown."
+msgstr "O ponto de vendas apresentará esta categoria de produto por padrão. Se nenhuma categoria for especificada, todos os produtos disponíveis serão apresentados."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__pricelist_id
-msgid ""
-"The pricelist used if no customer is selected or if the customer has no Sale"
-" Pricelist configured."
-msgstr ""
-"A lista de preços utilizada se nenhum cliente for selecionado ou se não "
-"houver uma lista de preços de venda configurada para o cliente."
+msgid "The pricelist used if no customer is selected or if the customer has no Sale Pricelist configured."
+msgstr "A lista de preços utilizada se nenhum cliente for selecionado ou se não houver uma lista de preços de venda configurada para o cliente."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__iface_display_categ_images
@@ -4178,19 +3939,15 @@ msgstr "As categorias de produtos serão apresentadas com imagens."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1379
+#: code:addons/point_of_sale/static/src/js/screens.js:1444
 #, python-format
 msgid "The provided file could not be read due to an unknown error"
 msgstr "O arquivo fornecido não pôde ser lido devido a um erro desconhecido"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__iface_print_skip_screen
-msgid ""
-"The receipt screen will be skipped if the receipt can be printed "
-"automatically."
-msgstr ""
-"Se o recibo puder ser impresso automaticamente, a tela do recibo será "
-"dispensada."
+msgid "The receipt screen will be skipped if the receipt can be printed automatically."
+msgstr "Se o recibo puder ser impresso automaticamente, a tela do recibo será dispensada."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__iface_print_auto
@@ -4198,57 +3955,41 @@ msgid "The receipt will automatically be printed at the end of each order."
 msgstr "O recibo será impresso ao final de cada pedido."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_config.py:227
+#: code:addons/point_of_sale/models/pos_config.py:230
 #, python-format
-msgid ""
-"The sales journal and the point of sale must belong to the same company."
-msgstr ""
-"O diário de vendas e o ponto de vendas devem pertencer à mesma companhia."
+msgid "The sales journal and the point of sale must belong to the same company."
+msgstr "O diário de vendas e o ponto de vendas devem pertencer à mesma companhia."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_config.py:255
+#: code:addons/point_of_sale/models/pos_config.py:258
 #, python-format
-msgid ""
-"The selected pricelists must belong to no company or the company of the "
-"point of sale."
-msgstr ""
-"As listas de preços selecionadas não devem pertencer a nenhuma empresa ou à "
-"empresa do ponto de venda."
+msgid "The selected pricelists must belong to no company or the company of the point of sale."
+msgstr "As listas de preços selecionadas não devem pertencer a nenhuma empresa ou à empresa do ponto de venda."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2081
+#: code:addons/point_of_sale/static/src/js/screens.js:230
 #, python-format
 msgid "The server encountered an error while receiving your order."
 msgstr "Houve um problema no servidor durante a recepção de seu pedido."
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_config_kanban
-msgid ""
-"The session has been opened for an unusually long period. Please consider "
-"closing."
-msgstr ""
-"A sessão está aberta por um período bem mais longo que o habitual. Por "
-"favor, considere encerrá-la."
+msgid "The session has been opened for an unusually long period. Please consider closing."
+msgstr "A sessão está aberta por um período bem mais longo que o habitual. Por favor, considere encerrá-la."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_config.py:222
+#: code:addons/point_of_sale/models/pos_config.py:225
 #, python-format
-msgid ""
-"The stock location and the point of sale must belong to the same company."
-msgstr ""
-"A localização do estoque e do ponto de venda devem pertencer à mesma "
-"companhia."
+msgid "The stock location and the point of sale must belong to the same company."
+msgstr "A localização do estoque e do ponto de venda devem pertencer à mesma companhia."
 
 #. module: point_of_sale
+#: model:ir.model.fields,help:point_of_sale.field_contact_config_settings__module_pos_mercury
 #: model:ir.model.fields,help:point_of_sale.field_res_config_settings__module_pos_mercury
 #: model_terms:ir.ui.view,arch_db:point_of_sale.res_config_settings_view_form
-msgid ""
-"The transactions are processed by Vantiv. Set your Vantiv credentials on the"
-" related payment journal."
-msgstr ""
-"As transações são processadas pela Vantiv. Defina suas credenciais Vantiv no"
-" diário de pagamento relacionado."
+msgid "The transactions are processed by Vantiv. Set your Vantiv credentials on the related payment journal."
+msgstr "As transações são processadas pela Vantiv. Defina suas credenciais Vantiv no diário de pagamento relacionado."
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_session__cash_register_balance_end
@@ -4259,35 +4000,24 @@ msgstr "Saldo Final Teórico"
 #. openerp-web
 #: code:addons/point_of_sale/static/src/xml/pos.xml:117
 #, python-format
-msgid ""
-"There are pending operations that could not be saved into the database, are "
-"you sure you want to exit?"
-msgstr ""
-"Existem operações pendentes que ainda não foram gravadas, você tem certeza "
-"de que quer sair?"
+msgid "There are pending operations that could not be saved into the database, are you sure you want to exit?"
+msgstr "Existem operações pendentes que ainda não foram gravadas, você tem certeza de que quer sair?"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.res_config_settings_view_form
-msgid ""
-"There are two ways to manage pricelists: 1) Multiple prices per product "
-"(e.g. quantity, shop-specific) : must be set in the Sales tab of the product"
-" detail form. 2) Price computed from formulas (discounts, margins, rounding)"
-" : must be set in the pricelist form."
-msgstr ""
-"Há duas formas de administrar listas de preços:\n"
+msgid "There are two ways to manage pricelists: 1) Multiple prices per product (e.g. quantity, shop-specific) : must be set in the Sales tab of the product detail form. 2) Price computed from formulas (discounts, margins, rounding) : must be set in the pricelist form."
+msgstr "Há duas formas de administrar listas de preços:\n"
 "1) múltiplos preços por produto (ex.: quantidade, específico por loja): deve ser configurado na aba de Vendas do formulário de detalhes do produto; e\n"
 "2) preço computado a partir de fórmulas (descontos, margens, arredondamento): deve ser configurado no formulário de lista de preço."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2017
+#: code:addons/point_of_sale/static/src/js/screens.js:2108
 #, python-format
-msgid ""
-"There is no cash payment method available in this point of sale to handle the change.\n"
+msgid "There is no cash payment method available in this point of sale to handle the change.\n"
 "\n"
 " Please pay the exact amount or add a cash payment method in the point of sale configuration"
-msgstr ""
-"Não existe um método de pagamento em dinheiro disponível neste ponto de venda para lidar com a alteração.\n"
+msgstr "Não existe um método de pagamento em dinheiro disponível neste ponto de venda para lidar com a alteração.\n"
 "\n"
 "Por favor, pague o valor exato ou adicione um método de pagamento em dinheiro na configuração do ponto de venda"
 
@@ -4298,28 +4028,22 @@ msgid "There is no cash register for this PoS Session"
 msgstr "Não tem nenhum caixa registradora para esta sessão do PdV"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:865
+#: code:addons/point_of_sale/models/pos_order.py:1013
 #, python-format
-msgid ""
-"There is no receivable account defined to make payment for the partner: "
-"\"%s\" (id:%d)."
-msgstr ""
-"Não há nenhuma conta a receber definida para fazer o pagamento para o "
-"cliente: \"%s\" (id:%d)."
+msgid "There is no receivable account defined to make payment for the partner: \"%s\" (id:%d)."
+msgstr "Não há nenhuma conta a receber definida para fazer o pagamento para o cliente: \"%s\" (id:%d)."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:863
+#: code:addons/point_of_sale/models/pos_order.py:1011
 #, python-format
 msgid "There is no receivable account defined to make payment."
-msgstr ""
-"Não existe nenhuma conta de recebimento configurada para fazer o pagamento."
+msgstr "Não existe nenhuma conta de recebimento configurada para fazer o pagamento."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1999
+#: code:addons/point_of_sale/static/src/js/screens.js:2090
 #, python-format
-msgid ""
-"There must be at least one product in your order before it can be validated"
+msgid "There must be at least one product in your order before it can be validated"
 msgstr "Só é possível validar um pedido se houver ao menos um produto nele."
 
 #. module: point_of_sale
@@ -4329,95 +4053,54 @@ msgstr "Isso permite a escolha da moeda nas listas de preço."
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_account_cashbox_line__default_pos_id
-msgid ""
-"This cashbox line is used by default when opening or closing a balance for "
-"this point of sale"
-msgstr ""
-"Esta linha de caixa é usada por padrão ao abrir ou fechar um saldo para este"
-" ponto de venda"
+msgid "This cashbox line is used by default when opening or closing a balance for this point of sale"
+msgstr "Esta linha de caixa é usada por padrão ao abrir ou fechar um saldo para este ponto de venda"
 
 #. module: point_of_sale
+#: model:ir.model.fields,help:point_of_sale.field_account_bank_statement_import_journal_creation__amount_authorized_diff
 #: model:ir.model.fields,help:point_of_sale.field_account_journal__amount_authorized_diff
-msgid ""
-"This field depicts the maximum difference allowed between the ending balance"
-" and the theoretical cash when closing a session, for non-POS managers. If "
-"this maximum is reached, the user will have an error message at the closing "
-"of his session saying that he needs to contact his manager."
-msgstr ""
-"Este campo mostra a diferença máxima permitida entre o saldo final eo "
-"dinheiro teórico ao fechar a sessão, para os gestores não-POS. Se esta "
-"máxima for atingida, o usuário terá uma mensagem de erro no encerramento de "
-"sua sessão dizendo que ele precisa entrar em contato com o seu gerente."
+msgid "This field depicts the maximum difference allowed between the ending balance and the theoretical cash when closing a session, for non-POS managers. If this maximum is reached, the user will have an error message at the closing of his session saying that he needs to contact his manager."
+msgstr "Este campo mostra a diferença máxima permitida entre o saldo final eo dinheiro teórico ao fechar a sessão, para os gestores não-POS. Se esta máxima for atingida, o usuário terá uma mensagem de erro no encerramento de sua sessão dizendo que ele precisa entrar em contato com o seu gerente."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_category__image
-msgid ""
-"This field holds the image used as image for the cateogry, limited to "
-"1024x1024px."
-msgstr ""
-"Este campo contém a imagem a ser usada na categoria, limitada a 1024x1024px."
+msgid "This field holds the image used as image for the cateogry, limited to 1024x1024px."
+msgstr "Este campo contém a imagem a ser usada na categoria, limitada a 1024x1024px."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__group_pos_manager_id
-msgid ""
-"This field is there to pass the id of the pos manager group to the point of "
-"sale client."
-msgstr ""
-"Este campo existe para passar o id do grupo do gerente de vendas ao cliente "
-"do ponto de venda."
+msgid "This field is there to pass the id of the pos manager group to the point of sale client."
+msgstr "Este campo existe para passar o id do grupo do gerente de vendas ao cliente do ponto de venda."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__group_pos_user_id
-msgid ""
-"This field is there to pass the id of the pos user group to the point of "
-"sale client."
-msgstr ""
-"Este campo existe para passar a identificação do grupo de usuários PdV para "
-"o cliente ponto de venda."
+msgid "This field is there to pass the id of the pos user group to the point of sale client."
+msgstr "Este campo existe para passar a identificação do grupo de usuários PdV para o cliente ponto de venda."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:622
+#: code:addons/point_of_sale/models/pos_order.py:752
 #, python-format
-msgid ""
-"This invoice has been created from the point of sale session: <a href=# "
-"data-oe-model=pos.order data-oe-id=%d>%s</a>"
-msgstr ""
-"Essa fatura foi criada a partir da sessão de ponto de venda: <a href=# data-"
-"oe-model=pos.order data-oe-id=%d>%s</a>"
+msgid "This invoice has been created from the point of sale session: <a href=# data-oe-model=pos.order data-oe-id=%d>%s</a>"
+msgstr "Essa fatura foi criada a partir da sessão de ponto de venda: <a href=# data-oe-model=pos.order data-oe-id=%d>%s</a>"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__fiscal_position_ids
-msgid ""
-"This is useful for restaurants with onsite and take-away services that imply"
-" specific tax rates."
-msgstr ""
-"Isso é útil em restaurantes com serviços no local e para viagem que "
-"acarretam em taxação específica."
+msgid "This is useful for restaurants with onsite and take-away services that imply specific tax rates."
+msgstr "Isso é útil em restaurantes com serviços no local e para viagem que acarretam em taxação específica."
 
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/chrome.js:275
 #, python-format
-msgid ""
-"This operation will destroy all unpaid orders in the browser. You will lose "
-"all the unsaved data and exit the point of sale. This operation cannot be "
-"undone."
-msgstr ""
-"Esta operação destruirá todos os pedidos não pagos do navegador. Você "
-"perderá todos os dados não salvos e sairá do ponto de venda. Esta operação é"
-" irreversível."
+msgid "This operation will destroy all unpaid orders in the browser. You will lose all the unsaved data and exit the point of sale. This operation cannot be undone."
+msgstr "Esta operação destruirá todos os pedidos não pagos do navegador. Você perderá todos os dados não salvos e sairá do ponto de venda. Esta operação é irreversível."
 
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/chrome.js:265
 #, python-format
-msgid ""
-"This operation will permanently destroy all paid orders from the local "
-"storage. You will lose all the data. This operation cannot be undone."
-msgstr ""
-"Esta operação irá destruir permanentemente todas as ordens não enviados a "
-"partir do armazenamento local. Você perderá todos os dados. Esta operação "
-"não pode ser desfeita."
+msgid "This operation will permanently destroy all paid orders from the local storage. You will lose all the data. This operation cannot be undone."
+msgstr "Esta operação irá destruir permanentemente todas as ordens não enviados a partir do armazenamento local. Você perderá todos os dados. Esta operação não pode ser desfeita."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__tip_product_id
@@ -4426,21 +4109,13 @@ msgstr "Este produto é usado como referência nos recibos dos clientes."
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__sequence_line_id
-msgid ""
-"This sequence is automatically created by Odoo but you can change it to "
-"customize the reference numbers of your orders lines."
-msgstr ""
-"Essa sequencia é criada automaticamente pelo Odoo mas vc pode mudar "
-"issocustomizando um número de referÊncia para as suas linhas de pedido"
+msgid "This sequence is automatically created by Odoo but you can change it to customize the reference numbers of your orders lines."
+msgstr "Essa sequencia é criada automaticamente pelo MultiERP mas vc pode mudar issocustomizando um número de referÊncia para as suas linhas de pedido"
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__sequence_id
-msgid ""
-"This sequence is automatically created by Odoo but you can change it to "
-"customize the reference numbers of your orders."
-msgstr ""
-"Esta sequência é criada automaticamente pelo Odoo mas você pode alterá-la "
-"para personalizar os números de referência das suas ordens."
+msgid "This sequence is automatically created by Odoo but you can change it to customize the reference numbers of your orders."
+msgstr "Esta sequência é criada automaticamente pelo MultiERP mas você pode alterá-la para personalizar os números de referência das suas ordens."
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.res_config_settings_view_form
@@ -4448,14 +4123,10 @@ msgid "This tax is applied to any new product created in the catalog."
 msgstr "Este imposto se aplica a qualquer produto novo criado no catálogo."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:726
+#: code:addons/point_of_sale/models/pos_order.py:869
 #, python-format
-msgid ""
-"This transfer has been created from the point of sale session: <a href=# "
-"data-oe-model=pos.order data-oe-id=%d>%s</a>"
-msgstr ""
-"Essa transferencia foi criada apartir do sessão POS: <a href=# data-oe-"
-"model=pos.order data-oe-id=%d>%s</a>"
+msgid "This transfer has been created from the point of sale session: <a href=# data-oe-model=pos.order data-oe-id=%d>%s</a>"
+msgstr "Essa transferencia foi criada apartir do sessão POS: <a href=# data-oe-model=pos.order data-oe-id=%d>%s</a>"
 
 #. module: point_of_sale
 #. openerp-web
@@ -4468,12 +4139,6 @@ msgstr "Dica"
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__tip_product_id
 msgid "Tip Product"
 msgstr "Dica de Produto"
-
-#. module: point_of_sale
-#: model:product.product,name:point_of_sale.product_product_tip
-#: model:product.template,name:point_of_sale.product_product_tip_product_template
-msgid "Tips"
-msgstr "Gorjetas"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_config_kanban
@@ -4492,20 +4157,16 @@ msgid "To record new orders, start a new session."
 msgstr "Para registrar novos pedidos, inicie uma nova sessão."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:906
+#: code:addons/point_of_sale/models/pos_order.py:1054
 #, python-format
-msgid ""
-"To return product(s), you need to open a session that will be used to "
-"register the refund."
-msgstr ""
-"Para devolver o(s) produto(s), você precisa abrir uma sessão que será usada "
-"para registrar o reembolso."
+msgid "To return product(s), you need to open a session that will be used to register the refund."
+msgstr "Para devolver o(s) produto(s), você precisa abrir uma sessão que será usada para registrar o reembolso."
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order__amount_total
 #: model_terms:ir.ui.view,arch_db:point_of_sale.report_saledetails
 msgid "Total"
-msgstr "Total"
+msgstr ""
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_session__cash_register_total_entry_encoding
@@ -4524,7 +4185,7 @@ msgstr "Preço Total"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:868
+#: code:addons/point_of_sale/static/src/xml/pos.xml:869
 #, python-format
 msgid "Total Taxes"
 msgstr "Total de Impostos"
@@ -4551,16 +4212,16 @@ msgstr "Qtd Total"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:967
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1320
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1514
+#: code:addons/point_of_sale/static/src/xml/pos.xml:968
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1321
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1515
 #: model_terms:ir.ui.view,arch_db:point_of_sale.report_saledetails
 #, python-format
 msgid "Total:"
-msgstr "Total:"
+msgstr ""
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:416
+#: code:addons/point_of_sale/models/pos_order.py:445
 #, python-format
 msgid "Trade Receivables"
 msgstr "Contas a Receber"
@@ -4573,12 +4234,8 @@ msgstr "Tipo"
 #. module: point_of_sale
 #: code:addons/point_of_sale/models/pos_session.py:179
 #, python-format
-msgid ""
-"Unable to open the session. You have to assign a sales journal to your point"
-" of sale."
-msgstr ""
-"Não foi possivel abrir a sessão. Vocçê precisa definir um Diario de Venda "
-"para essePOS."
+msgid "Unable to open the session. You have to assign a sales journal to your point of sale."
+msgstr "Não foi possivel abrir a sessão. Vocçê precisa definir um Diario de Venda para essePOS."
 
 #. module: point_of_sale
 #. openerp-web
@@ -4598,30 +4255,22 @@ msgid "Unit Product"
 msgstr "Produto Unitário"
 
 #. module: point_of_sale
-#: model:product.product,uom_name:point_of_sale.product_product_consumable
-#: model:product.product,uom_name:point_of_sale.product_product_tip
-#: model:product.template,uom_name:point_of_sale.product_product_consumable_product_template
-#: model:product.template,uom_name:point_of_sale.product_product_tip_product_template
-msgid "Unit(s)"
-msgstr "UN"
-
-#. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1036
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1037
 #, python-format
 msgid "Unknown Barcode"
 msgstr "Código de barras desconhecido"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2085
+#: code:addons/point_of_sale/static/src/js/screens.js:234
 #, python-format
 msgid "Unknown Error"
 msgstr "Erro desconhecido"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1363
+#: code:addons/point_of_sale/static/src/js/screens.js:1428
 #, python-format
 msgid "Unsupported File Format"
 msgstr "Formato de arquivo não suportado"
@@ -4652,6 +4301,7 @@ msgid "Use a virtual keyboard for touchscreens"
 msgstr "Usa um teclado virtual para TouchScreens"
 
 #. module: point_of_sale
+#: model:ir.model.fields,field_description:point_of_sale.field_account_bank_statement_import_journal_creation__journal_user
 #: model:ir.model.fields,field_description:point_of_sale.field_account_journal__journal_user
 msgid "Use in Point of Sale"
 msgstr "Use no Ponto de Venda"
@@ -4669,7 +4319,7 @@ msgstr "Rótulos do Usuário"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1456
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1457
 #, python-format
 msgid "User:"
 msgstr "Usuário:"
@@ -4682,18 +4332,18 @@ msgstr "Usuários"
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__uuid
 msgid "Uuid"
-msgstr "Uuid"
+msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:751
+#: code:addons/point_of_sale/static/src/xml/pos.xml:752
 #, python-format
 msgid "VAT:"
 msgstr "ICMS"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1271
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1272
 #, python-format
 msgid "Valid product lot"
 msgstr "Lote de produto válido"
@@ -4716,14 +4366,8 @@ msgid "Virtual KeyBoard"
 msgstr "Teclado virtual"
 
 #. module: point_of_sale
-#: model:product.product,name:point_of_sale.wall_shelf
-#: model:product.template,name:point_of_sale.wall_shelf_product_template
-msgid "Wall Shelf Unit"
-msgstr "Unidade de prateleira de parede"
-
-#. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1369
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1370
 #, python-format
 msgid "Weighing"
 msgstr "Pesagem"
@@ -4735,64 +4379,41 @@ msgstr "Produto Pesado"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
-msgid ""
-"Whenever you close a session, one entry is generated in the following "
-"accounting journal for all the orders not invoiced. Invoices are recorded in"
-" accounting separately."
-msgstr ""
-"Ao encerrar uma sessão, uma entrada é gerada no seguinte diário contábil "
-"para todos os pedidos não faturados. Faturas são registradas contabilmente "
-"separadamente."
-
-#. module: point_of_sale
-#: model:product.product,name:point_of_sale.whiteboard
-#: model:product.template,name:point_of_sale.whiteboard_product_template
-msgid "Whiteboard"
-msgstr "Quadro branco"
+msgid "Whenever you close a session, one entry is generated in the following accounting journal for all the orders not invoiced. Invoices are recorded in accounting separately."
+msgstr "Ao encerrar uma sessão, uma entrada é gerada no seguinte diário contábil para todos os pedidos não faturados. Faturas são registradas contabilmente separadamente."
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
-#: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
-#: model:product.product,name:point_of_sale.whiteboard_pen
-#: model:product.template,name:point_of_sale.whiteboard_pen_product_template
 msgid "Whiteboard Pen"
 msgstr "Caneta do quadro branco"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1293
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1476
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1294
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1477
 #, python-format
 msgid "With a"
 msgstr "Com um(a)"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_session_form
-msgid ""
-"You can define another list of available currencies on the\n"
+msgid "You can define another list of available currencies on the\n"
 "                                    <i>Cash Registers</i> tab of the"
-msgstr ""
-"Você pode definir outra lista de moedas disponíveis no\n"
+msgstr "Você pode definir outra lista de moedas disponíveis no\n"
 "Guia de <i>Caixas Registradoras</i> do"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:558
+#: code:addons/point_of_sale/models/pos_order.py:691
 #, python-format
-msgid ""
-"You cannot change the partner of a POS order for which an invoice has "
-"already been issued."
-msgstr ""
-"Você não pode alterar o cliente de uma ordem de PDV para a qual já foi "
-"emitida uma fatura."
+msgid "You cannot change the partner of a POS order for which an invoice has already been issued."
+msgstr "Você não pode alterar o cliente de uma ordem de PDV para a qual já foi emitida uma fatura."
 
 #. module: point_of_sale
 #: code:addons/point_of_sale/models/pos_session.py:34
 #, python-format
-msgid ""
-"You cannot confirm all orders of this session, because they have not the 'paid' status.\n"
+msgid "You cannot confirm all orders of this session, because they have not the 'paid' status.\n"
 "{reference} is in state {state}, total amount: {total}, paid: {paid}"
-msgstr ""
-"Você não pode confirmar todos os pedidos desta sessão, porque eles não têm o status 'pago'.\n"
+msgstr "Você não pode confirmar todos os pedidos desta sessão, porque eles não têm o status 'pago'.\n"
 "{reference} está no estado {state}, valor total: {total}, pago: {paid}"
 
 #. module: point_of_sale
@@ -4802,62 +4423,40 @@ msgid "You cannot create two active sessions with the same responsible."
 msgstr "Não é possível criar duas sessões ativas com o mesmo responsável."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/product.py:21
-#: code:addons/point_of_sale/models/product.py:38
+#: code:addons/point_of_sale/models/product.py:27
+#: code:addons/point_of_sale/models/product.py:51
 #, python-format
-msgid ""
-"You cannot delete a product saleable in point of sale while a session is "
-"still opened."
-msgstr ""
-"Você não pode excluir um produto vendável no ponto de venda, enquanto uma "
-"sessão ainda está aberta."
+msgid "You cannot delete a product saleable in point of sale while a session is still opened."
+msgstr "Você não pode excluir um produto vendável no ponto de venda, enquanto uma sessão ainda está aberta."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_session.py:300
+#: code:addons/point_of_sale/models/pos_session.py:306
 #, python-format
-msgid ""
-"You cannot use the session of another user. This session is owned by %s. "
-"Please first close this one to use this point of sale."
-msgstr ""
-"Você não pode usar uma sessão de outro usuário. Essa sessão pertence a: "
-"%sPor favor primeiro feche a sessão e depois abra neste POS"
+msgid "You cannot use the session of another user. This session is owned by %s. Please first close this one to use this point of sale."
+msgstr "Você não pode usar uma sessão de outro usuário. Essa sessão pertence a: %sPor favor primeiro feche a sessão e depois abra neste POS"
 
 #. module: point_of_sale
 #: code:addons/point_of_sale/wizard/pos_open_statement.py:18
 #, python-format
-msgid ""
-"You have to define which payment method must be available in the point of "
-"sale by reusing existing bank and cash through \"Accounting / Configuration "
-"/ Journals / Journals\". Select a journal and check the field \"PoS Payment "
-"Method\" from the \"Point of Sale\" tab. You can also create new payment "
-"methods directly from menu \"PoS Backend / Configuration / Payment "
-"Methods\"."
-msgstr ""
-"Você tem que definir qual o método de pagamento deve estar disponível no "
-"ponto de venda através da reutilização de banco e dinheiro existente através"
-" de \"Contabilidade / Configurações / Diários / Diários\". Selecione um "
-"diário e deixe o campo \"PdV Forma de Pagamento\" da aba \"Ponto de Venda\"."
-" Você também pode criar novos métodos de pagamento diretamente a partir do "
-"menu \"PdV Backend / Configurações / Métodos de pagamento\"."
+msgid "You have to define which payment method must be available in the point of sale by reusing existing bank and cash through \"Accounting / Configuration / Journals / Journals\". Select a journal and check the field \"PoS Payment Method\" from the \"Point of Sale\" tab. You can also create new payment methods directly from menu \"PoS Backend / Configuration / Payment Methods\"."
+msgstr "Você tem que definir qual o método de pagamento deve estar disponível no ponto de venda através da reutilização de banco e dinheiro existente através de \"Contabilidade / Configurações / Diários / Diários\". Selecione um diário e deixe o campo \"PdV Forma de Pagamento\" da aba \"Ponto de Venda\". Você também pode criar novos métodos de pagamento diretamente a partir do menu \"PdV Backend / Configurações / Métodos de pagamento\"."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:879
+#: code:addons/point_of_sale/models/pos_order.py:1027
 #, python-format
 msgid "You have to open at least one cashbox."
 msgstr "Você precisa abrir pelo menos uma Caixa Registradora"
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:1026
+#: code:addons/point_of_sale/models/pos_order.py:1174
 #, python-format
-msgid ""
-"You have to select a pricelist in the sale form !\n"
+msgid "You have to select a pricelist in the sale form !\n"
 "Please set one before choosing a product."
-msgstr ""
-"Selecione uma lista de preços, no formulário de venda!\n"
+msgstr "Selecione uma lista de preços, no formulário de venda!\n"
 "Por favor, defina uma antes de escolher um produto."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_order.py:1040
+#: code:addons/point_of_sale/models/pos_order.py:1188
 #, python-format
 msgid "You have to select a pricelist in the sale form."
 msgstr "Selecione uma lista de preços no formulário de venda."
@@ -4882,16 +4481,14 @@ msgstr "Você precisa definir o layout de cabeçalho e rodapé do relatório."
 
 #. module: point_of_sale
 #: model_terms:ir.actions.act_window,help:point_of_sale.product_product_action
-msgid ""
-"You must define a product for everything you sell through\n"
+msgid "You must define a product for everything you sell through\n"
 "                the point of sale interface."
-msgstr ""
-"Você deve definir um produto para tudo que você vende através\n"
+msgstr "Você deve definir um produto para tudo que você vende através\n"
 "a interface do ponto de venda."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2068
+#: code:addons/point_of_sale/static/src/js/screens.js:203
 #, python-format
 msgid "You need to select the customer before you can invoice an order."
 msgstr "Selecione um cliente antes de faturar um pedido."
@@ -4911,26 +4508,20 @@ msgstr "Você perderá todos os dados associados com a ordem atual"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:1301
+#: code:addons/point_of_sale/static/src/js/screens.js:1363
 #, python-format
 msgid "Your Internet connection is probably down."
 msgstr "A ligação à Internet é provavelmente baixo."
 
 #. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_session.py:282
+#: code:addons/point_of_sale/models/pos_session.py:288
 #, python-format
-msgid ""
-"Your ending balance is too different from the theoretical cash closing "
-"(%.2f), the maximum allowed is: %.2f. You can contact your manager to force "
-"it."
-msgstr ""
-"O seu saldo final é muito diferente do dinheiro teórico de fechamento "
-"(%.2f), o máximo permitido é:%.2f. Você pode entrar em contato com seu "
-"gerente para forçá-lo."
+msgid "Your ending balance is too different from the theoretical cash closing (%.2f), the maximum allowed is: %.2f. You can contact your manager to force it."
+msgstr "O seu saldo final é muito diferente do dinheiro teórico de fechamento (%.2f), o máximo permitido é:%.2f. Você pode entrar em contato com seu gerente para forçá-lo."
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1312
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1313
 #, python-format
 msgid "Your shopping cart is empty"
 msgstr "Seu Carrinho de Compras está vazio"
@@ -4944,44 +4535,44 @@ msgstr "CEP"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1285
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1286
 #, python-format
 msgid "at"
 msgstr "em"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1222
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1223
 #, python-format
 msgid "belong to another session:"
 msgstr "pertence a outra sessão:"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1581
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1582
 #, python-format
 msgid "caps lock"
-msgstr "caps lock"
+msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1608
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1650
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1609
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1651
 #, python-format
 msgid "close"
 msgstr "fechar"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1566
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1643
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1567
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1644
 #, python-format
 msgid "delete"
 msgstr "excluir"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1295
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1296
 #, python-format
 msgid "discount"
 msgstr "desconto"
@@ -5005,65 +4596,13 @@ msgstr "erro"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/js/screens.js:2031
+#: code:addons/point_of_sale/static/src/js/screens.js:2122
 #, python-format
 msgid "for an order of"
 msgstr "para um pedido de"
 
 #. module: point_of_sale
-#: model:product.product,uom_name:point_of_sale.desk_organizer
-#: model:product.product,uom_name:point_of_sale.desk_pad
-#: model:product.product,uom_name:point_of_sale.led_lamp
-#: model:product.product,uom_name:point_of_sale.letter_tray
-#: model:product.product,uom_name:point_of_sale.magnetic_board
-#: model:product.product,uom_name:point_of_sale.monitor_stand
-#: model:product.product,uom_name:point_of_sale.newspaper_rack
-#: model:product.product,uom_name:point_of_sale.small_shelf
-#: model:product.product,uom_name:point_of_sale.wall_shelf
-#: model:product.product,uom_name:point_of_sale.whiteboard
-#: model:product.product,uom_name:point_of_sale.whiteboard_pen
-#: model:product.product,weight_uom_name:point_of_sale.desk_organizer
-#: model:product.product,weight_uom_name:point_of_sale.desk_pad
-#: model:product.product,weight_uom_name:point_of_sale.led_lamp
-#: model:product.product,weight_uom_name:point_of_sale.letter_tray
-#: model:product.product,weight_uom_name:point_of_sale.magnetic_board
-#: model:product.product,weight_uom_name:point_of_sale.monitor_stand
-#: model:product.product,weight_uom_name:point_of_sale.newspaper_rack
-#: model:product.product,weight_uom_name:point_of_sale.product_product_consumable
-#: model:product.product,weight_uom_name:point_of_sale.product_product_tip
-#: model:product.product,weight_uom_name:point_of_sale.small_shelf
-#: model:product.product,weight_uom_name:point_of_sale.wall_shelf
-#: model:product.product,weight_uom_name:point_of_sale.whiteboard
-#: model:product.product,weight_uom_name:point_of_sale.whiteboard_pen
-#: model:product.template,uom_name:point_of_sale.desk_organizer_product_template
-#: model:product.template,uom_name:point_of_sale.desk_pad_product_template
-#: model:product.template,uom_name:point_of_sale.led_lamp_product_template
-#: model:product.template,uom_name:point_of_sale.letter_tray_product_template
-#: model:product.template,uom_name:point_of_sale.magnetic_board_product_template
-#: model:product.template,uom_name:point_of_sale.monitor_stand_product_template
-#: model:product.template,uom_name:point_of_sale.newspaper_rack_product_template
-#: model:product.template,uom_name:point_of_sale.small_shelf_product_template
-#: model:product.template,uom_name:point_of_sale.wall_shelf_product_template
-#: model:product.template,uom_name:point_of_sale.whiteboard_pen_product_template
-#: model:product.template,uom_name:point_of_sale.whiteboard_product_template
-#: model:product.template,weight_uom_name:point_of_sale.desk_organizer_product_template
-#: model:product.template,weight_uom_name:point_of_sale.desk_pad_product_template
-#: model:product.template,weight_uom_name:point_of_sale.led_lamp_product_template
-#: model:product.template,weight_uom_name:point_of_sale.letter_tray_product_template
-#: model:product.template,weight_uom_name:point_of_sale.magnetic_board_product_template
-#: model:product.template,weight_uom_name:point_of_sale.monitor_stand_product_template
-#: model:product.template,weight_uom_name:point_of_sale.newspaper_rack_product_template
-#: model:product.template,weight_uom_name:point_of_sale.product_product_consumable_product_template
-#: model:product.template,weight_uom_name:point_of_sale.product_product_tip_product_template
-#: model:product.template,weight_uom_name:point_of_sale.small_shelf_product_template
-#: model:product.template,weight_uom_name:point_of_sale.wall_shelf_product_template
-#: model:product.template,weight_uom_name:point_of_sale.whiteboard_pen_product_template
-#: model:product.template,weight_uom_name:point_of_sale.whiteboard_product_template
-msgid "kg"
-msgstr "kg"
-
-#. module: point_of_sale
-#: code:addons/point_of_sale/models/pos_config.py:336
+#: code:addons/point_of_sale/models/pos_config.py:339
 #, python-format
 msgid "not used"
 msgstr "não usado"
@@ -5071,7 +4610,7 @@ msgstr "não usado"
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/chrome.js:294
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1216
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1217
 #, python-format
 msgid "paid orders"
 msgstr "pedidos pagos"
@@ -5084,23 +4623,23 @@ msgstr "método de pagamento"
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/models/pos_order.py:152
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1593
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1648
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1594
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1649
 #, python-format
 msgid "return"
 msgstr "retornar"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1594
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1605
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1595
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1606
 #, python-format
 msgid "shift"
-msgstr "shift"
+msgstr ""
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1567
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1568
 #, python-format
 msgid "tab"
 msgstr "aba"
@@ -5108,21 +4647,22 @@ msgstr "aba"
 #. module: point_of_sale
 #. openerp-web
 #: code:addons/point_of_sale/static/src/js/chrome.js:286
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1217
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1218
 #, python-format
 msgid "unpaid orders"
 msgstr "pedidos sem pagametnos"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1219
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1220
 #, python-format
 msgid "unpaid orders could not be imported"
 msgstr "pedidos sem pagamentos não podem ser importados"
 
 #. module: point_of_sale
 #. openerp-web
-#: code:addons/point_of_sale/static/src/xml/pos.xml:1221
+#: code:addons/point_of_sale/static/src/xml/pos.xml:1222
 #, python-format
 msgid "were duplicates of existing orders"
 msgstr "foram duplicadas de pedidos existentes"
+

--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -13,6 +13,12 @@ class ProductTemplate(models.Model):
         'pos.category', string='Point of Sale Category',
         help="Category used in the Point of Sale.")
 
+    show_root_category = fields.Boolean( # Adicionado pela Multidados
+        string='Show in Root Category',
+        help='Check if you want this product to appear in the Point of Sale root category.',
+        default=False,
+    )
+
     @api.multi
     def unlink(self):
         product_ctx = dict(self.env.context or {}, active_test=False)
@@ -29,6 +35,13 @@ class ProductTemplate(models.Model):
 
 class ProductProduct(models.Model):
     _inherit = 'product.product'
+
+    show_root_category = fields.Boolean( # Adicionado pela Multidados
+        string='Show in Root Category',
+        help='Check if you want this product to appear in the Point of Sale root category.',
+        related='product_tmpl_id.show_root_category',
+        store=True,
+    )
 
     @api.multi
     def unlink(self):

--- a/addons/point_of_sale/static/src/js/db.js
+++ b/addons/point_of_sale/static/src/js/db.js
@@ -14,7 +14,7 @@ var PosDB = core.Class.extend({
         options = options || {};
         this.name = options.name || this.name;
         this.limit = options.limit || this.limit;
-        
+
         if (options.uuid) {
             this.name = this.name + '_' + options.uuid;
         }
@@ -41,7 +41,7 @@ var PosDB = core.Class.extend({
         this.category_search_string = {};
     },
 
-    /* 
+    /*
      * sets an uuid to prevent conflict in locally stored data between multiple databases running
      * in the same browser at the same origin (Doing this is not advised !)
      */
@@ -50,8 +50,8 @@ var PosDB = core.Class.extend({
     },
 
     /* returns the category object from its id. If you pass a list of id as parameters, you get
-     * a list of category objects. 
-     */  
+     * a list of category objects.
+     */
     get_category_by_id: function(categ_id){
         if(categ_id instanceof Array){
             var list = [];
@@ -68,7 +68,7 @@ var PosDB = core.Class.extend({
             return this.category_by_id[categ_id];
         }
     },
-    /* returns a list of the category's child categories ids, or an empty list 
+    /* returns a list of the category's child categories ids, or an empty list
      * if a category has no childs */
     get_category_childs_ids: function(categ_id){
         return this.category_childs[categ_id] || [];
@@ -84,7 +84,7 @@ var PosDB = core.Class.extend({
         return this.category_parent[categ_id] || this.root_category_id;
     },
     /* adds categories definitions to the database. categories is a list of categories objects as
-     * returned by the openerp server. Categories must be inserted before the products or the 
+     * returned by the openerp server. Categories must be inserted before the products or the
      * product/ categories association may (will) not work properly */
     add_categories: function(categories){
         var self = this;
@@ -200,7 +200,7 @@ var PosDB = core.Class.extend({
                 if( this.category_search_string[ancestor] === undefined){
                     this.category_search_string[ancestor] = '';
                 }
-                this.category_search_string[ancestor] += search_string; 
+                this.category_search_string[ancestor] += search_string;
             }
             this.product_by_id[product.id] = product;
             if(product.barcode){
@@ -247,9 +247,9 @@ var PosDB = core.Class.extend({
                 // FIXME: The write_date is stored with milisec precision in the database
                 // but the dates we get back are only precise to the second. This means when
                 // you read partners modified strictly after time X, you get back partners that were
-                // modified X - 1 sec ago. 
+                // modified X - 1 sec ago.
                 continue;
-            } else if ( new_write_date < partner.write_date ) { 
+            } else if ( new_write_date < partner.write_date ) {
                 new_write_date  = partner.write_date;
             }
             if (!this.partner_by_id[partner.id]) {
@@ -263,7 +263,7 @@ var PosDB = core.Class.extend({
         this.partner_write_date = new_write_date || this.partner_write_date;
 
         if (updated_count) {
-            // If there were updates, we need to completely 
+            // If there were updates, we need to completely
             // rebuild the search string and the barcode indexing
 
             this.partner_search_string = "";
@@ -275,9 +275,9 @@ var PosDB = core.Class.extend({
                 if(partner.barcode){
                     this.partner_by_barcode[partner.barcode] = partner;
                 }
-                partner.address = (partner.street || '') +', '+ 
+                partner.address = (partner.street || '') +', '+
                                   (partner.zip || '')    +' '+
-                                  (partner.city || '')   +', '+ 
+                                  (partner.city || '')   +', '+
                                   (partner.country_id[1] || '');
                 this.partner_search_string += this._partner_search_string(partner);
             }
@@ -352,14 +352,16 @@ var PosDB = core.Class.extend({
         var list = [];
         if (product_ids) {
             for (var i = 0, len = Math.min(product_ids.length, this.limit); i < len; i++) {
-                list.push(this.product_by_id[product_ids[i]]);
+                if (category_id !== 0 || this.product_by_id[product_ids[i]].show_root_category){
+                    list.push(this.product_by_id[product_ids[i]]);
+                }
             }
         }
         return list;
     },
     /* returns a list of products with :
      * - a category that is or is a child of category_id,
-     * - a name, package or barcode containing the query (case insensitive) 
+     * - a name, package or barcode containing the query (case insensitive)
      */
     search_product_in_category: function(category_id, query){
         try {

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -23,12 +23,12 @@ var round_pr = utils.round_precision;
 var exports = {};
 
 // The PosModel contains the Point Of Sale's representation of the backend.
-// Since the PoS must work in standalone ( Without connection to the server ) 
-// it must contains a representation of the server's PoS backend. 
+// Since the PoS must work in standalone ( Without connection to the server )
+// it must contains a representation of the server's PoS backend.
 // (taxes, product list, configuration options, etc.)  this representation
-// is fetched and stored by the PosModel at the initialisation. 
-// this is done asynchronously, a ready deferred alows the GUI to wait interactively 
-// for the loading to be completed 
+// is fetched and stored by the PosModel at the initialisation.
+// this is done asynchronously, a ready deferred alows the GUI to wait interactively
+// for the loading to be completed
 // There is a single instance of the PosModel for each Front-End instance, it is usually called
 // 'pos' and is available to all widgets extending PosWidget.
 
@@ -89,7 +89,7 @@ exports.PosModel = Backbone.Model.extend({
 
         // We fetch the backend data on the server asynchronously. this is done only when the pos user interface is launched,
         // Any change on this data made on the server is thus not reflected on the point of sale until it is relaunched.
-        // when all the data has loaded, we compute some stuff, and declare the Pos ready to be used. 
+        // when all the data has loaded, we compute some stuff, and declare the Pos ready to be used.
         this.ready = this.load_server_data().then(function(){
             return self.after_load_server_data();
         });
@@ -369,7 +369,7 @@ exports.PosModel = Backbone.Model.extend({
         // todo remove list_price in master, it is unused
         fields: ['display_name', 'list_price', 'lst_price', 'standard_price', 'categ_id', 'pos_categ_id', 'taxes_id',
                  'barcode', 'default_code', 'to_weight', 'uom_id', 'description_sale', 'description',
-                 'product_tmpl_id','tracking'],
+                 'product_tmpl_id','tracking', 'show_root_category'],
         order:  _.map(['sequence','default_code','name'], function (name) { return {name: name}; }),
         domain: [['sale_ok','=',true],['available_in_pos','=',true]],
         context: function(self){ return { display_default_code: false }; },
@@ -1177,7 +1177,7 @@ exports.load_fields = function(model_name, fields) {
 
 // Loads openerp models at the point of sale startup.
 // load_models take an array of model loader declarations.
-// - The models will be loaded in the array order. 
+// - The models will be loaded in the array order.
 // - If no openerp model name is provided, no server data
 //   will be loaded, but the system can be used to preprocess
 //   data before load.
@@ -1193,9 +1193,9 @@ exports.load_fields = function(model_name, fields) {
 // models: [{
 //  model: [string] the name of the openerp model to load.
 //  label: [string] The label displayed during load.
-//  fields: [[string]|function] the list of fields to be loaded. 
+//  fields: [[string]|function] the list of fields to be loaded.
 //          Empty Array / Null loads all fields.
-//  order:  [[string]|function] the models will be ordered by 
+//  order:  [[string]|function] the models will be ordered by
 //          the provided fields
 //  domain: [domain|function] the domain that determines what
 //          models need to be loaded. Null loads everything
@@ -1204,7 +1204,7 @@ exports.load_fields = function(model_name, fields) {
 //  context: [Dict|function] the openerp context for the model read
 //  condition: [function] do not load the models if it evaluates to
 //             false.
-//  loaded: [function(self,model)] this function is called once the 
+//  loaded: [function(self,model)] this function is called once the
 //          models have been loaded, with the data as second argument
 //          if the function returns a deferred, the next model will
 //          wait until it resolves before loading.
@@ -1336,7 +1336,7 @@ exports.Product = Backbone.Model.extend({
 var orderline_id = 1;
 
 // An orderline represent one element of the content of a client's shopping cart.
-// An orderline contains a product, its quantity, its price, discount. etc. 
+// An orderline contains a product, its quantity, its price, discount. etc.
 // An Order contains zero or more Orderlines.
 exports.Orderline = Backbone.Model.extend({
     initialize: function(attr,options){
@@ -1570,7 +1570,7 @@ exports.Orderline = Backbone.Model.extend({
         }
         return price;
     },
- 
+
     merge: function(orderline){
         this.order.assert_editable();
         this.set_quantity(this.get_quantity() + orderline.get_quantity());
@@ -1979,8 +1979,8 @@ var PaymentlineCollection = Backbone.Collection.extend({
     model: exports.Paymentline,
 });
 
-// An order more or less represents the content of a client's shopping cart (the OrderLines) 
-// plus the associated payment information (the Paymentlines) 
+// An order more or less represents the content of a client's shopping cart (the OrderLines)
+// plus the associated payment information (the Paymentlines)
 // there is always an active ('selected') order in the Pos, a new one is created
 // automaticaly once an order is completed and sent to the server.
 exports.Order = Backbone.Model.extend({

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -56,6 +56,7 @@
                 <group name="pos" string="Point Of Sale">
                     <group>
                         <field name="available_in_pos"/>
+                        <field name="show_root_category"/>
                         <field name="pos_categ_id" attrs="{'invisible': [('available_in_pos', '=', False)]}" string="Category"/>
                         <field name="to_weight" attrs="{'invisible': [('available_in_pos', '=', False)]}"/>
                     </group>


### PR DESCRIPTION
# Descrição

- [IMP] Adicionando campo da categoria 'Root' aos produtos
- Campo criado para definir se o produto irá aparecer na tela da
    categoria principal dos produtos no POS. Será possivel alterar
    o campo no form do 'product.template'

# Informações adicionais

- [T5559](https://multi.multidadosti.com.br/web?#id=5968&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/657)
