### PR TITLE
T7072 - Ajustar Cadastro do Plano de Contas

### DIFF
--- a/addons/account/i18n/pt_BR.po
+++ b/addons/account/i18n/pt_BR.po
@@ -10721,7 +10721,7 @@ msgstr "Usado para registrar um lucro quando o saldo final em caixa difere do qu
 #: model:ir.model.fields,field_description:account.field_account_account_template__user_type_id
 #: model:ir.model.fields,field_description:account.field_account_move_line__user_type_id
 msgid "User Type"
-msgstr "Tipo de usuário"
+msgstr "Tipo Conta"
 
 #. module: account
 #: model:ir.model,name:account.model_res_users

--- a/addons/account/views/account_view.xml
+++ b/addons/account/views/account_view.xml
@@ -21,7 +21,7 @@
                              <field name="group_id"/>
                              <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                              <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
-                             <field name="internal_type" invisible="1" readonly="1"/>
+                             <field name="internal_type" invisible="0" readonly="1"/>
                              <label for="reconcile" attrs="{'invisible': [('internal_type','=','liquidity')]}"/>
                              <div attrs="{'invisible': [('internal_type','=','liquidity')]}">
                                 <field name="reconcile"/>


### PR DESCRIPTION
# Descrição

Ajusta Cadastro de Plano de Contas módulo 'account'

- Deixa visivel o campo 'internal_type'.
- Atualiza tradução pt_br do módulo.

# Informações adicionais

Dados da tarefa: [T7072 ](https://multi.multidados.tech/web#id=7481&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [1147](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1147)
