### PR TITLE
T6324 - Erro: Plano de Contas com mais de uma Empresa

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -456,6 +456,7 @@ class Field(MetaField('DummyField', (object,), {})):
             attrs['copy'] = attrs.get('copy', False)
             attrs['readonly'] = attrs.get('readonly', not attrs.get('inverse'))
             attrs['context_dependent'] = attrs.get('context_dependent', True)
+            attrs['compute_sudo'] = attrs.get('compute_sudo', False)
         if attrs.get('related'):
             # by default, related fields are not stored and not copied
             attrs['store'] = attrs.get('store', False)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2916,7 +2916,10 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         # make a query object for selecting ids, and apply security rules to it
         param_ids = object()
         query = Query(['"%s"' % self._table], ['"%s".id IN %%s' % self._table], [param_ids])
-        self._apply_ir_rules(query, 'read')
+
+        # Multidados: Adiciona para controlar as regras via contexto
+        if not context.get('compute_sudo', False):
+            self._apply_ir_rules(query, 'read')
 
         # determine the fields that are stored as columns in tables; ignore 'id'
         fields_pre = [


### PR DESCRIPTION
# Descrição

[FIX] Ajusta Fields e Models para tratar 'compute_sudo'

- Adiciona 'Model' verificação de contexto para aplicar as regras
  de visualização do conteudo das tabelas.
  Dando a opção para forçar a visualização do resultado do banco de
  dados ignorando a regra do Odoo.

- Adiciona nos atributos dos campos a tag compute_sudo

# Informações adicionais

Dados da tarefa: [T6324](https://multi.multidados.tech/web?#id=6733&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [426](https://github.com/multidadosti-erp/multidadosti-financial-addons/pull/426)
