### PR TITLE
T5580 - Erro ao importar XML de compras (Valor Total e Parcelas)

### DIFF
--- a/addons/web/static/src/js/services/crash_manager.js
+++ b/addons/web/static/src/js/services/crash_manager.js
@@ -211,7 +211,19 @@ var RedirectWarningHandler = Dialog.extend(ExceptionHandler, {
             title: _.str.capitalize(error.type) || _t("Odoo Warning"),
             buttons: [
                 {text: error.data.arguments[2], classes : "btn-primary", click: function() {
-                    window.location.href = '#action='+error.data.arguments[1];
+                    var url_params = window.location.href.split('&');
+                    var menu_url = false;
+                    for (var i in url_params){
+                        if (url_params[i].startsWith('menu_id')){
+                            menu_url = url_params[i];
+                            break;
+                        }
+                    }
+                    var new_href = '#action='+error.data.arguments[1];
+                    if (menu_url){
+                        new_href += '&'+menu_url;
+                    }
+                    window.location.href = new_href;
                     self.destroy();
                 }},
                 {text: _t("Cancel"), click: function() { self.destroy(); }, close: true}


### PR DESCRIPTION
# Descrição

- [FIX] Erro ao usar o RedirectWarning perde o menu de referência
  - Ao utilizar o RedirectWarning, o sistema permite que na mensagem de erro, aparece um botão para o usuário realizar uma action. Mas ao usuário realizar a action, o menu superior era perdido, fazendo com que o usuário não pudesse mais navegar pelo módulo, sem trocar de módulo antes.

# Informações adicionais

- [T5580](https://multi.multidados.tech/web#id=5989&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/838)