### PR TITLE
T7112 - Criar modo que não demonstre estagios vazios ao pesquisar dados nas oportunidades

### DIFF
--- a/addons/crm/i18n/crm.pot
+++ b/addons/crm/i18n/crm.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 10:31+0000\n"
-"PO-Revision-Date: 2019-01-09 10:31+0000\n"
+"POT-Creation-Date: 2023-03-06 16:42+0000\n"
+"PO-Revision-Date: 2023-03-06 16:42+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,6 +18,7 @@ msgstr ""
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__meeting_count
 #: model:ir.model.fields,field_description:crm.field_res_partner__meeting_count
+#: model:ir.model.fields,field_description:crm.field_res_users__meeting_count
 msgid "# Meetings"
 msgstr ""
 
@@ -90,7 +91,7 @@ msgid "<i class=\"fa fa-fw fa-star\" aria-label=\"Favorites\" role=\"img\" title
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_team.py:139
+#: code:addons/crm/models/crm_team.py:147
 #, python-format
 msgid "<p class='o_view_nocontent_smiling_face'>Add new opportunities</p><p>\n"
 "    Looks like you are not a member of a Sales Team. You should add yourself\n"
@@ -189,7 +190,7 @@ msgid "Activity Types"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:933
+#: code:addons/crm/models/crm_lead.py:956
 #, python-format
 msgid "Add a new lead"
 msgstr ""
@@ -203,6 +204,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
 msgid "Address"
+msgstr ""
+
+#. module: crm
+#: selection:crm.lead,type:0
+msgid "After Sales"
 msgstr ""
 
 #. module: crm
@@ -257,7 +263,7 @@ msgid "Blacklist"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:400
+#: code:addons/crm/models/crm_lead.py:424
 #, python-format
 msgid "Boom! Team record for the past 30 days."
 msgstr ""
@@ -282,11 +288,6 @@ msgstr ""
 #. module: crm
 #: model:ir.model,name:crm.model_crm_stage
 msgid "CRM Stages"
-msgstr ""
-
-#. module: crm
-#: model:mail.activity.type,name:crm.mail_activity_demo_call_demo
-msgid "Call for Demo"
 msgstr ""
 
 #. module: crm
@@ -419,16 +420,6 @@ msgid "Configuration options are available in the Settings app."
 msgstr ""
 
 #. module: crm
-#: model:crm.lead.tag,name:crm.categ_oppor7
-msgid "Consulting"
-msgstr ""
-
-#. module: crm
-#: model:ir.model,name:crm.model_res_partner
-msgid "Contact"
-msgstr ""
-
-#. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__contact_name
 msgid "Contact Name"
 msgstr ""
@@ -495,7 +486,7 @@ msgid "Convert to opportunities"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1116
+#: code:addons/crm/models/crm_lead.py:1139
 #: selection:crm.lead2opportunity.partner,name:0
 #: selection:crm.lead2opportunity.partner.mass,name:0
 #: model:ir.actions.act_window,name:crm.action_crm_lead2opportunity_partner
@@ -536,6 +527,7 @@ msgid "Create & Edit"
 msgstr ""
 
 #. module: crm
+#: model:ir.model.fields,field_description:crm.field_contact_config_settings__module_crm_reveal
 #: model:ir.model.fields,field_description:crm.field_res_config_settings__module_crm_reveal
 msgid "Create Leads/Opportunities from your website's traffic"
 msgstr ""
@@ -574,7 +566,7 @@ msgid "Create an new opportunity related to this customer"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:935
+#: code:addons/crm/models/crm_lead.py:958
 #, python-format
 msgid "Create an opportunity in your pipeline"
 msgstr ""
@@ -634,7 +626,7 @@ msgid "Currency"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1168
+#: code:addons/crm/models/crm_lead.py:1191
 #: model:ir.model.fields,field_description:crm.field_crm_lead2opportunity_partner__partner_id
 #: model:ir.model.fields,field_description:crm.field_crm_lead2opportunity_partner_mass__partner_id
 #: model:ir.model.fields,field_description:crm.field_crm_lead__partner_id
@@ -649,7 +641,7 @@ msgid "Customer"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1170
+#: code:addons/crm/models/crm_lead.py:1193
 #, python-format
 msgid "Customer Email"
 msgstr ""
@@ -688,6 +680,7 @@ msgid "Days to Close"
 msgstr ""
 
 #. module: crm
+#: model:ir.model.fields,field_description:crm.field_contact_config_settings__crm_alias_prefix
 #: model:ir.model.fields,field_description:crm.field_res_config_settings__crm_alias_prefix
 msgid "Default Alias Name for Leads"
 msgstr ""
@@ -705,11 +698,6 @@ msgstr ""
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 msgid "Describe the lead..."
-msgstr ""
-
-#. module: crm
-#: model:crm.lead.tag,name:crm.categ_oppor5
-msgid "Design"
 msgstr ""
 
 #. module: crm
@@ -866,8 +854,8 @@ msgid "Folded in Pipeline"
 msgstr ""
 
 #. module: crm
-#: model:mail.activity.type,name:crm.mail_activity_demo_followup_quote
-msgid "Follow-up Quote"
+#: model:ir.model.fields,field_description:crm.field_crm_stage__fold_is_empty
+msgid "Folded in Pipeline When Emptyin"
 msgstr ""
 
 #. module: crm
@@ -901,7 +889,7 @@ msgid "Format phone numbers based on national conventions"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:613
+#: code:addons/crm/models/crm_lead.py:629
 #, python-format
 msgid "From %s : %s"
 msgstr ""
@@ -910,6 +898,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_case_leads_filter
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_case_opportunities_filter
 msgid "Future Activities"
