### PR TITLE
T6879 - Erro no POS ao Tentar Incluir Produto com Posição Fiscal Definida

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1744,7 +1744,13 @@ exports.Orderline = Backbone.Model.extend({
         var taxes_ids = this.get_product().taxes_id;
         var taxes = [];
         for (var i = 0; i < taxes_ids.length; i++) {
-            taxes.push(this.pos.taxes_by_id[taxes_ids[i]]);
+            /* Adicionado pela Multidados:
+            - Adiciona verificação se a taxa foi encontrada para evitar que
+            obtenha ovalor 'undefined'
+            */
+            if (this.pos.taxes_by_id[taxes_ids[i]]){
+                taxes.push(this.pos.taxes_by_id[taxes_ids[i]]);
+            }
         }
         return taxes;
     },


### PR DESCRIPTION
# Descrição

- Corrige erro de produto com posição fiscal no POS

# Informações adicionais

- [T6879](https://multi.multidados.tech/web#id=7288&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)