### PR TITLE
T6582 - Equipe de atividades

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -454,7 +454,6 @@ class Lead(models.Model):
             'default_opportunity_id': self.id if self.type == 'opportunity' else False,
             'default_partner_id': self.partner_id.id,
             'default_partner_ids': partner_ids,
-            'default_team_id': self.team_id.id,
             'default_name': self.name,
         }
         return action


### PR DESCRIPTION
# Descrição

[FIX] Remove context 'team_id' metodo 'action_schedule_meeting' modulo 'crm'

- Remove contexto default_team_id': self.team_id.id para a criação
  do calendar.event.

  Obs.: Campo não existe no Odoo e ao utilizarmos o modulo da
        OCA/mail_activity_team ocorreu conflito.

# Informações adicionais

Dados da tarefa: [T6582](https://multi.multidados.tech/web?debug=#id=6991&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