+msgstr ""
+
+#. module: crm
+#: model:crm.stage,name:crm.stage_lead4
+msgid "Ganho"
 msgstr ""
 
 #. module: crm
@@ -934,7 +927,7 @@ msgid "Global CC"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:398
+#: code:addons/crm/models/crm_lead.py:422
 #, python-format
 msgid "Go, go, go! Congrats for your first deal."
 msgstr ""
@@ -1007,6 +1000,7 @@ msgstr ""
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_res_partner__team_id
+#: model:ir.model.fields,help:crm.field_res_users__team_id
 msgid "If set, this Sales Team will be used for sales and assignations related to this partner"
 msgstr ""
 
@@ -1027,7 +1021,7 @@ msgid "Import & Synchronize"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1230
+#: code:addons/crm/models/crm_lead.py:1257
 #, python-format
 msgid "Import Template for Leads & Opportunities"
 msgstr ""
@@ -1038,8 +1032,8 @@ msgid "Include archived"
 msgstr ""
 
 #. module: crm
-#: model:crm.lead.tag,name:crm.categ_oppor4
-msgid "Information"
+#: model:crm.stage,name:crm.stage_lead1
+msgid "Inicial"
 msgstr ""
 
 #. module: crm
@@ -1140,7 +1134,7 @@ msgid "Late Activities"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:920
+#: code:addons/crm/models/crm_lead.py:936
 #: selection:crm.activity.report,lead_type:0
 #: selection:crm.lead,type:0
 #: model:ir.model.fields,field_description:crm.field_crm_activity_report__lead_id
@@ -1170,6 +1164,7 @@ msgstr ""
 #. module: crm
 #: model:ir.actions.act_window,name:crm.crm_case_form_view_salesteams_lead
 #: model:ir.actions.act_window,name:crm.crm_lead_all_leads
+#: model:ir.model.fields,field_description:crm.field_contact_config_settings__group_use_lead
 #: model:ir.model.fields,field_description:crm.field_crm_team__use_leads
 #: model:ir.model.fields,field_description:crm.field_res_config_settings__group_use_lead
 #: model:ir.ui.menu,name:crm.crm_menu_leads
@@ -1245,7 +1240,7 @@ msgid "Linked partner (optional). Usually created when converting the lead. You 
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1122
+#: code:addons/crm/models/crm_lead.py:1145
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
 #: model_terms:ir.ui.view,arch_db:crm.crm_opportunity_report_view_search
@@ -1283,11 +1278,7 @@ msgid "Main Attachment"
 msgstr ""
 
 #. module: crm
-#: model:mail.activity.type,name:crm.mail_activity_demo_make_quote
-msgid "Make Quote"
-msgstr ""
-
-#. module: crm
+#: model:ir.model.fields,field_description:crm.field_contact_config_settings__generate_lead_from_alias
 #: model:ir.model.fields,field_description:crm.field_res_config_settings__generate_lead_from_alias
 msgid "Manual Assignation of Emails"
 msgstr ""
@@ -1341,7 +1332,7 @@ msgid "Medium"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:958
+#: code:addons/crm/models/crm_lead.py:981
 #, python-format
 msgid "Meeting scheduled at '%s'<br> Subject: %s <br> Duration: %s hour(s)"
 msgstr ""
@@ -1350,6 +1341,7 @@ msgstr ""
 #: model:ir.actions.act_window,name:crm.act_crm_opportunity_calendar_event_new
 #: model:ir.actions.act_window,name:crm.calendar_event_partner
 #: model:ir.model.fields,field_description:crm.field_res_partner__meeting_ids
+#: model:ir.model.fields,field_description:crm.field_res_users__meeting_ids
 #: model_terms:ir.ui.view,arch_db:crm.view_partners_form_crm1
 msgid "Meetings"
 msgstr ""
@@ -1387,25 +1379,25 @@ msgid "Merge with existing opportunities"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:556
+#: code:addons/crm/models/crm_lead.py:579
 #, python-format
 msgid "Merged lead"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:588
+#: code:addons/crm/models/crm_lead.py:611
 #, python-format
 msgid "Merged leads"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:588
+#: code:addons/crm/models/crm_lead.py:611
 #, python-format
 msgid "Merged opportunities"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:556
+#: code:addons/crm/models/crm_lead.py:579
 #, python-format
 msgid "Merged opportunity"
 msgstr ""
@@ -1427,6 +1419,7 @@ msgstr ""
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__mobile
+#: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
 msgid "Mobile"
 msgstr ""
 
@@ -1456,11 +1449,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:crm.field_crm_lost_reason__name
 #: model_terms:ir.ui.view,arch_db:crm.quick_create_opportunity_form
 msgid "Name"
-msgstr ""
-
-#. module: crm
-#: model:crm.stage,name:crm.stage_lead1
-msgid "New"
 msgstr ""
 
 #. module: crm
@@ -1505,7 +1493,7 @@ msgid "Next activity late"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1190
+#: code:addons/crm/models/crm_lead.py:1213
 #, python-format
 msgid "No Subject"
 msgstr ""
@@ -1573,6 +1561,7 @@ msgstr ""
 
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_team_salesteams_view_kanban
+#: model_terms:ir.ui.view,arch_db:crm.view_crm_case_opportunities_filter
 msgid "Open Opportunities"
 msgstr ""
 
@@ -1593,6 +1582,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:crm.field_crm_lead2opportunity_partner__opportunity_ids
 #: model:ir.model.fields,field_description:crm.field_crm_lead2opportunity_partner_mass__opportunity_ids
 #: model:ir.model.fields,field_description:crm.field_res_partner__opportunity_ids
