### PR TITLE
T7055 - Alguns tipos de Atividade não estão disponiveis para a inclusão de uma nova atividade

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -18,12 +18,12 @@
                     <group>
                         <group>
                             <field name="category" invisible="1"/>
-                            <field name="res_model_id" groups="base.group_no_one"/>
+                            <field name="res_model_id"/>
                             <field name="res_model_change" invisible="1"/>
                             <field name="initial_res_model_id" invisible="1"/>
                             <field name="summary"/>
                             <field name="icon" groups="base.group_no_one"/>
-                            <field name="decoration_type" groups="base.group_no_one"/>
+                            <field name="decoration_type"/>
                             <label for="delay_count"/>
                             <div>
                                 <div class="o_row">


### PR DESCRIPTION
# Descrição

Remove groups 'group_no_one' módulo 'mail'
- Remove dos campos: 'res_model_id' e 'decoration_type' para liberar o acesso para os usuários normais do sistema.

# Informações adicionais

Dados da tarefa: [T7055 ](https://multi.multidados.tech/web#id=7464&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)
