### PR TITLE
T5597 - Criação de inventário não adiciona produtos sem estoque

### DIFF
--- a/addons/stock/i18n/pt_BR.po
+++ b/addons/stock/i18n/pt_BR.po
@@ -2497,7 +2497,7 @@ msgstr "No Tipo"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_inventory__exhausted
 msgid "Include Exhausted Products"
-msgstr "Inclua Produtos Esgotados"
+msgstr "Incluir Produtos Esgotados (sem estoque)"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_product__incoming_qty

--- a/addons/stock/views/stock_inventory_views.xml
+++ b/addons/stock/views/stock_inventory_views.xml
@@ -154,7 +154,8 @@
                         <field name="lot_id" attrs="{'invisible': [('filter', '!=', 'lot')], 'required': [('filter', '=', 'lot')]}" groups="stock.group_production_lot" />
                         <field name="partner_id" attrs="{'invisible': [('filter', 'not in', ('owner', 'product_owner'))], 'required': [('filter', 'in', ('owner', 'product_owner'))]}" groups="stock.group_tracking_owner"/>
                         <field name="package_id" attrs="{'invisible': [('filter', '!=', 'pack')], 'required': [('filter', '=', 'pack')]}" groups="stock.group_tracking_lot"/>
-                        <field name="exhausted" attrs="{'invisible': [('filter', 'in', ('owner', 'product_owner','lot','pack','partial', 'product'))]}"/>
+                        <separator/>
+                        <field name="exhausted" attrs="{'invisible': [('filter', 'in', ('owner', 'product_owner','lot','pack','partial', 'product'))]}" />
                     </group>
                 </group>
                 <notebook attrs="{'invisible':[('state','=','draft')]}">


### PR DESCRIPTION
# Descrição

* [IMP] Melhora descrição do filtro na tela de inventario de estoque

Adiciona uma texto mais descrivo para o checkbox de adicionar produtos esgotados e melhora o posicionamento do campo na tela.

# Informações adicionais

![screenshot_1](https://user-images.githubusercontent.com/8174740/127048667-80e75f2e-4243-40ea-a0ec-8aeb56a1ab95.png)

Dados da tarefa: [T5597](https://multi.multidadosti.com.br/web#id=6006&action=323&active_id=61&model=project.task&view_type=form&menu_id=
)

PR relacionado: https://github.com/multidadosti-erp/odoo-brasil-addons/pull/677