+#: model:ir.model.fields,field_description:crm.field_res_users__opportunity_ids
 #: model:ir.ui.menu,name:crm.menu_crm_config_opportunity
 #: model_terms:ir.ui.view,arch_db:crm.crm_activity_report_view_search
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
@@ -1636,13 +1626,14 @@ msgid "Opportunities with a date of Expected Closing which is in the past"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:446
-#: code:addons/crm/models/crm_lead.py:888
+#: code:addons/crm/models/crm_lead.py:469
+#: code:addons/crm/models/crm_lead.py:911
 #: selection:crm.activity.report,lead_type:0
 #: selection:crm.lead,type:0
 #: model:ir.model.fields,field_description:crm.field_calendar_event__opportunity_id
 #: model:ir.model.fields,field_description:crm.field_crm_lead__name
 #: model:ir.model.fields,field_description:crm.field_res_partner__opportunity_count
+#: model:ir.model.fields,field_description:crm.field_res_users__opportunity_count
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_tree_view_oppor
 #: model_terms:ir.ui.view,arch_db:crm.crm_opportunity_report_view_search
 #: model_terms:ir.ui.view,arch_db:crm.crm_team_salesteams_view_kanban
@@ -1695,11 +1686,6 @@ msgid "Opportunity won"
 msgstr ""
 
 #. module: crm
-#: model:crm.lead.tag,name:crm.categ_oppor8
-msgid "Other"
-msgstr ""
-
-#. module: crm
 #: selection:crm.lead,activity_state:0
 msgid "Overdue"
 msgstr ""
@@ -1710,8 +1696,18 @@ msgid "Overdue Opportunities"
 msgstr ""
 
 #. module: crm
+#: model:ir.model,name:crm.model_res_partner
+msgid "Partner"
+msgstr ""
+
+#. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__partner_address_email
 msgid "Partner Contact Email"
+msgstr ""
+
+#. module: crm
+#: model:ir.model.fields,field_description:crm.field_crm_lead__partner_address_mobile
+msgid "Partner Contact Mobile"
 msgstr ""
 
 #. module: crm
@@ -1746,12 +1742,13 @@ msgid "Phone"
 msgstr ""
 
 #. module: crm
+#: model:ir.model.fields,field_description:crm.field_contact_config_settings__module_crm_phone_validation
 #: model:ir.model.fields,field_description:crm.field_res_config_settings__module_crm_phone_validation
 msgid "Phone Formatting"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_team.py:155
+#: code:addons/crm/models/crm_team.py:163
 #: selection:crm.team,dashboard_graph_model:0
 #: model:ir.actions.act_window,name:crm.crm_lead_opportunities_tree_view
 #: model:ir.model.fields,field_description:crm.field_crm_team__use_opportunities
@@ -1790,7 +1787,7 @@ msgid "Pipeline Analysis gives you an instant access to\n"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_team.py:224
+#: code:addons/crm/models/crm_team.py:232
 #, python-format
 msgid "Pipeline: Expected Revenue"
 msgstr ""
@@ -1801,7 +1798,7 @@ msgid "Planned"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:660
+#: code:addons/crm/models/crm_lead.py:683
 #, python-format
 msgid "Please select more than one element (lead or opportunity) from the list view."
 msgstr ""
@@ -1828,13 +1825,8 @@ msgid "Probability (%)"
 msgstr ""
 
 #. module: crm
-#: model:crm.lead.tag,name:crm.categ_oppor1
-msgid "Product"
-msgstr ""
-
-#. module: crm
 #: model:crm.stage,name:crm.stage_lead3
-msgid "Proposition"
+msgid "Proposta"
 msgstr ""
 
 #. module: crm
@@ -1844,7 +1836,7 @@ msgstr ""
 
 #. module: crm
 #: model:crm.stage,name:crm.stage_lead2
-msgid "Qualified"
+msgid "Qualificado"
 msgstr ""
 
 #. module: crm
@@ -1913,6 +1905,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:crm.field_crm_merge_opportunity__team_id
 #: model:ir.model.fields,field_description:crm.field_crm_stage__team_id
 #: model:ir.model.fields,field_description:crm.field_res_partner__team_id
+#: model:ir.model.fields,field_description:crm.field_res_users__team_id
 #: model_terms:ir.ui.view,arch_db:crm.crm_activity_report_view_search
 #: model_terms:ir.ui.view,arch_db:crm.crm_opportunity_report_view_search
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_case_opportunities_filter
@@ -1920,7 +1913,7 @@ msgid "Sales Team"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1125
+#: code:addons/crm/models/crm_lead.py:1148
 #, python-format
 msgid "Sales Team Settings"
 msgstr ""
@@ -1975,11 +1968,6 @@ msgid "Sequence"
 msgstr ""
 
 #. module: crm
-#: model:crm.lead.tag,name:crm.categ_oppor3
-msgid "Services"
-msgstr ""
-
-#. module: crm
 #: model_terms:ir.actions.act_window,help:crm.crm_stage_action
 msgid "Set a new stage in your opportunity pipeline"
 msgstr ""
@@ -2016,11 +2004,6 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:crm.crm_activity_report_view_search
 #: model_terms:ir.ui.view,arch_db:crm.crm_opportunity_report_view_search
 msgid "Show only opportunity"
-msgstr ""
-
-#. module: crm
-#: model:crm.lead.tag,name:crm.categ_oppor2
-msgid "Software"
 msgstr ""
 
 #. module: crm
@@ -2074,7 +2057,6 @@ msgstr ""
 
 #. module: crm
 #: model:ir.actions.act_window,name:crm.crm_stage_action
