### PR TITLE
T6936 - Adicionar Melhorias ao Calcular os Custos

### DIFF
--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -103,8 +103,8 @@
                             <field name="sale_delay" class="oe_inline" style="vertical-align:baseline"/> days
                         </div>
                     </group>
-                    <group string="Traceability" name="traceability" groups="stock.group_production_lot">
-                        <field name="tracking" widget="radio" attrs="{'invisible': [('type', 'in', ['service', 'digital'])]}"/>
+                    <group string="Traceability" name="traceability" attrs="{'invisible': [('type', 'in', ['service', 'digital', 'consu'])]}" groups="stock.group_production_lot">
+                        <field name="tracking" widget="radio" attrs="{'invisible': [('type', 'in', ['service', 'digital', 'consu'])]}"/>
                     </group>
                      <group string="Counterpart Locations" name="stock_property" groups="base.group_no_one">
                         <field name="property_stock_production" domain="[('usage', '=', 'production')]"/>


### PR DESCRIPTION
# Descrição

Adiciona Regra Visible campo 'traceability' módulo 'stock'

- Deixar Invisible se o campo type não for 'product'

# Informações adicionais

Dados da tarefa: [T6936](https://multi.multidados.tech/web?#id=7345&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [1117](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1117)
