### PR TITLE
T5958 - Erro no Odoo ref as Tabelas/Views criadas pelo Modulo ks_custom_report

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -331,6 +331,17 @@ class Registry(Mapping):
         table2model = {model._table: name for name, model in env.items() if not model._abstract}
         missing_tables = set(table2model).difference(existing_tables(cr, table2model))
 
+        # Correção: Multidados
+        # Ignorando a Verificação de Tabelas Criadas pelo sistema
+        # com inicio = x_ks_cr
+        ignore_missing_tables = []
+        for table in missing_tables:
+            if 'x_ks_cr' in table2model[table]:
+                ignore_missing_tables.append(table)
+        # Removendo tabelas a Ignorar do SET missing_tables
+        for table in ignore_missing_tables:
+            missing_tables.discard(table)
+
         if missing_tables:
             missing = {table2model[table] for table in missing_tables}
             _logger.warning("Models have no table: %s.", ", ".join(missing))


### PR DESCRIPTION
# Descrição
[IMP] Adiciona tratamento para tabela externas modulo 'registry.py'

- Adiciona tratamento para ignorar tabelas iniciadas com
  = 'x_ks_cr'

# Informações adicionais

Dados da tarefa: [T5958](https://multi.multidados.tech/web?debug#id=6367&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)