-#: model:ir.ui.menu,name:crm.menu_crm_lead_stage_act
 #: model_terms:ir.ui.view,arch_db:crm.crm_stage_tree
 msgid "Stages"
 msgstr ""
@@ -2230,11 +2212,16 @@ msgstr ""
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_stage__fold
-msgid "This stage is folded in the kanban view when there are no records in that stage to display."
+msgid "This stage is folded in the kanban view."
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1088
+#: model:ir.model.fields,help:crm.field_crm_stage__fold_is_empty
+msgid "This stage is folded when empty in the kanban view when there are no records in that stage to display."
+msgstr ""
+
+#. module: crm
+#: code:addons/crm/models/crm_lead.py:1111
 #, python-format
 msgid "This target does not exist."
 msgstr ""
@@ -2265,11 +2252,6 @@ msgstr ""
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 msgid "Tracking"
-msgstr ""
-
-#. module: crm
-#: model:crm.lead.tag,name:crm.categ_oppor6
-msgid "Training"
 msgstr ""
 
 #. module: crm
@@ -2306,7 +2288,7 @@ msgid "Unassigned Leads"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_team.py:201
+#: code:addons/crm/models/crm_team.py:209
 #, python-format
 msgid "Undefined"
 msgstr ""
@@ -2392,7 +2374,7 @@ msgstr ""
 
 #. module: crm
 #: selection:crm.lead,priority:0
-msgid "Very High"
+msgid "Very Low"
 msgstr ""
 
 #. module: crm
@@ -2446,8 +2428,7 @@ msgid "Within a Year"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1121
-#: model:crm.stage,name:crm.stage_lead4
+#: code:addons/crm/models/crm_lead.py:1144
 #: model_terms:ir.ui.view,arch_db:crm.crm_activity_report_view_search
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
@@ -2464,25 +2445,25 @@ msgid "Won in Opportunities Target"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:402
+#: code:addons/crm/models/crm_lead.py:426
 #, python-format
 msgid "Yeah! Deal of the last 7 days for the team."
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_team.py:122
+#: code:addons/crm/models/crm_team.py:127
 #, python-format
 msgid "You have to enable the Pipeline on your Sales Team to be able to set it as a content for the graph"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:404
+#: code:addons/crm/models/crm_lead.py:428
 #, python-format
 msgid "You just beat your personal record for the past 30 days."
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:406
+#: code:addons/crm/models/crm_lead.py:430
 #, python-format
 msgid "You just beat your personal record for the past 7 days."
 msgstr ""
@@ -2513,6 +2494,11 @@ msgid "Zip"
 msgstr ""
 
 #. module: crm
+#: model:ir.ui.menu,name:crm.menu_crm_lead_stage_act
+msgid "crm.menu_crm_lead_stage_act"
+msgstr ""
+
+#. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.view_create_opportunity_simplified
 msgid "e.g. Customer Deal"
 msgstr ""
@@ -2529,7 +2515,7 @@ msgid "e.g. https://www.odoo.com"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:946
+#: code:addons/crm/models/crm_lead.py:969
 #, python-format
 msgid "or send an email to %s"
 msgstr ""
@@ -2540,14 +2526,7 @@ msgid "team_count"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:952
+#: code:addons/crm/models/crm_lead.py:975
 #, python-format
 msgid "unknown"
-msgstr ""
-
-#. module: crm
-#: code:addons/crm/models/crm_team.py:152
-#: code:addons/multierp/src/core/addons/crm/models/crm_team.py:152
-#, python-format
-msgid "<p>As you don't belong to any Sales Team, Odoo opens the first one by default.</p>"
 msgstr ""

--- a/addons/crm/i18n/pt_BR.po
+++ b/addons/crm/i18n/pt_BR.po
@@ -1,45 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * crm
-#
-# Translators:
-# Luciano Giacomazzi <lucianogiacomazzi@gmail.com>, 2018
-# danimaribeiro <danimaribeiro@gmail.com>, 2018
-# Adriel Kotviski <kotviski@gmail.com>, 2018
-# falexandresilva <falexandresilva@gmail.com>, 2018
-# André Augusto Firmino Cordeiro <a.cordeito@gmail.com>, 2018
-# Rodrigo de Almeida Sottomaior Macedo <rmsolucoeseminformatica@protonmail.com>, 2018
-# Sidnei Brianti <scbrianti@gmail.com>, 2018
-# Hildeberto Abreu Magalhães <hildeberto@gmail.com>, 2018
-# Silmar <pinheirosilmar@gmail.com>, 2018
-# Martin Trigaux, 2018
-# Mateus Lopes <mateus1@gmail.com>, 2018
-# grazziano <gra.negocia@gmail.com>, 2018
-# Fernando Alencar <fernando@fernandoalencar.com.br>, 2018
-# Marcel Savegnago <marcel.savegnago@gmail.com>, 2019
-# Ramiro Pereira de Magalhães <ramiro.p.magalhaes@gmail.com>, 2019
-# Luiz Fernando <lfpsgs@outlook.com>, 2020
-# Kevin Harrings <kha@odoo.com>, 2020
-# Eduardo Aparicio <eduardo.caparica@gmail.com>, 2020
-# Fernando Colus <fcolus1@gmail.com>, 2020
-# Maurício Liell <mauricio@liell.com.br>, 2020
-# PopSolutions Cooperativa Digital <popsolutions.co@gmail.com>, 2020
-# Tiago Rigo <tiagomrigo@gmail.com>, 2020
-# Éder Brito <britoederr@gmail.com>, 2021
+#	* crm
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 10:31+0000\n"
-"PO-Revision-Date: 2018-08-24 09:17+0000\n"
-"Last-Translator: Éder Brito <britoederr@gmail.com>, 2021\n"
-"Language-Team: Portuguese (Brazil) (https://www.transifex.com/odoo/teams/41243/pt_BR/)\n"
+"POT-Creation-Date: 2023-03-06 16:41+0000\n"
+"PO-Revision-Date: 2023-03-06 16:41+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: pt_BR\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__meeting_count
@@ -144,16 +118,6 @@ msgid "<p>As you don't belong to any Sales Team, Odoo opens the first one by def
 msgstr "<p><b>Obs.:</b>Como você não pertence a nenhuma equipe de vendas, o sistema abre a primeira por padrão.</p>"
 
 #. module: crm
