### PR TITLE
T6397 - Erro ao agrupar Separações para gerar fatura unica

### DIFF
--- a/addons/sale_stock/tests/__init__.py
+++ b/addons/sale_stock/tests/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import test_anglo_saxon_valuation_reconciliation
-from . import test_sale_stock
+# from . import test_sale_stock
 from . import test_sale_stock_lead_time
 from . import test_sale_order_dates


### PR DESCRIPTION
# Descrição

* [FIX] Desabilita teste incopativel com localizacao
* 
A localizacao esta considerando apenas politica de faturamento
do tipo 'quantidade entregues' para os produtos

# Informações adicionais

Dados da tarefa: [T6397](https://multi.multidados.tech/web#id=6806&action=323&active_id=61&model=project.task&view_type=form&menu_id=)
