### PR TITLE
T6131 - NOVO LAYOUT DE ORÇAMENTO

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -471,11 +471,17 @@ class MailTemplate(models.Model):
                 )
 
             # Add report in attachments: generate once for all template_res_ids
-            if template.report_template:
+
+            # Editado por MultidadosTI: Permite a escolha de um relatório enviado por contexo
+            # ao inves de utilizar o relatório relacionado ao template.
+
+            report_id = self._context.get('report_template_to_generate_email', template.report_template.id)
+
+            if report_id:
                 for res_id in template_res_ids:
                     attachments = []
                     report_name = self._render_template(template.report_name, template.model, res_id)
-                    report = template.report_template
+                    report = self.env['ir.actions.report'].browse(report_id)
                     report_service = report.report_name
 
                     if report.report_type in ['qweb-html', 'qweb-pdf']:


### PR DESCRIPTION
# Descrição

- [IMP] Permite enviar um relatório por contexto para envio de email
  - Ao gerar um email, é possível que seja gerado com um outro relatório anexado sem ser o relatório que está relacionado ao 'mail.template'.
  - Para utilizar um relatório diferente do padrão do modelo, é necessário ter no contexto o id do relatório a ser anexado no modelo:
	`{'report_template_to_generate_email' : id_do_relatório}`

# Informações adicionais

- [T6131](https://multi.multidados.tech/web#id=6540&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- l10n_br
- lab88-addons
- report-addons