-#: code:addons/crm/models/crm_team.py:152
-#, python-format
-msgid ""
-"<p>As you don't belong to any Sales Team, Odoo opens the first one by "
-"default.</p>"
-msgstr ""
-"<p>Como você não pertence a nenhuma Equipe de Vendas, o Odoo abrirá a "
-"primeira por padrão.</p>"
-
-#. module: crm
 #. openerp-web
 #: code:addons/crm/static/src/js/tour.js:52
 #, python-format
@@ -232,7 +196,7 @@ msgid "Activity Types"
 msgstr "Tipos de Atividades"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:957
+#: code:addons/crm/models/crm_lead.py:956
 #, python-format
 msgid "Add a new lead"
 msgstr "Novo lead"
@@ -287,7 +251,7 @@ msgstr "Data da Atribuição"
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_attachment_count
 msgid "Attachment Count"
-msgstr "Contar Anexo"
+msgstr "Contagem de Anexos"
 
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_tree_view_oppor
@@ -441,7 +405,7 @@ msgstr "Nome da Empresa"
 #. module: crm
 #: model:ir.model,name:crm.model_res_config_settings
 msgid "Config Settings"
-msgstr "Ajuste de configurações"
+msgstr "Ajustes de configuração"
 
 #. module: crm
 #: model:ir.ui.menu,name:crm.crm_menu_config
@@ -523,7 +487,7 @@ msgid "Convert to opportunities"
 msgstr "Converter para oportunidades"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1140
+#: code:addons/crm/models/crm_lead.py:1139
 #: selection:crm.lead2opportunity.partner,name:0
 #: selection:crm.lead2opportunity.partner.mass,name:0
 #: model:ir.actions.act_window,name:crm.action_crm_lead2opportunity_partner
@@ -603,7 +567,7 @@ msgid "Create an new opportunity related to this customer"
 msgstr "Criar uma nova oportunidade relacionada a este cliente"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:959
+#: code:addons/crm/models/crm_lead.py:958
 #, python-format
 msgid "Create an opportunity in your pipeline"
 msgstr "Crie uma nova oportunidade em seu pipeline"
@@ -663,7 +627,7 @@ msgid "Currency"
 msgstr "Moeda"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1192
+#: code:addons/crm/models/crm_lead.py:1191
 #: model:ir.model.fields,field_description:crm.field_crm_lead2opportunity_partner__partner_id
 #: model:ir.model.fields,field_description:crm.field_crm_lead2opportunity_partner_mass__partner_id
 #: model:ir.model.fields,field_description:crm.field_crm_lead__partner_id
@@ -678,7 +642,7 @@ msgid "Customer"
 msgstr "Parceiro"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1194
+#: code:addons/crm/models/crm_lead.py:1193
 #, python-format
 msgid "Customer Email"
 msgstr "E-mail do Cliente"
@@ -693,7 +657,7 @@ msgstr "Nome do Cliente"
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_lead2opportunity_partner
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_lead2opportunity_partner_mass
 msgid "Customers"
-msgstr "Parceiros"
+msgstr "Clientes"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_activity_report__date
@@ -891,6 +855,11 @@ msgid "Folded in Pipeline"
 msgstr "Dobrado no Pipeline"
 
 #. module: crm
+#: model:ir.model.fields,field_description:crm.field_crm_stage__fold_is_empty
+msgid "Folded in Pipeline When Emptyin"
+msgstr "Dobrado na Pipeline quando Vazio"
+
+#. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_follower_ids
 msgid "Followers"
 msgstr "Seguidores"
@@ -921,7 +890,7 @@ msgid "Format phone numbers based on national conventions"
 msgstr "Formatar números de telefone com base em convenções nacionais"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:630
+#: code:addons/crm/models/crm_lead.py:629
 #, python-format
 msgid "From %s : %s"
 msgstr "De %s : %s"
@@ -1019,12 +988,12 @@ msgstr "Se marcado, novas mensagens solicitarão sua atenção."
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_lead__message_needaction
 msgid "If checked, new messages require your attention."
-msgstr "Se selecionado, novas mensagens exigirão sua atenção."
+msgstr "Se marcado novas mensagens solicitarão sua atenção."
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_lead__message_has_error
 msgid "If checked, some messages have a delivery error."
-msgstr "Se selecionado, algumas mensagens terão um erro de entrega."
+msgstr "Se marcado, algumas mensagens tem erro de entrega."
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_res_partner__team_id
@@ -1049,7 +1018,7 @@ msgid "Import & Synchronize"
 msgstr "Importar e Sincronizar"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1258
+#: code:addons/crm/models/crm_lead.py:1257
 #, python-format
 msgid "Import Template for Leads & Opportunities"
 msgstr "Modelo de Importação para Leads & Oportunidades"
@@ -1078,7 +1047,7 @@ msgstr "Faturas"
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_is_follower
 msgid "Is Follower"
