### PR TITLE
T6128 - Erro ao baixar Título por pemissão

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1136,9 +1136,15 @@ class Field(MetaField('DummyField', (object,), {})):
                 self._compute_value(records)
             except (AccessError, MissingError):
                 # some record is forbidden or missing, retry record by record
+
+                # TOFIX: Multidados/Augusto
+                #        Adicionado SUDO() para forçar o recalculo de registros
+                #        sem acesso pelo usuário logado.
+                # Motivo: account_move_backup (ajustar no futuro)
+                #         campos estavam causando erros de permissão.
                 for record in records:
                     try:
-                        self._compute_value(record)
+                        self._compute_value(record.sudo())
                     except Exception as exc:
                         record.env.cache.set_failed(record, [self], exc)
 


### PR DESCRIPTION
# Descrição

[FIX] Adiciona SUDO() metodo compute modulo 'odoo/fields'

- Adicionado SUDO() para forçar o recalculo de registros
  sem acesso pelo usuário logado.

Motivo: account_move_backup (ajustar no futuro)
        campos estavam causando erros de permissão.

# Informações adicionais

Dados da tarefa: [T6128](https://multi.multidados.tech/web#id=6537&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

