### PR TITLE
T5570 - Acertar tradução de "parceiros" para "fornecedores no cadastro de Produto na Aba Compra

### DIFF
--- a/addons/product/i18n/pt_BR.po
+++ b/addons/product/i18n/pt_BR.po
@@ -1835,7 +1835,7 @@ msgstr "Preço público"
 #. module: product
 #: model_terms:ir.ui.view,arch_db:product.product_template_form_view
 msgid "Purchase"
-msgstr "Compra"
+msgstr "Compras"
 
 #. module: product
 #: model:ir.model.fields,field_description:product.field_product_product__description_purchase
@@ -2632,7 +2632,7 @@ msgstr "Fornecedor deste produto"
 #: model:ir.model.fields,field_description:product.field_product_product__seller_ids
 #: model:ir.model.fields,field_description:product.field_product_template__seller_ids
 msgid "Vendors"
-msgstr "Parceiros"
+msgstr "Fornecedores"
 
 #. module: product
 #: model:product.product,name:product.product_product_2

--- a/addons/purchase/i18n/pt_BR.po
+++ b/addons/purchase/i18n/pt_BR.po
@@ -2115,7 +2115,7 @@ msgstr "Ref. de Fornecedor"
 #: model:ir.ui.menu,name:purchase.menu_procurement_management_supplier_name
 #: model_terms:ir.ui.view,arch_db:purchase.view_product_supplier_inherit
 msgid "Vendors"
-msgstr "Parceiros"
+msgstr "Fornecedores"
 
 #. module: purchase
 #: model_terms:ir.actions.act_window,help:purchase.act_res_partner_2_supplier_invoices


### PR DESCRIPTION
# Descrição

- [IMP] Corrige a tradução de 'Vendors'

# Informações adicionais

- [T5570](https://multi.multidadosti.com.br/web#id=5979&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/659)