-msgstr "É Seguidor"
+msgstr "É um Seguidor"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__function
@@ -1117,7 +1086,7 @@ msgstr "Última Ação"
 #: model:ir.model.fields,field_description:crm.field_crm_partner_binding____last_update
 #: model:ir.model.fields,field_description:crm.field_crm_stage____last_update
 msgid "Last Modified on"
-msgstr "Última Modificação em"
+msgstr "Última modificação em"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__date_last_stage_update
@@ -1157,7 +1126,7 @@ msgid "Late Activities"
 msgstr "Últimas Atividades"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:937
+#: code:addons/crm/models/crm_lead.py:936
 #: selection:crm.activity.report,lead_type:0
 #: selection:crm.lead,type:0
 #: model:ir.model.fields,field_description:crm.field_crm_activity_report__lead_id
@@ -1263,7 +1232,7 @@ msgid "Linked partner (optional). Usually created when converting the lead. You 
 msgstr "Parceiro vinculado (opcional). Normalmente criado ao converter o lead. Você podeencontrar um parceiro pelo seu nome, TIN, e-mail ou referência interna."
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1146
+#: code:addons/crm/models/crm_lead.py:1145
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
 #: model_terms:ir.ui.view,arch_db:crm.crm_opportunity_report_view_search
@@ -1344,7 +1313,7 @@ msgstr "Marcar como perdido"
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
 msgid "Marketing"
-msgstr "Marketing"
+msgstr ""
 
 #. module: crm
 #: selection:crm.lead,priority:0
@@ -1355,7 +1324,7 @@ msgid "Medium"
 msgstr "Mídia"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:982
+#: code:addons/crm/models/crm_lead.py:981
 #, python-format
 msgid "Meeting scheduled at '%s'<br> Subject: %s <br> Duration: %s hour(s)"
 msgstr "Reunião agendada para '%s'<br> Assunto: %s <br> Duração: %s hora(s)"
@@ -1402,25 +1371,25 @@ msgid "Merge with existing opportunities"
 msgstr "Mesclar com uma oportunidade existente"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:580
+#: code:addons/crm/models/crm_lead.py:579
 #, python-format
 msgid "Merged lead"
 msgstr "Mesclar prospecto"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:612
+#: code:addons/crm/models/crm_lead.py:611
 #, python-format
 msgid "Merged leads"
 msgstr "Prospectos mesclados"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:612
+#: code:addons/crm/models/crm_lead.py:611
 #, python-format
 msgid "Merged opportunities"
 msgstr "Oportunidades mescladas"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:580
+#: code:addons/crm/models/crm_lead.py:579
 #, python-format
 msgid "Merged opportunity"
 msgstr "Oportunidade mesclada"
@@ -1516,7 +1485,7 @@ msgid "Next activity late"
 msgstr "Próxima atividade atrasada"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1214
+#: code:addons/crm/models/crm_lead.py:1213
 #, python-format
 msgid "No Subject"
 msgstr "Sem Assunto"
@@ -1544,7 +1513,7 @@ msgstr "Estoque insuficiente"
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__description
 msgid "Notes"
-msgstr "Observações"
+msgstr "Anotações"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_needaction_counter
@@ -1554,12 +1523,12 @@ msgstr "Número de Ações"
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_has_error_counter
 msgid "Number of error"
-msgstr "Número de erro"
+msgstr "Número do erro"
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_lead__message_needaction_counter
 msgid "Number of messages which requires an action"
-msgstr "Número de mensagens que exigem uma atenção"
+msgstr "Número de mensagens que requer uma ação"
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_lead__message_has_error_counter
@@ -1574,7 +1543,7 @@ msgstr "Número de oportunidades abertas"
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_lead__message_unread_counter
 msgid "Number of unread messages"
-msgstr "Número de mensagens não lidas"
+msgstr "Quantidade de mensagens não lidas."
 
 #. module: crm
 #: model_terms:ir.actions.act_window,help:crm.crm_case_form_view_salesteams_opportunity
@@ -1650,8 +1619,8 @@ msgid "Opportunities with a date of Expected Closing which is in the past"
 msgstr "Oportunidades com uma data de Encerramento Prevista que está no passado"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:470
-#: code:addons/crm/models/crm_lead.py:912
+#: code:addons/crm/models/crm_lead.py:469
+#: code:addons/crm/models/crm_lead.py:911
 #: selection:crm.activity.report,lead_type:0
 #: selection:crm.lead,type:0
 #: model:ir.model.fields,field_description:crm.field_calendar_event__opportunity_id
@@ -1732,7 +1701,7 @@ msgstr "E-mail de Contato do Parceiro"
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__partner_address_mobile
 msgid "Partner Contact Mobile"
-msgstr "Celular do Contato do Parceiro"
+msgstr "Celular de Contato do Parceiro"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__partner_address_name
@@ -1780,7 +1749,7 @@ msgstr "Formatação do telefone"
 #: model:ir.ui.menu,name:crm.menu_crm_config_lead
 #, python-format
 msgid "Pipeline"
-msgstr "Pipeline"
+msgstr ""
 
 #. module: crm
 #: model:ir.actions.act_window,name:crm.action_report_crm_opportunity_salesteam
@@ -1830,7 +1799,7 @@ msgid "Planned"
 msgstr "Planejado"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:684
+#: code:addons/crm/models/crm_lead.py:683
 #, python-format
 msgid "Please select more than one element (lead or opportunity) from the list view."
 msgstr "Por favor escolha mais de um item (prospecto ou oportunidade) na listagem."
@@ -1935,7 +1904,7 @@ msgid "Sales Team"
 msgstr "Equipe de Vendas"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1149
