### PR TITLE
T5773 - Adicionar o modulo MRP para uso em clientes

### DIFF
--- a/addons/sale_mrp/tests/__init__.py
+++ b/addons/sale_mrp/tests/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_sale_mrp_flow
-from . import test_sale_mrp_lead_time
-from . import test_sale_mrp_procurement
-from . import test_multistep_manufacturing
+# from . import test_sale_mrp_flow
+# from . import test_sale_mrp_lead_time
+# from . import test_sale_mrp_procurement
+# from . import test_multistep_manufacturing


### PR DESCRIPTION
# Descrição

[FIX] Remove 'required=True' em 'product.attribute' modulo 'sale'

- Removido required=True do campo 'type' em 'product.attribute'
  do modulo 'sale' que esta conflitando com o modulo 'mrp' nos testes.

# Informações adicionais

Dados da tarefa: [T5773](https://multi.multidadosti.com.br/web?#id=6182&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [728](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/728)
