### PR TITLE
T6851 - Erro no processamento Queue no Retorno de CNAB

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3079,6 +3079,24 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         return self.env['ir.model.access'].check(self._name, operation, raise_exception)
 
     @api.multi
+    def check_access_rule_bool(self, operation):
+        """ Método Criado pela Multidados para Retornar True ou False
+            de Acordo com o método original do Core (check_access_rule)
+
+        Args:
+            operation (str): :param operation: one of ``write``, ``unlink``
+
+        Returns:
+            bool: True - Tem Acesso
+                  False - Sem Acesso
+        """
+        try:
+            self.check_access_rule(operation)
+            return True
+        except:
+            return False
+
+    @api.multi
     def check_access_rule(self, operation):
         """ Verifies that the operation given by ``operation`` is allowed for
             the current user according to ir.rules.


### PR DESCRIPTION
# Descrição

Adiciona novo método 'check_access_rule_bool' módulo 'odoo'

- Método para retornar True ou False de Acordo com a verificação do método original 'check_access_rule'

# Informações adicionais

Dados da tarefa: [T6851](https://multi.multidados.tech/web?#id=7260&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver):
[1088](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1088)
[614](https://github.com/multidadosti-erp/multidadosti-addons/pull/614)
[478](https://github.com/multidadosti-erp/multidadosti-financial-addons/pull/478)