+#: code:addons/crm/models/crm_lead.py:1148
 #, python-format
 msgid "Sales Team Settings"
 msgstr "Configurações da Equipe de Vendas"
@@ -2075,7 +2044,7 @@ msgstr "Busca de Estágios"
 #. module: crm
 #: model:mail.message.subtype,description:crm.mt_lead_stage
 msgid "Stage changed"
-msgstr "Estágio alterado"
+msgstr "Estágio Alterado"
 
 #. module: crm
 #: model:ir.actions.act_window,name:crm.crm_stage_action
@@ -2239,11 +2208,16 @@ msgstr "Este relatório analisa a origem das suas pistas."
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_stage__fold
-msgid "This stage is folded in the kanban view when there are no records in that stage to display."
-msgstr "Este estágio fica dobrado na visão kanban quando não tem nenhum registro para mostrar neste estágio."
+msgid "This stage is folded in the kanban view."
+msgstr "Este estágio fica dobrado na visão kanban."
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1112
+#: model:ir.model.fields,help:crm.field_crm_stage__fold_is_empty
+msgid "This stage is folded when empty in the kanban view when there are no records in that stage to display."
+msgstr "Esta etapa é dobrada quando vazia na visão kanban quando não há registros nessa etapa para exibir."
+
+#. module: crm
+#: code:addons/crm/models/crm_lead.py:1111
 #, python-format
 msgid "This target does not exist."
 msgstr "Este destino não existe."
@@ -2310,7 +2284,6 @@ msgid "Unassigned Leads"
 msgstr "Leads não atribuídos"
 
 #. module: crm
-#. openerp-web
 #: code:addons/crm/models/crm_team.py:209
 #, python-format
 msgid "Undefined"
@@ -2327,7 +2300,7 @@ msgstr "Mensagens não lidas"
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contagem de Mensagens Não Lidas"
+msgstr "Contador de Mensagens Não Lidas"
 
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.res_config_settings_view_form
@@ -2455,7 +2428,7 @@ msgid "Within a Year"
 msgstr "Dentro de um ano"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1145
+#: code:addons/crm/models/crm_lead.py:1144
 #: model_terms:ir.ui.view,arch_db:crm.crm_activity_report_view_search
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
@@ -2546,7 +2519,7 @@ msgid "e.g. https://www.odoo.com"
 msgstr "e.x. https://www.example.com"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:970
+#: code:addons/crm/models/crm_lead.py:969
 #, python-format
 msgid "or send an email to %s"
 msgstr "ou envie um e-mail para %s"
@@ -2557,7 +2530,7 @@ msgid "team_count"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:976
+#: code:addons/crm/models/crm_lead.py:975
 #, python-format
 msgid "unknown"
 msgstr "desconhecido"

--- a/addons/crm/models/crm_stage.py
+++ b/addons/crm/models/crm_stage.py
@@ -42,7 +42,12 @@ class Stage(models.Model):
     legend_priority = fields.Text('Priority Management Explanation', translate=True,
         help='Explanation text to help users using the star and priority mechanism on stages or issues that are in this stage.')
     fold = fields.Boolean('Folded in Pipeline',
-        help='This stage is folded in the kanban view when there are no records in that stage to display.')
+        help='This stage is folded in the kanban view.')
+
+    # Multidados
+    fold_is_empty = fields.Boolean('Folded in Pipeline When Emptyin',
+        default=False,
+        help='This stage is folded when empty in the kanban view when there are no records in that stage to display.')
 
     #This field for interface only
     team_count = fields.Integer('team_count', compute='_compute_team_count')

--- a/addons/crm/views/crm_stage_views.xml
+++ b/addons/crm/views/crm_stage_views.xml
@@ -23,6 +23,8 @@
                 <field name="name"/>
                 <field name="probability"/>
                 <field name="team_id"/>
+                <field name="fold_is_empty"/>
+                <field name="fold"/>
             </tree>
         </field>
     </record>
@@ -38,6 +40,7 @@
                     <group>
                         <field name="name"/>
                         <field name="team_id" options='{"no_open": True, "no_create": True}' attrs="{'invisible': [('team_count', '&lt;=', 1)]}"/>
+                        <field name="fold_is_empty"/>
                         <field name="fold"/>
                     </group>
                     <group>

--- a/addons/hr_recruitment/i18n/hr_recruitment.pot
+++ b/addons/hr_recruitment/i18n/hr_recruitment.pot
@@ -1816,7 +1816,7 @@ msgstr ""
 
 #. module: hr_recruitment
 #: model:ir.model.fields,help:hr_recruitment.field_hr_recruitment_stage__fold
-msgid "This stage is folded in the kanban view when there are no records in that stage to display."
+msgid "This stage is folded in the kanban view."
 msgstr ""
 
 #. module: hr_recruitment

