### PR TITLE
T6366 - Incluir no modulo br_pos_base - Cache de Clientes/Produtos

### DIFF
--- a/addons/pos_cache/__manifest__.py
+++ b/addons/pos_cache/__manifest__.py
@@ -18,7 +18,7 @@ time it takes to load a POS session with a lot of products.
         'data/pos_cache_data.xml',
         'security/ir.model.access.csv',
         'views/pos_cache_views.xml',
-        'views/pos_cache_templates.xml',
+        #'views/pos_cache_templates.xml',
     ],
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
# Descrição

- [FIX] Bloqueia a instalação do módulo 'POS_CACHE' para não dar erro
  - O módulo causa incompatibilidade com o módulo 'br_pos_base', então seu conteúdo foi passado para o módulo 'br_pos_base' e alterado o que deveria lá mesmo.

# Informações adicionais

- [T6366](https://multi.multidados.tech/web#id=6775&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/915)