### PR TITLE
T6514 - Menu sobrepondo informações

### DIFF
--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -766,6 +766,10 @@ var FormRenderer = BasicRenderer.extend({
             if (child.tag === 'field') {
                 var $el = self._renderFieldWidget(child, self.state);
                 $statusbar.append($el);
+                // if adicionado pela Multidados
+                if (child.attrs['z-index'] === '0'){
+                    $statusbar.css('z-index', 0);
+                }
             }
         });
         this._handleAttributes($statusbar, node);


### PR DESCRIPTION
# Descrição

- [FIX] Adiciona tag para corrigir o statusbar sobrepondo elementos
  - A tag z-index é verificada para determinar se o statusbar deve ter o estilo z-index = 0.

# Informações adicionais

- [T6514](https://multi.multidados.tech/web#id=6923&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/979)