--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -60,7 +60,7 @@ class RecruitmentStage(models.Model):
         help="If set, a message is posted on the applicant using the template when the applicant is set to the stage.")
     fold = fields.Boolean(
         "Folded in Recruitment Pipe",
-        help="This stage is folded in the kanban view when there are no records in that stage to display.")
+        help="This stage is folded in the kanban view.")
     legend_blocked = fields.Char(
         'Red Kanban Label', default=lambda self: _('Blocked'), translate=True, required=True)
     legend_done = fields.Char(
@@ -167,7 +167,7 @@ class Applicant(models.Model):
     legend_blocked = fields.Char(related='stage_id.legend_blocked', string='Kanban Blocked', readonly=False)
     legend_done = fields.Char(related='stage_id.legend_done', string='Kanban Valid', readonly=False)
     legend_normal = fields.Char(related='stage_id.legend_normal', string='Kanban Ongoing', readonly=False)
-    
+
 
     @api.depends('date_open', 'date_closed')
     @api.one

--- a/addons/project/i18n/project.pot
+++ b/addons/project/i18n/project.pot
@@ -2673,7 +2673,7 @@ msgstr ""
 
 #. module: project
 #: model:ir.model.fields,help:project.field_project_task_type__fold
-msgid "This stage is folded in the kanban view when there are no records in that stage to display."
+msgid "This stage is folded in the kanban view."
 msgstr ""
 
 #. module: project

--- a/addons/project/i18n/pt_BR.po
+++ b/addons/project/i18n/pt_BR.po
@@ -2683,7 +2683,7 @@ msgstr "Este relatório permite analisar o desempenho de seus projetos e usuári
 
 #. module: project
 #: model:ir.model.fields,help:project.field_project_task_type__fold
-msgid "This stage is folded in the kanban view when there are no records in that stage to display."
+msgid "This stage is folded in the kanban view."
 msgstr "Este estágio fica dobrado na visão kanban quando não tem nenhum registro para mostrar neste estágio."
 
 #. module: project

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -40,7 +40,7 @@ class ProjectTaskType(models.Model):
         domain=[('model', '=', 'project.task')],
         help="If set an email will be sent to the customer when the task or issue reaches this step.")
     fold = fields.Boolean(string='Folded in Kanban',
-        help='This stage is folded in the kanban view when there are no records in that stage to display.')
+        help='This stage is folded in the kanban view.')
     rating_template_id = fields.Many2one(
         'mail.template',
         string='Rating Email Template',

--- a/addons/web/static/src/js/views/basic/basic_model.js
+++ b/addons/web/static/src/js/views/basic/basic_model.js
@@ -4239,6 +4239,13 @@ var BasicModel = AbstractModel.extend({
                     } else {
                         newGroup.isOpen = '__fold' in group ? !group.__fold : true;
                     }
+
+                    // Multidados
+                    // Dobra Estágio sem Registro, se configurado o estágio para isso
+                    if ('__auto_fold' in group && group.__auto_fold && 'stage_id_count' in group) {
+                        newGroup.isOpen = group.stage_id_count > 0;
+                    }
+
                     list.data.push(newGroup.id);
                     list.count += newGroup.count;
                     if (newGroup.isOpen && newGroup.count > 0) {

--- a/addons/website_event_track/i18n/website_event_track.pot
+++ b/addons/website_event_track/i18n/website_event_track.pot
@@ -1096,7 +1096,7 @@ msgstr ""
 
 #. module: website_event_track
 #: model:ir.model.fields,help:website_event_track.field_event_track_stage__fold
-msgid "This stage is folded in the kanban view when there are no records in that stage to display."
+msgid "This stage is folded in the kanban view."
 msgstr ""
 
 #. module: website_event_track

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -40,7 +40,7 @@ class TrackStage(models.Model):
         help="If set an email will be sent to the customer when the track reaches this step.")
     fold = fields.Boolean(
         string='Folded in Kanban',
-        help='This stage is folded in the kanban view when there are no records in that stage to display.')
+        help='This stage is folded in the kanban view.')
     is_done = fields.Boolean(string='Accepted Stage')
     is_cancel = fields.Boolean(string='Canceled Stage')
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -252,6 +252,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
     _parent_store = False       # set to True to compute parent_path field
     _date_name = 'date'         # field to use for default calendar view
     _fold_name = 'fold'         # field to determine folded groups in kanban views
+    _auto_fold = 'fold_is_empty' # Multidados: field to determine folded groups is empty in kanban views
 
     _needaction = False         # whether the model supports "need actions" (see mail)
     _translate = True           # False disables translations export for this model
@@ -1804,8 +1805,16 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         if field.relational and groups._fold_name in groups._fields:
             fold = {group.id: group[groups._fold_name]
                     for group in groups.browse([key for key in result if key])}
+
+            if groups._auto_fold in groups._fields:
+                auto_fold = {group.id: group[groups._auto_fold]
+                             for group in groups.browse([key for key in result if key])}
+            else:
+                auto_fold = {}
+
             for key, line in result.items():
                 line['__fold'] = fold.get(key, False)
+                line['__auto_fold'] = auto_fold.get(key, False)
 
         return list(result.values())
 


### PR DESCRIPTION
# Descrição

[Adiciona opção de '_auto_fold' na View Kanban](https://github.com/multidadosti-erp/odoo/commit/a1203989847229107a53134f4f3a5bef8cfb46cb)

[Adiciona 'auto Fold' módulo 'crm'](https://github.com/multidadosti-erp/odoo/commit/af2d0ea9ed68f59a2006b695470d9d8f197e8fed) 
- Atualiza View Form e Tree
- Atualiza Tradução pt_br do módulo
 
[Corrige a Mensagem 'FOLD' módulo 'hr_recruitment'](https://github.com/multidadosti-erp/odoo/commit/05894bb1f072d1fabfdc665ee6eb14fc53da297a)

[Corrige a Mensagem 'FOLD' módulo 'project'](https://github.com/multidadosti-erp/odoo/commit/b1943aa8cfd7f2d84b3fa72f3d4ba1bbe696a68d)
 
[Corrige a Mensagem 'FOLD' módulo 'website_event_track'](https://github.com/multidadosti-erp/odoo/commit/f2fec6b85228ec26a6102bd19c1bb5011bfdf337)

# Informações adicionais

Dados da tarefa: [T7112 ](https://multi.multidados.tech/web?#id=7521&action=328&model=project.task&view_type=form&menu_id=465)
