### PR TITLE
T5857 - Para Correção da Tarefa: T5837 - Bug nas atividades de prospectos

### DIFF
--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -446,18 +446,24 @@ var BasicActivity = AbstractField.extend({
      * @returns {$.Promise}
      */
     _onUnlinkActivity: function (ev, options) {
+        // Editado pela Multidados para não excluir uma atividade cancelada.
         ev.preventDefault();
         var activityID = $(ev.currentTarget).data('activity-id');
         options = _.defaults(options || {}, {
             model: 'mail.activity',
             args: [[activityID]],
         });
+        // Atualizando contexto
+        var context = this.record.getContext();
+        context.cancelling_activity = true;
+
         return this._rpc({
-                model: options.model,
-                method: 'unlink',
-                args: options.args,
-            })
-            .then(this._reload.bind(this, {activity: true}));
+            model: options.model,
+            method: 'unlink',
+            args: options.args,
+            context: context,
+        })
+        .then(this._reload.bind(this, {activity: true}));
     },
 });
 


### PR DESCRIPTION
# Descrição

- [FIX] Adicionando parâmetro no contexto para cancelar a atividade
  - A atividade deve ser cancelada e não excluida da base de dados.

# Informações adicionais

- [T5857](https://multi.multidados.tech/web?#id=6266&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [private-addons](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/680)