### PR TITLE
T5850 - O sistema esta filtrando de forma errada os clientes no POS

### DIFF
--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -32,3 +32,8 @@ class ResPartner(models.Model):
             partner['lang'] = self.env.user.lang
             partner_id = self.create(partner).id
         return partner_id
+
+    def get_allowed_partner_ids(self):
+        """Adiciona método no core para evitar erro no POS."""
+        # Adicionado pela Multidados
+        pass

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -203,6 +203,14 @@ exports.PosModel = Backbone.Model.extend({
         domain: [['customer','=',true]],
         loaded: function(self,partners){
             self.partners = partners;
+            rpc.query({
+                model: 'res.partner',
+                method: 'get_allowed_partner_ids',
+                args: [0],
+            }).then(function (result){
+                self.partner_ids_allowed = result;
+                self.partner_security_domain = ['id', 'in', result];
+            });
             self.db.add_partners(partners);
         },
     },{


### PR DESCRIPTION
# Descrição

- [FIX] Corrigindo filtro de Parceiros no POS
- Foi adicionado o comportamento de criar 2 campos para o objeto do POS para serem utilizados em outros lugares. Os campos são criados ao iniciar a model de 'res.partner'

Descrição do PR

# Informações adicionais

- [T5850](https://multi.multidados.tech/web?debug=#id=6259&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/759)