### PR TITLE
T7197 - Adicionar a Funcionalidade do widget="list_activity" do Odoo 14 ao Odoo 12

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -567,6 +567,7 @@ class MailActivityMixin(models.AbstractModel):
         related='activity_ids.activity_type_id', readonly=False,
         search='_search_activity_type_id',
         groups="base.group_user")
+    activity_type_icon = fields.Char('Activity Type Icon', related='activity_ids.icon')
     activity_date_deadline = fields.Date(
         'Next Activity Deadline',
         compute='_compute_activity_date_deadline', search='_search_activity_date_deadline',

--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -689,12 +689,7 @@ const ListActivity = KanbanActivity.extend({
         this.$('.o_activity_btn > span').prop('special_click', true);
         if (this.value.count) {
             let text;
-            if (this.recordData.activity_exception_decoration) {
-                text = _t('Warning');
-            } else {
-                text = this.recordData.activity_summary ||
-                          this.recordData.activity_type_id.data.display_name;
-            }
+            text = this.recordData.activity_summary || this.recordData.activity_type_id.data.display_name;
             this.$('.o_activity_summary').text(text);
         }
         if (this.recordData.activity_type_icon) {

--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -658,8 +658,69 @@ var KanbanActivity = BasicActivity.extend({
     },
 });
 
+// -----------------------------------------------------------------------------
+// Activities Widget for List views ('list_activity' widget)
+// -----------------------------------------------------------------------------
+const ListActivity = KanbanActivity.extend({
+    template: 'mail.ListActivity',
+    events: Object.assign({}, KanbanActivity.prototype.events, {
+        'click .dropdown-menu.o_activity': '_onDropdownClicked',
+    }),
+    fieldDependencies: _.extend({}, KanbanActivity.prototype.fieldDependencies, {
+        activity_summary: {type: 'char'},
+        activity_type_id: {type: 'many2one', relation: 'mail.activity.type'},
+        activity_type_icon: {type: 'char'},
+    }),
+    label: _t('Next Activity'),
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     * @private
+     */
+    _render: async function () {
+        await this._super(...arguments);
+        // set the 'special_click' prop on the activity icon to prevent from
+        // opening the record when the user clicks on it (as it opens the
+        // activity dropdown instead)
+        this.$('.o_activity_btn > span').prop('special_click', true);
+        if (this.value.count) {
+            let text;
+            if (this.recordData.activity_exception_decoration) {
+                text = _t('Warning');
+            } else {
+                text = this.recordData.activity_summary ||
+                          this.recordData.activity_type_id.data.display_name;
+            }
+            this.$('.o_activity_summary').text(text);
+        }
+        if (this.recordData.activity_type_icon) {
+            this.el.querySelector('.o_activity_btn > span').classList.replace('fa-clock-o', this.recordData.activity_type_icon);
+        }
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * As we are in a list view, we don't want clicks inside the activity
+     * dropdown to open the record in a form view.
+     *
+     * @private
+     * @param {MouseEvent} ev
+     */
+    _onDropdownClicked: function (ev) {
+        ev.stopPropagation();
+    },
+});
+
 field_registry
     .add('mail_activity', Activity)
+    .add('list_activity', ListActivity)
     .add('kanban_activity', KanbanActivity);
 
 return Activity;

--- a/addons/mail/static/src/scss/mail_activity.scss
+++ b/addons/mail/static/src/scss/mail_activity.scss
@@ -119,7 +119,7 @@
     }
 
     .o_activity_color_default {
-        color: #dddddd;
+        color: #2C8397;
     }
 
     .o_activity_color_planned {

--- a/addons/mail/static/src/scss/mail_activity.scss
+++ b/addons/mail/static/src/scss/mail_activity.scss
@@ -143,6 +143,25 @@
     }
 }
 
+/* list_activity widget */
+.o_list_view {
+    .o_list_table tbody > tr {
+        > td.o_data_cell.o_list_activity_cell {
+            overflow: visible !important; // allow the activity dropdown to overflow
+            .o_mail_activity {
+                display: flex;
+                max-width: 275px;
+                .o_activity_btn {
+                    margin-right: 3px;
+                }
+                .o_activity_summary {
+                    @include o-text-overflow;
+                }
+            }
+        }
+    }
+}
+
 /* Kanban View */
 .o_kanban_record{
     .o_kanban_inline_block {

--- a/addons/mail/static/src/xml/web_kanban_activity.xml
+++ b/addons/mail/static/src/xml/web_kanban_activity.xml
@@ -10,6 +10,12 @@
     </div>
 </t>
 
+<t t-name="mail.ListActivity" t-extend="mail.KanbanActivity">
+    <t t-jquery=".o_mail_activity" t-operation="append">
+        <span class="o_activity_summary"/>
+    </t>
+</t>
+
 <t t-name="mail.KanbanActivityLoading">
     <div class="dropdown-item text-center o_no_activity">
         <span class="fa fa-spinner fa-spin fa-2x" role="img" aria-label="Loading..." title="Loading..."/>

--- a/addons/purchase/i18n/pt_BR.po
+++ b/addons/purchase/i18n/pt_BR.po
@@ -27,10 +27,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-14 07:33+0000\n"
-"PO-Revision-Date: 2018-08-24 09:23+0000\n"
-"Last-Translator: Marcel Savegnago <marcel.savegnago@gmail.com>, 2021\n"
-"Language-Team: Portuguese (Brazil) (https://www.transifex.com/odoo/teams/41243/pt_BR/)\n"
+"POT-Creation-Date: 2023-04-11 14:43+0000\n"
+"PO-Revision-Date: 2023-04-11 14:43+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -52,7 +52,7 @@ msgstr "# de Linhas"
 #: model:mail.template,subject:purchase.email_template_edi_purchase
 #: model:mail.template,subject:purchase.email_template_edi_purchase_done
 msgid "${object.company_id.name} Order (Ref ${object.name or 'n/a' })"
-msgstr "${object.company_id.name} Pedido (Ref ${object.name or 'n/a' })"
+msgstr "${object.company_id.name} Ordem (Ref ${object.name or 'n/a' })"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.res_config_settings_view_form_purchase
@@ -60,14 +60,14 @@ msgid "3-way matching"
 msgstr "Combinação em 3 vias"
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__module_account_3way_match
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__module_account_3way_match
 msgid "3-way matching: purchases, receptions and bills"
 msgstr "Combinação em 3 vias: compras, recepções e contas"
 
 #. module: purchase
 #: model:mail.template,body_html:purchase.email_template_edi_purchase_done
-msgid ""
-"<div style=\"margin: 0px; padding: 0px;\">\n"
+msgid "<div style=\"margin: 0px; padding: 0px;\">\n"
 "    <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
 "        Dear ${object.partner_id.name}\n"
 "        % if object.partner_id.parent_id:\n"
@@ -86,31 +86,29 @@ msgid ""
 "        Best regards,\n"
 "    </p>\n"
 "</div>"
-msgstr ""
-"<div style=\"margin: 0px; padding: 0px;\">\n"
+msgstr "<div style=\"margin: 0px; padding: 0px;\">\n"
 "    <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
-"        Prezado ${object.partner_id.name}\n"
+"        Car@ ${object.partner_id.name}\n"
 "        % if object.partner_id.parent_id:\n"
 "            (${object.partner_id.parent_id.name})\n"
 "        % endif\n"
 "        <br/><br/>\n"
-"       Aqui está um pedido de compra em anexo<strong>${object.name}</strong>\n"
+"        Segue em anexo o pedido de cotação <strong>${object.name}</strong>\n"
 "        % if object.partner_ref:\n"
-"            with reference: ${object.partner_ref}\n"
+"            com a referencia: ${object.partner_ref}\n"
 "        % endif\n"
-"        amounting in <strong>${format_amount(object.amount_total, object.currency_id)}</strong>\n"
+"        no valor de <strong>${format_amount(object.amount_total, object.currency_id)}</strong>\n"
 "        de ${object.company_id.name}.\n"
 "        <br/><br/>\n"
-"       Se você tiver alguma dúvida, não hesite em nos contatar.\n"
+"        Se tiver alguma dúvida, não hesite em contactar-nos.\n"
 "        <br/><br/>\n"
-"        Atenciosamente\n"
+"        Os melhores cumprimentos,\n"
 "    </p>\n"
 "</div>"
 
 #. module: purchase
 #: model:mail.template,body_html:purchase.email_template_edi_purchase
-msgid ""
-"<div style=\"margin: 0px; padding: 0px;\">\n"
+msgid "<div style=\"margin: 0px; padding: 0px;\">\n"
 "    <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
 "        Dear ${object.partner_id.name}\n"
 "        % if object.partner_id.parent_id:\n"
@@ -128,80 +126,57 @@ msgid ""
 "        Best regards,\n"
 "    </p>\n"
 "</div>"
-msgstr ""
-"<div style=\"margin: 0px; padding: 0px;\">\n"
+msgstr "<div style=\"margin: 0px; padding: 0px;\">\n"
 "    <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
-"        Prezado ${object.partner_id.name}\n"
+"        Car@ ${object.partner_id.name}\n"
 "        % if object.partner_id.parent_id:\n"
 "            (${object.partner_id.parent_id.name})\n"
 "        % endif\n"
 "        <br/><br/>\n"
-"        Aqui está em anexo um pedido de orçamento<strong>${object.name}</strong>\n"
+"        Segue em anexo o pedido de cotação <strong>${object.name}</strong>\n"
 "        % if object.partner_ref:\n"
-"            with reference: ${object.partner_ref}\n"
+"            com a referencia: ${object.partner_ref}\n"
 "        % endif\n"
 "        de ${object.company_id.name}.\n"
 "        <br/><br/>\n"
-"       Se você tiver alguma dúvida, não hesite em nos contatar.\n"
+"        Se tiver alguma dúvida, não hesite em contactar-nos.\n"
 "        <br/><br/>\n"
-"         Atenciosamente,\n"
+"        Os melhores cumprimentos,\n"
 "    </p>\n"
 "</div>"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.res_config_settings_view_form_purchase
-msgid ""
-"<i class=\"fa fa-arrow-right\"/>\n"
+msgid "<i class=\"fa fa-arrow-right\"/>\n"
 "                                            How to import"
-msgstr ""
-"<i class=\"fa fa-arrow-right\"/>\n"
+msgstr "<i class=\"fa fa-arrow-right\"/>\n"
 "                                            Como importar"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_partner_kanban_view
-msgid ""
-"<i class=\"fa fa-fw fa-shopping-cart\" role=\"img\" aria-label=\"Shopping "
-"cart\" title=\"Shopping cart\"/>"
-msgstr ""
-"<i class=\"fa fa-fw fa-shopping-cart\" role=\"img\" aria-label=\"Shopping "
-"cart\" title=\"Shopping cart\"/>"
+msgid "<i class=\"fa fa-fw fa-shopping-cart\" role=\"img\" aria-label=\"Shopping cart\" title=\"Shopping cart\"/>"
+msgstr "<i class=\"fa fa-fw fa-shopping-cart\" role=\"img\" aria-label=\"Carrinho de compras\" title=\"Carrinho de compras\"/>"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.portal_my_purchase_orders
-msgid ""
-"<span class=\"badge badge-info\"><i class=\"fa fa-fw fa-file-text\"/> "
-"Waiting for Bill</span>"
-msgstr ""
-"<span class=\"badge badge-info\"><i class=\"fa fa-fw fa-file-text\"/> "
-"Esperando por conta</span>"
+msgid "<span class=\"badge badge-info\"><i class=\"fa fa-fw fa-file-text\"/> Waiting for Bill</span>"
+msgstr "<span class=\"badge badge-info\"><i class=\"fa fa-fw fa-file-text\"/> Esperando por conta</span>"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.portal_my_purchase_orders
-msgid ""
-"<span class=\"badge badge-secondary\"><i class=\"fa fa-fw fa-remove\"/> "
-"Cancelled</span>"
-msgstr ""
-"<span class=\"badge badge-secondary\"><i class=\"fa fa-fw fa-remove\"/> "
-"Cancelado</span>"
+msgid "<span class=\"badge badge-secondary\"><i class=\"fa fa-fw fa-remove\"/> Cancelled</span>"
+msgstr "<span class=\"badge badge-secondary\"><i class=\"fa fa-fw fa-remove\"/> Cancelado</span>"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.res_config_settings_view_form_purchase
-msgid ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" aria-label=\"Values set here are company-specific.\" "
-"groups=\"base.group_multi_company\" role=\"img\"/>"
-msgstr ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" aria-label=\"Values set here are company-specific.\" "
-"groups=\"base.group_multi_company\" role=\"img\"/>"
+msgid "<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-specific.\" aria-label=\"Values set here are company-specific.\" groups=\"base.group_multi_company\" role=\"img\"/>"
+msgstr "<span class=\"fa fa-lg fa-building-o\" title=\"Os valores definidos aqui são específicos da empresa.\" aria-label=\"Os valores definidos aqui são específicos da empresa.\" groups=\"base.group_multi_company\" role=\"img\"/>"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_form
-msgid ""
-"<span class=\"o_form_label\" attrs=\"{'invisible': [('state','not in',('draft','sent'))]}\">Request for Quotation </span>\n"
+msgid "<span class=\"o_form_label\" attrs=\"{'invisible': [('state','not in',('draft','sent'))]}\">Request for Quotation </span>\n"
 "                        <span class=\"o_form_label\" attrs=\"{'invisible': [('state','in',('draft','sent'))]}\">Purchase Order </span>"
-msgstr ""
-"<span class=\"o_form_label\" attrs=\"{'invisible': [('state','not in',('draft','sent'))]}\">Pedido de Cotação</span>\n"
+msgstr "<span class=\"o_form_label\" attrs=\"{'invisible': [('state','not in',('draft','sent'))]}\">Pedido de Cotação</span>\n"
 "                        <span class=\"o_form_label\" attrs=\"{'invisible': [('state','in',('draft','sent'))]}\">Ordem de compra </span>"
 
 #. module: purchase
@@ -307,12 +282,10 @@ msgstr "<strong>Seu Pedido de Referência:</strong>"
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_purchase_order_line__product_type
-msgid ""
-"A storable product is a product for which you manage stock. The Inventory app has to be installed.\n"
+msgid "A storable product is a product for which you manage stock. The Inventory app has to be installed.\n"
 "A consumable product is a product for which stock is not managed.\n"
 "A service is a non-material product you provide."
-msgstr ""
-"Um produto armazenável é um produto no qual você pode gerenciar o estoque. O aplicativo Inventário deve ser instalado.\n"
+msgstr "Um produto armazenável é um produto no qual você pode gerenciar o estoque. O aplicativo Inventário deve ser instalado.\n"
 "Um produto consumível é um produto para o qual o estoque não é gerenciado.\n"
 "Um serviço é um produto não material que você fornece."
 
@@ -342,12 +315,17 @@ msgid "Activity State"
 msgstr "Estado de Atividade"
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_purchase_order__activity_type_icon
+msgid "Activity Type Icon"
+msgstr "Ícone de Tipo de Atividade"
+
+#. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_account_invoice__purchase_id
 msgid "Add Purchase Order"
 msgstr "Adicionar Pedido de Compra"
 
 #. module: purchase
-#: code:addons/purchase/controllers/portal.py:50
+#: code:addons/purchase/controllers/portal.py:62
 #, python-format
 msgid "All"
 msgstr "Tudo"
@@ -360,7 +338,7 @@ msgstr "Permite editar ordens de compra"
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_bill_union__amount
 msgid "Amount"
-msgstr "Total"
+msgstr "Valor"
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order_line__account_analytic_id
@@ -385,12 +363,8 @@ msgstr "Aprovar Ordem"
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_account_invoice_line__purchase_id
-msgid ""
-"Associated Purchase Order. Filled in automatically when a PO is chosen on "
-"the vendor bill."
-msgstr ""
-"Ordem de Compra associada. Preenchida automaticamente quando um OC é "
-"escolhida na conta de fornecedor."
+msgid "Associated Purchase Order. Filled in automatically when a PO is chosen on the vendor bill."
+msgstr "Ordem de Compra associada. Preenchida automaticamente quando um OC é escolhida na conta de fornecedor."
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order__message_attachment_count
@@ -413,6 +387,7 @@ msgid "Average Price"
 msgstr "Preço Médio"
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__default_purchase_method
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__default_purchase_method
 msgid "Bill Control"
 msgstr "Controle de Conta"
@@ -460,15 +435,8 @@ msgstr "Mensagem de Bloqueio"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.res_config_settings_view_form_purchase
-msgid ""
-"By default, vendor prices can be set manually in the product detail form. If"
-" your vendors provide you with pricelist files, this option allows you to "
-"easily import them into the system from ‘Purchase > Vendor Pricelists’ menu."
-msgstr ""
-"Por padrão, os preços do fornecedor podem ser definidos manualmente no "
-"formulário de detalhes do produto. Se seus fornecedores fornecem arquivos de"
-" lista de preços, esta opção permite importá-los facilmente para o sistema a"
-" partir do menu ‘Comprar> Lista de preços do fornecedor’."
+msgid "By default, vendor prices can be set manually in the product detail form. If your vendors provide you with pricelist files, this option allows you to easily import them into the system from ‘Purchase > Vendor Pricelists’ menu."
+msgstr "Por padrão, os preços do fornecedor podem ser definidos manualmente no formulário de detalhes do produto. Se seus fornecedores fornecem arquivos de lista de preços, esta opção permite importá-los facilmente para o sistema a partir do menu ‘Comprar> Lista de preços do fornecedor’."
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_calendar
@@ -477,17 +445,8 @@ msgstr "Visão de Calendário"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.res_config_settings_view_form_purchase
-msgid ""
-"Calls for tenders are used when you want to generate requests for quotations"
-" to several vendors for a given set of products. You can configure per "
-"product if you directly do a Request for Quotation to one vendor or if you "
-"want a Call for Tenders to compare offers from several vendors."
-msgstr ""
-"Os editais são usados quando você deseja gerar pedidos de cotação para "
-"vários fornecedores para um determinado conjunto de produtos. Você pode "
-"configurar por produto se fizer uma solicitação de cotação diretamente a um "
-"fornecedor ou se quiser uma licitação para comparar ofertas de vários "
-"fornecedores."
+msgid "Calls for tenders are used when you want to generate requests for quotations to several vendors for a given set of products. You can configure per product if you directly do a Request for Quotation to one vendor or if you want a Call for Tenders to compare offers from several vendors."
+msgstr "Os editais são usados quando você deseja gerar pedidos de cotação para vários fornecedores para um determinado conjunto de produtos. Você pode configurar por produto se fizer uma solicitação de cotação diretamente a um fornecedor ou se quiser uma licitação para comparar ofertas de vários fornecedores."
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_form
@@ -495,8 +454,9 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: purchase
-#: code:addons/purchase/controllers/portal.py:52
-#: selection:purchase.order,state:0 selection:purchase.report,state:0
+#: code:addons/purchase/controllers/portal.py:64
+#: selection:purchase.order,state:0
+#: selection:purchase.report,state:0
 #, python-format
 msgid "Cancelled"
 msgstr "Cancelado"
@@ -507,7 +467,7 @@ msgid "Cancelled Purchase Order #"
 msgstr "Ordem de Compra Cancelada #"
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:509
+#: code:addons/purchase/models/purchase.py:559
 #, python-format
 msgid "Cannot delete a purchase order line which is in state '%s'."
 msgstr "Não é possível excluir uma linha do pedido de compras no estado '%s'."
@@ -532,12 +492,13 @@ msgid "Company"
 msgstr "Empresa"
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__company_currency_id
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__company_currency_id
 msgid "Company Currency"
 msgstr "Moeda da Empresa"
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:268
+#: code:addons/purchase/models/purchase.py:296
 #, python-format
 msgid "Compose Email"
 msgstr "Escrever E-mail"
@@ -566,11 +527,6 @@ msgstr "Confirmar pedidos de compra em uma etapa"
 #: selection:res.company,po_lock:0
 msgid "Confirmed purchase orders are not editable"
 msgstr "Ordens confirmadas não são editáveis"
-
-#. module: purchase
-#: model:ir.model,name:purchase.model_res_partner
-msgid "Contact"
-msgstr "Parceiro"
 
 #. module: purchase
 #: model:ir.ui.menu,name:purchase.menu_purchase_control
@@ -669,19 +625,16 @@ msgid "Define your terms and conditions ..."
 msgstr "Definir seus termos e condições ..."
 
 #. module: purchase
+#: selection:contact.config.settings,default_purchase_method:0
 #: selection:res.config.settings,default_purchase_method:0
 msgid "Delivered quantities"
-msgstr "Quantidades entregues"
+msgstr "Qtdes Entregues"
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_purchase_order__date_order
 #: model:ir.model.fields,help:purchase.field_purchase_order_line__date_order
-msgid ""
-"Depicts the date where the Quotation should be validated and converted into "
-"a purchase order."
-msgstr ""
-"Descreve a data em que a cotação deve ser validada e convertida em um pedido"
-" de compra."
+msgid "Depicts the date where the Quotation should be validated and converted into a purchase order."
+msgstr "Descreve a data em que a cotação deve ser validada e convertida em um pedido de compra."
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order_line__name
@@ -732,7 +685,7 @@ msgid "Extended Filters"
 msgstr "Filtros Ampliados"
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:491
+#: code:addons/purchase/models/purchase.py:541
 #, python-format
 msgid "Extra line with %s "
 msgstr "Linha extra com %s "
@@ -760,9 +713,19 @@ msgid "Followers (Partners)"
 msgstr "Seguidores (Parceiros)"
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_purchase_order__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr "Ícone do Font Awesome. Ex: fa-tasks"
+
+#. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.view_purchase_order_filter
 msgid "Future Activities"
 msgstr "Atividades Futuras"
+
+#. module: purchase
+#: model_terms:ir.ui.view,arch_db:purchase.purchase_order_line_form2
+msgid "General"
+msgstr "Geral"
 
 #. module: purchase
 #: selection:res.company,po_double_validation:0
@@ -797,7 +760,7 @@ msgstr "Ocultar linhas canceladas"
 #: model:ir.model.fields,field_description:purchase.field_purchase_order_line__id
 #: model:ir.model.fields,field_description:purchase.field_purchase_report__id
 msgid "ID"
-msgstr "ID"
+msgstr "Id."
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_purchase_order__message_unread
@@ -816,12 +779,8 @@ msgstr "Se marcado, algumas mensagens tem erro de entrega."
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.res_config_settings_view_form_purchase
-msgid ""
-"If enabled, activates 3-way matching on vendor bills : the items must be "
-"received in order to pay the invoice."
-msgstr ""
-"Se habilitado, ativa combinação em 3 vias para contas de fornecedor: os "
-"itens devem ser recebidos para que a fatura seja paga."
+msgid "If enabled, activates 3-way matching on vendor bills : the items must be received in order to pay the invoice."
+msgstr "Se habilitado, ativa combinação em 3 vias para contas de fornecedor: os itens devem ser recebidos para que a fatura seja paga."
 
 #. module: purchase
 #: code:addons/purchase/models/product.py:38
@@ -835,25 +794,20 @@ msgid "Import vendor pricelists"
 msgstr "Importar lista de preço de fornecedor"
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:165
+#: code:addons/purchase/models/purchase.py:172
 #, python-format
 msgid "In order to delete a purchase order, you must cancel it first."
-msgstr ""
-"Para poder excluir uma ordem de compra, você precisa primeiro cancelá-la"
+msgstr "Para poder excluir uma ordem de compra, você precisa primeiro cancelá-la"
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order__incoterm_id
 msgid "Incoterm"
-msgstr "Incoterm"
+msgstr ""
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_purchase_order__incoterm_id
-msgid ""
-"International Commercial Terms are a series of predefined commercial terms "
-"used in international transactions."
-msgstr ""
-"International Commercial Terms são uma série de termos comerciais pré-"
-"definidos utilizados em transações internacionais."
+msgid "International Commercial Terms are a series of predefined commercial terms used in international transactions."
+msgstr "International Commercial Terms são uma série de termos comerciais pré-definidos utilizados em transações internacionais."
 
 #. module: purchase
 #: model:ir.model,name:purchase.model_account_invoice
@@ -873,7 +827,7 @@ msgstr "Faturas e Remessas Recebidas"
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.res_config_settings_view_form_purchase
 msgid "Invoicing"
-msgstr "Faturamento"
+msgstr "Financeiro"
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order__message_is_follower
@@ -891,7 +845,7 @@ msgstr "Será convertido em uma ordem de compra."
 #: model:ir.model.fields,field_description:purchase.field_purchase_order_line____last_update
 #: model:ir.model.fields,field_description:purchase.field_purchase_report____last_update
 msgid "Last Modified on"
-msgstr "Última modificação em"
+msgstr "Última Modificação em"
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order__write_uid
@@ -916,18 +870,15 @@ msgid "Levels of Approvals"
 msgstr "Níveis de Aprovações"
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__po_double_validation
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__po_double_validation
 msgid "Levels of Approvals *"
 msgstr "Níveis de aprovação"
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_account_invoice__purchase_id
-msgid ""
-"Load the vendor bill based on selected purchase order. Several PO can be "
-"selected."
-msgstr ""
-"Carregar a fatura de fornecedor baseada na ordem de compra selecionada. "
-"Muitas ordens de compra podem ser selecionadas"
+msgid "Load the vendor bill based on selected purchase order. Several PO can be selected."
+msgstr "Carregar a fatura de fornecedor baseada na ordem de compra selecionada. Muitas ordens de compra podem ser selecionadas"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_form
@@ -935,12 +886,13 @@ msgid "Lock"
 msgstr "Trancar"
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__lock_confirmed_po
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__lock_confirmed_po
 msgid "Lock Confirmed Orders"
 msgstr "Trancar Pedidos Confirmados"
 
 #. module: purchase
-#: code:addons/purchase/controllers/portal.py:53
+#: code:addons/purchase/controllers/portal.py:65
 #: selection:purchase.order,state:0
 #, python-format
 msgid "Locked"
@@ -953,11 +905,8 @@ msgstr "Anexo Principal"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.res_config_settings_view_form_purchase
-msgid ""
-"Make sure you only pay bills for which you received the goods you ordered"
-msgstr ""
-"Certifique-se de pagar somente as contas pelas quais você recebeu os bens "
-"que pediu"
+msgid "Make sure you only pay bills for which you received the goods you ordered"
+msgstr "Certifique-se de pagar somente as contas pelas quais você recebeu os bens que pediu"
 
 #. module: purchase
 #: model:res.groups,name:purchase.group_manage_vendor_price
@@ -985,28 +934,17 @@ msgid "Manual Invoices"
 msgstr "Faturamento Manual"
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__po_lead
 #: model:ir.model.fields,help:purchase.field_res_company__po_lead
 #: model:ir.model.fields,help:purchase.field_res_config_settings__po_lead
-msgid ""
-"Margin of error for vendor lead times. When the system generates Purchase "
-"Orders for procuring products, they will be scheduled that many days earlier"
-" to cope with unexpected vendor delays."
-msgstr ""
-"A margem de erro para os prazos de entrega do fornecedor. Quando o sistema "
-"gera Pedidos de Compra para a aquisição de produtos, eles serão agendados "
-"dias antes para lidar com atrasos inesperados de fornecedores."
+msgid "Margin of error for vendor lead times. When the system generates Purchase Orders for procuring products, they will be scheduled that many days earlier to cope with unexpected vendor delays."
+msgstr "A margem de erro para os prazos de entrega do fornecedor. Quando o sistema gera Pedidos de Compra para a aquisição de produtos, eles serão agendados dias antes para lidar com atrasos inesperados de fornecedores."
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__use_po_lead
 #: model:ir.model.fields,help:purchase.field_res_config_settings__use_po_lead
-msgid ""
-"Margin of error for vendor lead times. When the system generates Purchase "
-"Orders for reordering products,they will be scheduled that many days earlier"
-" to cope with unexpected vendor delays."
-msgstr ""
-"Margem de erro para tempo de entrega de fornecedor. Quando o sistema gerar "
-"Ordens de Compra para recomprar produtos, eles serão agendados nesses número"
-" de dias anteriormente para levar em conta demoras inesperadas de "
-"fornecedores."
+msgid "Margin of error for vendor lead times. When the system generates Purchase Orders for reordering products,they will be scheduled that many days earlier to cope with unexpected vendor delays."
+msgstr "Margem de erro para tempo de entrega de fornecedor. Quando o sistema gerar Ordens de Compra para recomprar produtos, eles serão agendados nesses número de dias anteriormente para levar em conta demoras inesperadas de fornecedores."
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order__message_has_error
@@ -1031,11 +969,13 @@ msgid "Messages"
 msgstr "Mensagens"
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__po_double_validation_amount
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__po_double_validation_amount
 msgid "Minimum Amount"
 msgstr "Quantidade Mínima"
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__po_double_validation_amount
 #: model:ir.model.fields,help:purchase.field_res_company__po_double_validation_amount
 #: model:ir.model.fields,help:purchase.field_res_config_settings__po_double_validation_amount
 msgid "Minimum amount for which a double validation is required"
@@ -1057,7 +997,7 @@ msgid "My Purchases"
 msgstr "Minhas Compras"
 
 #. module: purchase
-#: code:addons/purchase/controllers/portal.py:41
+#: code:addons/purchase/controllers/portal.py:53
 #, python-format
 msgid "Name"
 msgstr "Nome"
@@ -1068,10 +1008,15 @@ msgid "Name, TIN, Email, or Reference"
 msgstr "Nome, TIN, e-mail ou referência"
 
 #. module: purchase
-#: code:addons/purchase/controllers/portal.py:40
+#: code:addons/purchase/controllers/portal.py:52
 #, python-format
 msgid "Newest"
 msgstr "Mais Recente"
+
+#. module: purchase
+#: model_terms:ir.ui.view,arch_db:purchase.purchase_order_tree
+msgid "Next Activity"
+msgstr "Próxima Atividade"
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order__activity_date_deadline
@@ -1106,12 +1051,8 @@ msgstr "Não editar pedidos uma vez confirmados"
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_purchase_order_line__product_image
-msgid ""
-"Non-stored related field to allow portal user to see the image of the "
-"product he has ordered"
-msgstr ""
-"Campo relacionado não armazenado para permitir que o usuário do portal veja "
-"a imagem do produto que solicitou"
+msgid "Non-stored related field to allow portal user to see the image of the product he has ordered"
+msgstr "Campo relacionado não armazenado para permitir que o usuário do portal veja a imagem do produto que solicitou"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_form
@@ -1156,11 +1097,9 @@ msgstr "Em quantidades solicitadas"
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_product_product__purchase_method
 #: model:ir.model.fields,help:purchase.field_product_template__purchase_method
-msgid ""
-"On ordered quantities: Control bills based on ordered quantities.\n"
+msgid "On ordered quantities: Control bills based on ordered quantities.\n"
 "On received quantities: Control bills based on received quantities."
-msgstr ""
-"Em quantidades pedidas: controle as contas com base nas quantidades pedidas.\n"
+msgstr "Em quantidades pedidas: controle as contas com base nas quantidades pedidas.\n"
 "Em quantidades recebidas: Controle as contas com base nas quantidades recebidas."
 
 #. module: purchase
@@ -1198,12 +1137,13 @@ msgstr "Situação de Pedido"
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.track_po_line_template
 msgid "Ordered Quantity:"
-msgstr "Quantidade Pedida:"
+msgstr "Qtde Pedida:"
 
 #. module: purchase
+#: selection:contact.config.settings,default_purchase_method:0
 #: selection:res.config.settings,default_purchase_method:0
 msgid "Ordered quantities"
-msgstr "Quantidades solicitadas"
+msgstr "Qtdes Solicitadas"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.res_config_settings_view_form_purchase
@@ -1224,9 +1164,10 @@ msgstr "Vencido"
 #. module: purchase
 #: model:mail.template,report_name:purchase.email_template_edi_purchase_done
 msgid "PO_${(object.name or '').replace('/','_')}"
-msgstr "OC_${(object.name or '').replace('/','_')}"
+msgstr ""
 
 #. module: purchase
+#: model:ir.model,name:purchase.model_res_partner
 #: model:ir.model.fields,field_description:purchase.field_purchase_order_line__partner_id
 msgid "Partner"
 msgstr "Parceiro"
@@ -1298,7 +1239,7 @@ msgstr "Imagem do Produto"
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_report__unit_quantity
 msgid "Product Quantity"
-msgstr "Quantidade do produto"
+msgstr "Qtde Produto"
 
 #. module: purchase
 #: model:ir.model,name:purchase.model_product_template
@@ -1337,6 +1278,7 @@ msgid "Products Value"
 msgstr "Valor dos Produtos"
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__po_double_validation
 #: model:ir.model.fields,help:purchase.field_res_company__po_double_validation
 #: model:ir.model.fields,help:purchase.field_res_config_settings__po_double_validation
 msgid "Provide a double validation mechanism for purchases"
@@ -1350,6 +1292,7 @@ msgid "Purchase"
 msgstr "Compra"
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__module_purchase_requisition
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__module_purchase_requisition
 msgid "Purchase Agreements"
 msgstr "Acordos de Compra"
@@ -1361,17 +1304,11 @@ msgstr "Análise de Compras"
 
 #. module: purchase
 #: model_terms:ir.actions.act_window,help:purchase.action_purchase_order_report_all
-msgid ""
-"Purchase Analysis allows you to easily check and analyse your company "
-"purchase history and performance. From this menu you can track your "
-"negotiation performance, the delivery performance of your vendors, etc."
-msgstr ""
-"A Análise de Compras permite a você conferir e analisar facilmente o "
-"histórico e performance de compras da sua empresa. Neste menu você pode "
-"monitorar a performance de negociação, a performance de entrega dos "
-"fornecedores, etc."
+msgid "Purchase Analysis allows you to easily check and analyse your company purchase history and performance. From this menu you can track your negotiation performance, the delivery performance of your vendors, etc."
+msgstr "A Análise de Compras permite a você conferir e analisar facilmente o histórico e performance de compras da sua empresa. Neste menu você pode monitorar a performance de negociação, a performance de entrega dos fornecedores, etc."
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__po_lead
 #: model:ir.model.fields,field_description:purchase.field_res_company__po_lead
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__po_lead
 msgid "Purchase Lead Time"
@@ -1379,7 +1316,7 @@ msgstr "Prazo de compras"
 
 #. module: purchase
 #: code:addons/purchase/controllers/portal.py:63
-#: code:addons/purchase/models/purchase.py:281
+#: code:addons/purchase/models/purchase.py:293
 #: model:ir.actions.report,name:purchase.action_report_purchase_order
 #: model:ir.model,name:purchase.model_purchase_order
 #: model:ir.model.fields,field_description:purchase.field_account_invoice_line__purchase_id
@@ -1391,7 +1328,8 @@ msgstr "Prazo de compras"
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_graph
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_pivot
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_tree
-#: selection:purchase.order,state:0 selection:purchase.report,state:0
+#: selection:purchase.order,state:0
+#: selection:purchase.report,state:0
 #, python-format
 msgid "Purchase Order"
 msgstr "Pedido de Compra"
@@ -1402,6 +1340,7 @@ msgid "Purchase Order #"
 msgstr "Ordem de Compra #"
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__po_order_approval
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__po_order_approval
 msgid "Purchase Order Approval"
 msgstr "Aprovação do pedido de compra"
@@ -1444,19 +1383,17 @@ msgid "Purchase Order Modification"
 msgstr "Modificação de ordem de compra"
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__po_lock
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__po_lock
 msgid "Purchase Order Modification *"
 msgstr "Modificação de ordem de compra *"
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__po_lock
 #: model:ir.model.fields,help:purchase.field_res_company__po_lock
 #: model:ir.model.fields,help:purchase.field_res_config_settings__po_lock
-msgid ""
-"Purchase Order Modification used when you want to purchase order editable "
-"after confirm"
-msgstr ""
-"Modificação da ordem de compra usada quando você deseja que a ordem de "
-"compra seja editável após a confirmação"
+msgid "Purchase Order Modification used when you want to purchase order editable after confirm"
+msgstr "Modificação da ordem de compra usada quando você deseja que a ordem de compra seja editável após a confirmação"
 
 #. module: purchase
 #: model:ir.actions.act_window,name:purchase.purchase_form_action
@@ -1493,9 +1430,10 @@ msgstr "Relatório de Compra"
 #: model_terms:ir.ui.view,arch_db:purchase.view_purchase_order_filter
 #: model_terms:ir.ui.view,arch_db:purchase.view_purchase_order_search
 msgid "Purchase Representative"
-msgstr "Representativo de Compra"
+msgstr "Representante Compra"
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__group_warning_purchase
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__group_warning_purchase
 msgid "Purchase Warnings"
 msgstr "Avisos de Compra"
@@ -1544,12 +1482,8 @@ msgstr "União de compras & contas"
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_purchase_order__dest_address_id
-msgid ""
-"Put an address if you want to deliver directly from the vendor to the "
-"customer. Otherwise, keep empty to deliver to your own company."
-msgstr ""
-"Coloque um endereço, se você quer entregar diretamente do fornecedor ao "
-"cliente. Caso contrário, mantenha vazio para entregar a sua própria empresa."
+msgid "Put an address if you want to deliver directly from the vendor to the customer. Otherwise, keep empty to deliver to your own company."
+msgstr "Coloque um endereço, se você quer entregar diretamente do fornecedor ao cliente. Caso contrário, mantenha vazio para entregar a sua própria empresa."
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.res_config_settings_view_form_purchase
@@ -1588,14 +1522,15 @@ msgid "RFQ Done"
 msgstr "PDC Concluído"
 
 #. module: purchase
-#: selection:purchase.order,state:0 selection:purchase.report,state:0
+#: selection:purchase.order,state:0
+#: selection:purchase.report,state:0
 msgid "RFQ Sent"
 msgstr "RC Enviada"
 
 #. module: purchase
 #: model:mail.template,report_name:purchase.email_template_edi_purchase
 msgid "RFQ_${(object.name or '').replace('/','_')}"
-msgstr "RFQ_${(object.name or '').replace('/','_')}"
+msgstr ""
 
 #. module: purchase
 #: model:ir.actions.act_window,name:purchase.act_res_partner_2_purchase_order
@@ -1647,24 +1582,13 @@ msgstr "Unidade de Medida referencial"
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_purchase_order__origin
-msgid ""
-"Reference of the document that generated this purchase order request (e.g. a"
-" sales order)"
-msgstr ""
-"Referência do documento que gerou o requerimento para essa ordem de compra "
-"(ex.: uma ordem de compra)"
+msgid "Reference of the document that generated this purchase order request (e.g. a sales order)"
+msgstr "Referência do documento que gerou o requerimento para essa ordem de compra (ex.: uma ordem de compra)"
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_purchase_order__partner_ref
-msgid ""
-"Reference of the sales order or bid sent by the vendor. It's used to do the "
-"matching when you receive the products as this reference is usually written "
-"on the delivery order sent by your vendor."
-msgstr ""
-"Referência de pedidos de venda ou oferta enviada pelo fornecedor. É usada "
-"para fazer a correspondência quando você recebe os produtos como esta "
-"referência é geralmente escrito no pedido de entrega enviada pelo seu "
-"fornecedor."
+msgid "Reference of the sales order or bid sent by the vendor. It's used to do the matching when you receive the products as this reference is usually written on the delivery order sent by your vendor."
+msgstr "Referência de pedidos de venda ou oferta enviada pelo fornecedor. É usada para fazer a correspondência quando você recebe os produtos como esta referência é geralmente escrito no pedido de entrega enviada pelo seu fornecedor."
 
 #. module: purchase
 #: model:ir.ui.menu,name:purchase.purchase_report
@@ -1672,7 +1596,7 @@ msgid "Reporting"
 msgstr "Relatórios"
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:276
+#: code:addons/purchase/models/purchase.py:291
 #: model:ir.actions.report,name:purchase.report_purchase_quotation
 #: model_terms:ir.ui.view,arch_db:purchase.portal_my_purchase_order
 #: model_terms:ir.ui.view,arch_db:purchase.report_purchasequotation_document
@@ -1683,7 +1607,7 @@ msgstr "Solicitação para Cotação"
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.report_purchaseorder_document
 msgid "Request for Quotation #"
-msgstr "Solicitar Cotação "
+msgstr "Solicitar Cotação #"
 
 #. module: purchase
 #: model:ir.actions.act_window,name:purchase.purchase_rfq
@@ -1714,6 +1638,7 @@ msgid "Search Reference Document"
 msgstr "Procurar Documento Referência"
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__use_po_lead
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__use_po_lead
 msgid "Security Lead Time for Purchase"
 msgstr "Margem de Segurança de Tempo Para Compra"
@@ -1733,14 +1658,8 @@ msgstr "Selecione uma ordem de compra para uma fatura velha"
 #: model:ir.model.fields,help:purchase.field_product_template__purchase_line_warn
 #: model:ir.model.fields,help:purchase.field_res_partner__purchase_warn
 #: model:ir.model.fields,help:purchase.field_res_users__purchase_warn
-msgid ""
-"Selecting the \"Warning\" option will notify user with the message, "
-"Selecting \"Blocking Message\" will throw an exception with the message and "
-"block the flow. The Message has to be written in the next field."
-msgstr ""
-"Selecionando a opção de \"Aviso\" irá notificar o usuário com a mensagem, "
-"marcar \"Mensagem de Bloqueio\" irá lançar uma exceção com a mensagem e "
-"bloquear o fluxo. A mensagem tem de ser escrita no campo a seguir."
+msgid "Selecting the \"Warning\" option will notify user with the message, Selecting \"Blocking Message\" will throw an exception with the message and block the flow. The Message has to be written in the next field."
+msgstr "Selecionando a opção de \"Aviso\" irá notificar o usuário com a mensagem, marcar \"Mensagem de Bloqueio\" irá lançar uma exceção com a mensagem e bloquear o fluxo. A mensagem tem de ser escrita no campo a seguir."
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_form
@@ -1781,8 +1700,7 @@ msgstr "Compartilhar"
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.view_purchase_order_filter
 msgid "Show all records which has next action date is before today"
-msgstr ""
-"Mostrar todas as gravações em que a próxima data de ação seja antes de hoje."
+msgstr "Mostrar todas as gravações em que a próxima data de ação seja antes de hoje."
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_bill_union__reference
@@ -1804,13 +1722,11 @@ msgstr "Situação"
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_purchase_order__activity_state
-msgid ""
-"Status based on activities\n"
+msgid "Status based on activities\n"
 "Overdue: Due date is already passed\n"
 "Today: Activity date is today\n"
 "Planned: Future activities."
-msgstr ""
-"Status baseado em atividades\n"
+msgstr "Status baseado em atividades\n"
 "Atrasado: Data definida já passou\n"
 "Hoje: Data de atividade é hoje\n"
 "Planejado: Atividades futuras."
@@ -1855,71 +1771,48 @@ msgstr "Termos e Condições"
 
 #. module: purchase
 #: model_terms:ir.actions.act_window,help:purchase.purchase_rfq
-msgid ""
-"The quotation contains the history of the discussion\n"
+msgid "The quotation contains the history of the discussion\n"
 "                you had with your vendor."
-msgstr ""
-"A cotação contém a história da discussão\n"
+msgstr "A cotação contém a história da discussão\n"
 "                que você teve como fornecedor."
 
 #. module: purchase
 #: model_terms:ir.actions.act_window,help:purchase.act_res_partner_2_purchase_order
-msgid ""
-"The request for quotation is the first step of the purchases flow. Once\n"
+msgid "The request for quotation is the first step of the purchases flow. Once\n"
 "                    converted into a purchase order, you will be able to control the receipt\n"
 "                    of the products and the vendor bill."
-msgstr ""
-"O pedido de cotação é a primeira etapa do fluxo compras. Uma vez\n"
-"convertida em um pedido de compra, você será capaz de controlar o recebimento\n"
-"dos produtos e da conta de fornecedor."
+msgstr "O pedido de cotação é a primeira etapa do fluxo compras. Uma vez\n"
+"                    convertida em um pedido de compra, você será capaz de controlar o recebimento\n"
+"                    dos produtos e da conta de fornecedor."
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_product_product__property_account_creditor_price_difference
 #: model:ir.model.fields,help:purchase.field_product_template__property_account_creditor_price_difference
-msgid ""
-"This account is used in automated inventory valuation to record the price "
-"difference between a purchase order and its related vendor bill when "
-"validating this vendor bill."
-msgstr ""
-"Esta conta é usada em avaliação automatizada de estoque para registrar a "
-"diferença de preço entre uma ordem de compra e sua conta de fornecedor "
-"relacionada ao validar esta conta de fornecedor."
+msgid "This account is used in automated inventory valuation to record the price difference between a purchase order and its related vendor bill when validating this vendor bill."
+msgstr "Esta conta é usada em avaliação automatizada de estoque para registrar a diferença de preço entre uma ordem de compra e sua conta de fornecedor relacionada ao validar esta conta de fornecedor."
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_product_category__property_account_creditor_price_difference_categ
-msgid ""
-"This account will be used to value price difference between purchase price "
-"and accounting cost."
-msgstr ""
-"Esta conta será usada para avaliar diferença de preço entre preço de compra "
-"e custo contábil."
+msgid "This account will be used to value price difference between purchase price and accounting cost."
+msgstr "Esta conta será usada para avaliar diferença de preço entre preço de compra e custo contábil."
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_form
 msgid "This changes the scheduled date of all order lines to the given date"
-msgstr ""
-"Isso muda a data de todas as linhas de pedido agendadas para uma data "
-"definida"
+msgstr "Isso muda a data de todas as linhas de pedido agendadas para uma data definida"
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_res_partner__property_purchase_currency_id
 #: model:ir.model.fields,help:purchase.field_res_users__property_purchase_currency_id
-msgid ""
-"This currency will be used, instead of the default one, for purchases from "
-"the current partner"
-msgstr ""
-"Esta moeda será utilizada, em vez da padrão, para as compras do parceiro "
-"atual"
+msgid "This currency will be used, instead of the default one, for purchases from the current partner"
+msgstr "Esta moeda será utilizada, em vez da padrão, para as compras do parceiro atual"
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__default_purchase_method
 #: model:ir.model.fields,help:purchase.field_res_config_settings__default_purchase_method
 #: model_terms:ir.ui.view,arch_db:purchase.res_config_settings_view_form_purchase
-msgid ""
-"This default value is applied to any new product created. This can be "
-"changed in the product detail form."
-msgstr ""
-"Esse valor padrão é aplicado para cada novo produto criado. Isso pode ser "
-"mudado no formulário detalhe do produto."
+msgid "This default value is applied to any new product created. This can be changed in the product detail form."
+msgstr "Esse valor padrão é aplicado para cada novo produto criado. Isso pode ser mudado no formulário detalhe do produto."
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.view_product_supplier_inherit
@@ -1927,13 +1820,13 @@ msgid "This note will show up on purchase orders."
 msgstr "Essa nota aparecerá em ordens de compra."
 
 #. module: purchase
-#: code:addons/purchase/models/account_invoice.py:156
+#: code:addons/purchase/models/account_invoice.py:164
 #, python-format
 msgid "This vendor bill has been created from: %s"
 msgstr "Esta fatura de fornecedor foi criada de: %s"
 
 #. module: purchase
-#: code:addons/purchase/models/account_invoice.py:170
+#: code:addons/purchase/models/account_invoice.py:178
 #, python-format
 msgid "This vendor bill has been modified from: %s"
 msgstr "Esta fatura de fornecedor foi modificada por: %s"
@@ -1941,13 +1834,12 @@ msgstr "Esta fatura de fornecedor foi modificada por: %s"
 #. module: purchase
 #: model_terms:ir.actions.act_window,help:purchase.act_res_partner_2_purchase_order
 msgid "This vendor has no purchase order. Create a new RfQ"
-msgstr ""
-"Esse fornecedor não tem ordem de compra. Criar um novo Requerimento para "
-"Cotação"
+msgstr "Esse fornecedor não tem ordem de compra. Criar um novo Requerimento para Cotação"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.view_purchase_order_filter
-#: selection:purchase.order,state:0 selection:purchase.report,state:0
+#: selection:purchase.order,state:0
+#: selection:purchase.report,state:0
 msgid "To Approve"
 msgstr "Para Aprovar"
 
@@ -1962,7 +1854,7 @@ msgid "Today Activities"
 msgstr "Atividades de Hoje"
 
 #. module: purchase
-#: code:addons/purchase/controllers/portal.py:42
+#: code:addons/purchase/controllers/portal.py:54
 #: model:ir.model.fields,field_description:purchase.field_purchase_order__amount_total
 #: model:ir.model.fields,field_description:purchase.field_purchase_order_line__price_total
 #: model_terms:ir.ui.view,arch_db:purchase.portal_my_purchase_orders
@@ -1978,7 +1870,7 @@ msgstr "Preço Total"
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order_line__product_uom_qty
 msgid "Total Quantity"
-msgstr "Quantidade Total"
+msgstr "Qtd Total"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_tree
@@ -1991,14 +1883,10 @@ msgid "Total amount"
 msgstr "Valor total"
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:324
+#: code:addons/purchase/models/purchase.py:352
 #, python-format
-msgid ""
-"Unable to cancel this purchase order. You must first cancel the related "
-"vendor bills."
-msgstr ""
-"Incapaz de cancelar essa ordem de compra. Você primeiro deve cancelar as "
-"notas de fornecedor relacionadas."
+msgid "Unable to cancel this purchase order. You must first cancel the related vendor bills."
+msgstr "Incapaz de cancelar essa ordem de compra. Você primeiro deve cancelar as notas de fornecedor relacionadas."
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order_line__price_unit
@@ -2047,15 +1935,13 @@ msgstr "Valor sem Impostos"
 
 #. module: purchase
 #: model_terms:ir.actions.act_window,help:purchase.action_invoice_pending
-msgid ""
-"Use this menu to control the invoices to be received from your\n"
+msgid "Use this menu to control the invoices to be received from your\n"
 "            vendors. When registering a new bill, set the purchase order\n"
 "            and Odoo will fill the bill automatically according to ordered\n"
 "            or received quantities."
-msgstr ""
-"Use esse menu para controlar as faturas para serem recebidas de seus\n"
+msgstr "Use esse menu para controlar as faturas para serem recebidas de seus\n"
 "             fornecedores. Quando registrar uma nova fatura de fornecedor, defina a ordem de compra\n"
-"             e o Odoo irá preencher a nota automaticamente de acordo com o que foi pediro\n"
+"             e o MultiERP irá preencher a nota automaticamente de acordo com o que foi pediro\n"
 "             ou quantidades recebidas."
 
 #. module: purchase
@@ -2064,6 +1950,7 @@ msgid "User"
 msgstr "Usuário"
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__company_currency_id
 #: model:ir.model.fields,help:purchase.field_res_config_settings__company_currency_id
 msgid "Utility field to express amount currency"
 msgstr "Campo utilitário para expressar total em moeda"
@@ -2101,6 +1988,7 @@ msgid "Vendor Country"
 msgstr "País do Fornecedor"
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__group_manage_vendor_price
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__group_manage_vendor_price
 #: model:ir.ui.menu,name:purchase.menu_product_pricelist_action2_purchase
 msgid "Vendor Pricelists"
@@ -2119,16 +2007,14 @@ msgstr "Fornecedores"
 
 #. module: purchase
 #: model_terms:ir.actions.act_window,help:purchase.act_res_partner_2_supplier_invoices
-msgid ""
-"Vendors bills can be pre-generated based on purchase\n"
+msgid "Vendors bills can be pre-generated based on purchase\n"
 "                    orders or receipts. This allows you to control bills\n"
 "                    you receive from your vendor according to the draft\n"
 "                    document in Odoo."
-msgstr ""
-"Faturas de fornecedores podem ser previamente geradas com base no pedido\n"
-"de compra ou recibos. Isto permite-lhe controlar contas\n"
-"que recebe de o seu fornecedor de acordo com o documento\n"
-"de rascunho no Odoo."
+msgstr "Faturas de fornecedores podem ser previamente geradas com base no pedido\n"
+"                    de compra ou recibos. Isto permite-lhe controlar contas\n"
+"                    que recebe de o seu fornecedor de acordo com o documento\n"
+"                    de rascunho no Sistema."
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_report__volume
@@ -2148,8 +2034,8 @@ msgid "Warning"
 msgstr "Aviso"
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:227
-#: code:addons/purchase/models/purchase.py:574
+#: code:addons/purchase/models/purchase.py:239
+#: code:addons/purchase/models/purchase.py:619
 #, python-format
 msgid "Warning for %s"
 msgstr "Aviso para %s"
@@ -2181,35 +2067,32 @@ msgstr "Histórico de Comunicação do Site"
 
 #. module: purchase
 #: model_terms:ir.actions.act_window,help:purchase.purchase_open_invoice
-msgid ""
-"You can control the invoice from your vendor according to\n"
+msgid "You can control the invoice from your vendor according to\n"
 "            what you purchased (services) or received (products)."
-msgstr ""
-"Você pode controlar a fatura do seu fornecedor de acordo com\n"
+msgstr "Você pode controlar a fatura do seu fornecedor de acordo com\n"
 "o que você comprou (serviços) ou recebeu (produtos)."
 
 #. module: purchase
 #: model:ir.model.fields,help:purchase.field_purchase_order__partner_id
 #: model:ir.model.fields,help:purchase.field_purchase_order_line__partner_id
 msgid "You can find a vendor by its Name, TIN, Email or Internal Reference."
-msgstr ""
-"Você pode encontrar um fornecedor por seu nome, TIN, e-mail ou referência "
-"interna."
+msgstr "Você pode encontrar um fornecedor por seu nome, TIN, e-mail ou referência interna."
 
 #. module: purchase
 #: model_terms:ir.actions.act_window,help:purchase.product_product_action
-msgid ""
-"You must define a product for everything you purchase,\n"
+msgid "You must define a product for everything you purchase,\n"
 "                whether it's a physical product, a consumable or services."
-msgstr ""
-"Você deve definir um produto para tudo o que compra,\n"
+msgstr "Você deve definir um produto para tudo o que compra,\n"
 "                 Seja um produto físico, material de consumo ou serviços."
 
 #. module: purchase
 #: model_terms:ir.actions.act_window,help:purchase.product_normal_action_puchased
-msgid ""
-"You must define a product for everything you purchase,\n"
+msgid "You must define a product for everything you purchase,\n"
 "            whether it's a physical product, a consumable or services."
-msgstr ""
-"Você deve definir um produto para tudo o que compra,\n"
+msgstr "Você deve definir um produto para tudo o que compra,\n"
 "                 Seja um produto físico, material de consumo ou serviços."
+
+#. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_purchase_order__activity_team_user_ids
+msgid "test field"
+msgstr "campo de teste"

--- a/addons/purchase/i18n/purchase.pot
+++ b/addons/purchase/i18n/purchase.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-14 07:33+0000\n"
-"PO-Revision-Date: 2019-11-14 07:33+0000\n"
+"POT-Creation-Date: 2023-04-11 15:19+0000\n"
+"PO-Revision-Date: 2023-04-11 15:19+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -38,6 +38,7 @@ msgid "3-way matching"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__module_account_3way_match
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__module_account_3way_match
 msgid "3-way matching: purchases, receptions and bills"
 msgstr ""
@@ -253,12 +254,17 @@ msgid "Activity State"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_purchase_order__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_account_invoice__purchase_id
 msgid "Add Purchase Order"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/controllers/portal.py:50
+#: code:addons/purchase/controllers/portal.py:62
 #, python-format
 msgid "All"
 msgstr ""
@@ -320,6 +326,7 @@ msgid "Average Price"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__default_purchase_method
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__default_purchase_method
 msgid "Bill Control"
 msgstr ""
@@ -386,7 +393,7 @@ msgid "Cancel"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/controllers/portal.py:52
+#: code:addons/purchase/controllers/portal.py:64
 #: selection:purchase.order,state:0
 #: selection:purchase.report,state:0
 #, python-format
@@ -399,7 +406,7 @@ msgid "Cancelled Purchase Order #"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:509
+#: code:addons/purchase/models/purchase.py:559
 #, python-format
 msgid "Cannot delete a purchase order line which is in state '%s'."
 msgstr ""
@@ -424,12 +431,13 @@ msgid "Company"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__company_currency_id
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__company_currency_id
 msgid "Company Currency"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:268
+#: code:addons/purchase/models/purchase.py:296
 #, python-format
 msgid "Compose Email"
 msgstr ""
@@ -457,11 +465,6 @@ msgstr ""
 #. module: purchase
 #: selection:res.company,po_lock:0
 msgid "Confirmed purchase orders are not editable"
-msgstr ""
-
-#. module: purchase
-#: model:ir.model,name:purchase.model_res_partner
-msgid "Contact"
 msgstr ""
 
 #. module: purchase
@@ -561,6 +564,7 @@ msgid "Define your terms and conditions ..."
 msgstr ""
 
 #. module: purchase
+#: selection:contact.config.settings,default_purchase_method:0
 #: selection:res.config.settings,default_purchase_method:0
 msgid "Delivered quantities"
 msgstr ""
@@ -620,7 +624,7 @@ msgid "Extended Filters"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:491
+#: code:addons/purchase/models/purchase.py:541
 #, python-format
 msgid "Extra line with %s "
 msgstr ""
@@ -648,8 +652,18 @@ msgid "Followers (Partners)"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_purchase_order__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.view_purchase_order_filter
 msgid "Future Activities"
+msgstr ""
+
+#. module: purchase
+#: model_terms:ir.ui.view,arch_db:purchase.purchase_order_line_form2
+msgid "General"
 msgstr ""
 
 #. module: purchase
@@ -719,7 +733,7 @@ msgid "Import vendor pricelists"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:165
+#: code:addons/purchase/models/purchase.py:172
 #, python-format
 msgid "In order to delete a purchase order, you must cancel it first."
 msgstr ""
@@ -795,6 +809,7 @@ msgid "Levels of Approvals"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__po_double_validation
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__po_double_validation
 msgid "Levels of Approvals *"
 msgstr ""
@@ -810,12 +825,13 @@ msgid "Lock"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__lock_confirmed_po
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__lock_confirmed_po
 msgid "Lock Confirmed Orders"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/controllers/portal.py:53
+#: code:addons/purchase/controllers/portal.py:65
 #: selection:purchase.order,state:0
 #, python-format
 msgid "Locked"
@@ -857,12 +873,14 @@ msgid "Manual Invoices"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__po_lead
 #: model:ir.model.fields,help:purchase.field_res_company__po_lead
 #: model:ir.model.fields,help:purchase.field_res_config_settings__po_lead
 msgid "Margin of error for vendor lead times. When the system generates Purchase Orders for procuring products, they will be scheduled that many days earlier to cope with unexpected vendor delays."
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__use_po_lead
 #: model:ir.model.fields,help:purchase.field_res_config_settings__use_po_lead
 msgid "Margin of error for vendor lead times. When the system generates Purchase Orders for reordering products,they will be scheduled that many days earlier to cope with unexpected vendor delays."
 msgstr ""
@@ -890,11 +908,13 @@ msgid "Messages"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__po_double_validation_amount
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__po_double_validation_amount
 msgid "Minimum Amount"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__po_double_validation_amount
 #: model:ir.model.fields,help:purchase.field_res_company__po_double_validation_amount
 #: model:ir.model.fields,help:purchase.field_res_config_settings__po_double_validation_amount
 msgid "Minimum amount for which a double validation is required"
@@ -916,7 +936,7 @@ msgid "My Purchases"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/controllers/portal.py:41
+#: code:addons/purchase/controllers/portal.py:53
 #, python-format
 msgid "Name"
 msgstr ""
@@ -927,9 +947,14 @@ msgid "Name, TIN, Email, or Reference"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/controllers/portal.py:40
+#: code:addons/purchase/controllers/portal.py:52
 #, python-format
 msgid "Newest"
+msgstr ""
+
+#. module: purchase
+#: model_terms:ir.ui.view,arch_db:purchase.purchase_order_tree
+msgid "Next Activity"
 msgstr ""
 
 #. module: purchase
@@ -1053,6 +1078,7 @@ msgid "Ordered Quantity:"
 msgstr ""
 
 #. module: purchase
+#: selection:contact.config.settings,default_purchase_method:0
 #: selection:res.config.settings,default_purchase_method:0
 msgid "Ordered quantities"
 msgstr ""
@@ -1079,6 +1105,7 @@ msgid "PO_${(object.name or '').replace('/','_')}"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model,name:purchase.model_res_partner
 #: model:ir.model.fields,field_description:purchase.field_purchase_order_line__partner_id
 msgid "Partner"
 msgstr ""
@@ -1189,6 +1216,7 @@ msgid "Products Value"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__po_double_validation
 #: model:ir.model.fields,help:purchase.field_res_company__po_double_validation
 #: model:ir.model.fields,help:purchase.field_res_config_settings__po_double_validation
 msgid "Provide a double validation mechanism for purchases"
@@ -1202,6 +1230,7 @@ msgid "Purchase"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__module_purchase_requisition
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__module_purchase_requisition
 msgid "Purchase Agreements"
 msgstr ""
@@ -1217,6 +1246,7 @@ msgid "Purchase Analysis allows you to easily check and analyse your company pur
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__po_lead
 #: model:ir.model.fields,field_description:purchase.field_res_company__po_lead
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__po_lead
 msgid "Purchase Lead Time"
@@ -1224,7 +1254,7 @@ msgstr ""
 
 #. module: purchase
 #: code:addons/purchase/controllers/portal.py:63
-#: code:addons/purchase/models/purchase.py:281
+#: code:addons/purchase/models/purchase.py:293
 #: model:ir.actions.report,name:purchase.action_report_purchase_order
 #: model:ir.model,name:purchase.model_purchase_order
 #: model:ir.model.fields,field_description:purchase.field_account_invoice_line__purchase_id
@@ -1248,6 +1278,7 @@ msgid "Purchase Order #"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__po_order_approval
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__po_order_approval
 msgid "Purchase Order Approval"
 msgstr ""
@@ -1290,11 +1321,13 @@ msgid "Purchase Order Modification"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__po_lock
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__po_lock
 msgid "Purchase Order Modification *"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__po_lock
 #: model:ir.model.fields,help:purchase.field_res_company__po_lock
 #: model:ir.model.fields,help:purchase.field_res_config_settings__po_lock
 msgid "Purchase Order Modification used when you want to purchase order editable after confirm"
@@ -1338,6 +1371,7 @@ msgid "Purchase Representative"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__group_warning_purchase
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__group_warning_purchase
 msgid "Purchase Warnings"
 msgstr ""
@@ -1500,7 +1534,7 @@ msgid "Reporting"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:276
+#: code:addons/purchase/models/purchase.py:291
 #: model:ir.actions.report,name:purchase.report_purchase_quotation
 #: model_terms:ir.ui.view,arch_db:purchase.portal_my_purchase_order
 #: model_terms:ir.ui.view,arch_db:purchase.report_purchasequotation_document
@@ -1542,6 +1576,7 @@ msgid "Search Reference Document"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__use_po_lead
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__use_po_lead
 msgid "Security Lead Time for Purchase"
 msgstr ""
@@ -1705,6 +1740,7 @@ msgid "This currency will be used, instead of the default one, for purchases fro
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__default_purchase_method
 #: model:ir.model.fields,help:purchase.field_res_config_settings__default_purchase_method
 #: model_terms:ir.ui.view,arch_db:purchase.res_config_settings_view_form_purchase
 msgid "This default value is applied to any new product created. This can be changed in the product detail form."
@@ -1716,13 +1752,13 @@ msgid "This note will show up on purchase orders."
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/models/account_invoice.py:156
+#: code:addons/purchase/models/account_invoice.py:164
 #, python-format
 msgid "This vendor bill has been created from: %s"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/models/account_invoice.py:170
+#: code:addons/purchase/models/account_invoice.py:178
 #, python-format
 msgid "This vendor bill has been modified from: %s"
 msgstr ""
@@ -1750,7 +1786,7 @@ msgid "Today Activities"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/controllers/portal.py:42
+#: code:addons/purchase/controllers/portal.py:54
 #: model:ir.model.fields,field_description:purchase.field_purchase_order__amount_total
 #: model:ir.model.fields,field_description:purchase.field_purchase_order_line__price_total
 #: model_terms:ir.ui.view,arch_db:purchase.portal_my_purchase_orders
@@ -1779,7 +1815,7 @@ msgid "Total amount"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:324
+#: code:addons/purchase/models/purchase.py:352
 #, python-format
 msgid "Unable to cancel this purchase order. You must first cancel the related vendor bills."
 msgstr ""
@@ -1843,6 +1879,7 @@ msgid "User"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,help:purchase.field_contact_config_settings__company_currency_id
 #: model:ir.model.fields,help:purchase.field_res_config_settings__company_currency_id
 msgid "Utility field to express amount currency"
 msgstr ""
@@ -1880,6 +1917,7 @@ msgid "Vendor Country"
 msgstr ""
 
 #. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_contact_config_settings__group_manage_vendor_price
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__group_manage_vendor_price
 #: model:ir.ui.menu,name:purchase.menu_product_pricelist_action2_purchase
 msgid "Vendor Pricelists"
@@ -1922,8 +1960,8 @@ msgid "Warning"
 msgstr ""
 
 #. module: purchase
-#: code:addons/purchase/models/purchase.py:227
-#: code:addons/purchase/models/purchase.py:574
+#: code:addons/purchase/models/purchase.py:239
+#: code:addons/purchase/models/purchase.py:619
 #, python-format
 msgid "Warning for %s"
 msgstr ""
@@ -1977,3 +2015,7 @@ msgid "You must define a product for everything you purchase,\n"
 "            whether it's a physical product, a consumable or services."
 msgstr ""
 
+#. module: purchase
+#: model:ir.model.fields,field_description:purchase.field_purchase_order__activity_team_user_ids
+msgid "test field"
+msgstr ""

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -398,6 +398,7 @@
                 <field name="partner_id"/>
                 <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                 <field name="date_planned" invisible="context.get('quotation_only', False)"/>
+                <field name="activity_ids" string="Next Activity" widget="list_activity"/>
                 <field name="user_id"/>
                 <field name="origin"/>
                 <field name="amount_untaxed" sum="Total Untaxed amount" string="Untaxed" widget="monetary"/>

--- a/addons/sale/i18n/pt_BR.po
+++ b/addons/sale/i18n/pt_BR.po
@@ -40,10 +40,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-14 07:34+0000\n"
-"PO-Revision-Date: 2018-08-24 09:24+0000\n"
-"Last-Translator: Marcel Savegnago <marcel.savegnago@gmail.com>, 2021\n"
-"Language-Team: Portuguese (Brazil) (https://www.transifex.com/odoo/teams/41243/pt_BR/)\n"
+"POT-Creation-Date: 2023-04-11 17:13+0000\n"
+"PO-Revision-Date: 2023-04-11 17:13+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -63,16 +63,12 @@ msgstr "# de Pedidos de Venda"
 #. module: sale
 #: model:mail.template,report_name:sale.email_template_edi_sale
 msgid "${(object.name or '').replace('/','_')}"
-msgstr "${(object.name or ‘’).replace(‘/‘,’_’)}"
+msgstr ""
 
 #. module: sale
 #: model:mail.template,subject:sale.email_template_edi_sale
-msgid ""
-"${object.company_id.name} ${object.state in ('draft', 'sent') and "
-"'Quotation' or 'Order'} (Ref ${object.name or 'n/a' })"
-msgstr ""
-"${object.company_id.name} ${object.state in ('draft', 'sent') and 'Orçamento' "
-"or 'Pedido'} (Ref ${object.name or 'n/a' })"
+msgid "${object.company_id.name} ${object.state in ('draft', 'sent') and 'Quotation' or 'Order'} (Ref ${object.name or 'n/a' })"
+msgstr "${object.company_id.name} ${object.state in ('draft', 'sent') and 'Orçamento' or 'Pedido'} (Ref ${object.name or 'n/a' })"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_content
@@ -82,7 +78,7 @@ msgstr "% desconto"
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.portal_my_orders
 msgid "&amp;nbsp;"
-msgstr "&amp;nbsp;"
+msgstr ""
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.report_saleorder_document
@@ -94,14 +90,7 @@ msgstr "&amp;nbsp;<span>em</span>&amp;nbsp;"
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
 msgid "&amp;times;"
-msgstr "&amp;times;"
-
-#. module: sale
-#: model:product.product,description_sale:sale.product_product_4e
-#: model:product.product,description_sale:sale.product_product_4f
-#: model:product.template,description_sale:sale.product_product_4e_product_template
-msgid "160x80cm, with large legs."
-msgstr "160x80cm, com pernas grandes."
+msgstr ""
 
 #. module: sale
 #. openerp-web
@@ -112,8 +101,7 @@ msgstr "<b>Imprima este orçamento para visualizá-lo.</b>"
 
 #. module: sale
 #: model:mail.template,body_html:sale.email_template_edi_sale
-msgid ""
-"<div style=\"margin: 0px; padding: 0px;\">\n"
+msgid "<div style=\"margin: 0px; padding: 0px;\">\n"
 "    <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
 "        % set doc_name = 'quotation' if object.state in ('draft', 'sent') else 'order'\n"
 "        Dear ${object.partner_id.name}\n"
@@ -137,8 +125,7 @@ msgid ""
 "    </p>\n"
 "</div>\n"
 "            "
-msgstr ""
-"<div style=\"margin: 0px; padding: 0px;\">\n"
+msgstr "<div style=\"margin: 0px; padding: 0px;\">\n"
 "    <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
 "        % set doc_name = 'cotação' if object.state in ('draft', 'sent') else 'ordem de venda'\n"
 "        Caro ${object.partner_id.name}\n"
@@ -158,7 +145,7 @@ msgstr ""
 "        no valor de <strong>${format_amount(object.amount_total, object.pricelist_id.currency_id)}</strong>\n"
 "        de ${object.company_id.name}.\n"
 "        <br/><br/>\n"
-"        Se tiver alguma dúvida, não hesite em contatar-nos.\n"
+"        Se tiver alguma dúvida, não hesite em contactar-nos.\n"
 "    </p>\n"
 "</div>\n"
 "            "
@@ -186,7 +173,7 @@ msgstr "<i class=\"fa fa-comment\"/> Entre em contato conosco para obter a vers�
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
 msgid "<i class=\"fa fa-comment\"/> Feedback"
-msgstr "<i class=\"fa fa-comment\"/> Feedback"
+msgstr ""
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
@@ -195,12 +182,8 @@ msgstr "<i class=\"fa fa-comment\"/> Enviar Mensagem"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_content
-msgid ""
-"<i class=\"fa fa-download mr-1\" role=\"img\" aria-label=\"Download\" "
-"title=\"Download\"/>"
+msgid "<i class=\"fa fa-download mr-1\" role=\"img\" aria-label=\"Download\" title=\"Download\"/>"
 msgstr ""
-"<i class=\"fa fa-download mr-1\" role=\"img\" aria-label=\"Download\" "
-"title=\"Download\"/>"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
@@ -234,12 +217,8 @@ msgstr "<i class=\"fa fa-fw fa-remove\"/> Cancelado"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.crm_lead_partner_kanban_view
-msgid ""
-"<i class=\"fa fa-fw fa-usd\" role=\"img\" aria-label=\"Sale orders\" "
-"title=\"Sales orders\"/>"
-msgstr ""
-"<i class=\"fa fa-fw fa-usd\" role=\"img\" aria-label=\"Sale orders\" "
-"title=\"Ordens de Vendas\"/>"
+msgid "<i class=\"fa fa-fw fa-usd\" role=\"img\" aria-label=\"Sale orders\" title=\"Sales orders\"/>"
+msgstr "<i class=\"fa fa-fw fa-usd\" role=\"img\" aria-label=\"Sale orders\" title=\"Ordens de Vendas\"/>"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
@@ -268,32 +247,20 @@ msgstr "<small><b class=\"text-muted\">Sua vantagem</b></small>"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.portal_my_orders
-msgid ""
-"<span class=\"d-none d-md-inline\">Sales Order #</span>\n"
+msgid "<span class=\"d-none d-md-inline\">Sales Order #</span>\n"
 "                            <span class=\"d-block d-md-none\">Ref.</span>"
-msgstr ""
-"<span class=\"d-none d-md-inline\">Pedido de Venda #</span>\n"
+msgstr "<span class=\"d-none d-md-inline\">Pedido de Venda #</span>\n"
 "                            <span class=\"d-block d-md-none\">Ref.</span>"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
-msgid ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" aria-label=\"Values set here are company-specific.\" "
-"groups=\"base.group_multi_company\" role=\"img\"/>"
-msgstr ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Os valores definidos aqui são "
-"específicos da empresa.\" aria-label=\"Os valores definidos aqui são específicos da empresa\" "
-"groups=\"base.group_multi_company\" role=\"img\"/>"
+msgid "<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-specific.\" aria-label=\"Values set here are company-specific.\" groups=\"base.group_multi_company\" role=\"img\"/>"
+msgstr "<span class=\"fa fa-lg fa-building-o\" title=\"Os valores definidos aqui são específicos da empresa.\" aria-label=\"Os valores definidos aqui são específicos da empresa.\" groups=\"base.group_multi_company\" role=\"img\"/>"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
-msgid ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" groups=\"base.group_multi_company\"/>"
-msgstr ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Os valores definidos aqui são "
-"são específicos da empresa.\" groups=\"base.group_multi_company\"/>"
+msgid "<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-specific.\" groups=\"base.group_multi_company\"/>"
+msgstr "<span class=\"fa fa-lg fa-building-o\" title=\"Os valores definidos aqui são são específicos da empresa.\" groups=\"base.group_multi_company\"/>"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
@@ -308,11 +275,9 @@ msgstr "<span class=\"o_stat_text\">Vendido</span>"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_content
-msgid ""
-"<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
+msgid "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Amount</span>\n"
 "                                <span groups=\"account.group_show_line_subtotals_tax_included\">Total Price</span>"
-msgstr ""
-"<span groups=\"account.group_show_line_subtotals_tax_excluded\">Total</span>\n"
+msgstr "<span groups=\"account.group_show_line_subtotals_tax_excluded\">Total</span>\n"
 "                                <span groups=\"account.group_show_line_subtotals_tax_included\">Preço Total</span>"
 
 #. module: sale
@@ -323,8 +288,7 @@ msgstr "<span>Aceito em nome de:</span>"
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
 msgid "<span>By paying this proposal, I agree to the following terms:</span>"
-msgstr ""
-"<span>Ao pagar esta proposta, concordo com os seguintes termos:</span>"
+msgstr "<span>Ao pagar esta proposta, concordo com os seguintes termos:</span>"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
@@ -370,7 +334,7 @@ msgstr "<strong class=\"d-block mb-1\">Endereço de Entrega</strong>"
 #: model_terms:ir.ui.view,arch_db:sale.report_saleorder_document
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_content
 msgid "<strong class=\"mr16\">Subtotal</strong>"
-msgstr "<strong class=\"mr16\">Subtotal</strong>"
+msgstr "<strong class=\"mr16\">Subtotal </strong>"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
@@ -429,7 +393,7 @@ msgstr "<strong>Assinatura</strong>"
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_content
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_content_totals_table
 msgid "<strong>Subtotal</strong>"
-msgstr "<strong>Subtotal</strong>"
+msgstr ""
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
@@ -454,7 +418,7 @@ msgstr "<strong>Este orçamento foi cancelada.</strong>"
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.product_configurator_configure_optional_products
 msgid "<strong>Total:</strong>"
-msgstr "<strong>Total:</strong>"
+msgstr ""
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.report_saleorder_document
@@ -469,48 +433,41 @@ msgid "<strong>Your Reference:</strong>"
 msgstr "<strong>Sua Referência:</strong>"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:811
+#: code:addons/sale/models/sale.py:897
 #, python-format
 msgid "A journal must be specified of the acquirer %s."
 msgstr "Um diário deve ser especificado do adquirente %s."
 
 #. module: sale
-#: code:addons/sale/models/sale.py:804
+#: code:addons/sale/models/sale.py:890
 #, python-format
 msgid "A payment acquirer is required to create a transaction."
 msgstr "Um adquirente de pagamento é necessário para criar uma transação."
 
 #. module: sale
+#: selection:contact.config.settings,sale_pricelist_setting:0
 #: selection:res.config.settings,sale_pricelist_setting:0
 msgid "A single sales price per product"
 msgstr "Um único preço de venda por produto"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:775
+#: code:addons/sale/models/sale.py:861
 #, python-format
-msgid ""
-"A transaction can't be linked to sales orders having different currencies."
-msgstr ""
-"Uma transação não pode ser vinculada a pedidos de venda com moedas "
-"diferentes."
+msgid "A transaction can't be linked to sales orders having different currencies."
+msgstr "Uma transação não pode ser vinculada a pedidos de venda com moedas diferentes."
 
 #. module: sale
-#: code:addons/sale/models/sale.py:780
+#: code:addons/sale/models/sale.py:866
 #, python-format
-msgid ""
-"A transaction can't be linked to sales orders having different partners."
-msgstr ""
-"Uma transação não pode ser vinculada a pedidos de venda com parceiros "
-"diferentes."
+msgid "A transaction can't be linked to sales orders having different partners."
+msgstr "Uma transação não pode ser vinculada a pedidos de venda com parceiros diferentes."
 
 #. module: sale
 #: model_terms:ir.actions.act_window,help:sale.action_orders_upselling
-msgid ""
-"A typical example is the pre-paid hours of service,\n"
+msgid "A typical example is the pre-paid hours of service,\n"
 "                where you want to sell extra hours to the customer\n"
 "                because the initial hours have already been used."
-msgstr ""
-"Um exemplo típico são as horas de serviço pré-pagas,\n"
+msgstr "Um exemplo típico são as horas de serviço pré-pagas,\n"
 "                onde você quer vender horas extras para o cliente\n"
 "                porque as horas iniciais já foram usadas."
 
@@ -521,12 +478,8 @@ msgstr "Um aviso pode ser definido em um produto ou um cliente(Venda)"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
-msgid ""
-"Ability to select a package type in sales orders and to force a quantity "
-"that is a multiple of the number of units per package."
-msgstr ""
-"Habilidade para selecionar um tipo de pacote em ordens de vendas e forçar a "
-"quantidade para um número múltiplo de unidades por pacote."
+msgid "Ability to select a package type in sales orders and to force a quantity that is a multiple of the number of units per package."
+msgstr "Habilidade para selecionar um tipo de pacote em ordens de vendas e forçar a quantidade para um número múltiplo de unidades por pacote."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
@@ -545,18 +498,18 @@ msgstr "Aviso de acesso"
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order_line__qty_delivered_method
-msgid ""
-"According to product configuration, the delivered quantity can be automatically computed by mechanism :\n"
+msgid "According to product configuration, the delivered quantity can be automatically computed by mechanism :\n"
 "  - Manual: the quantity is set manually on the line\n"
 "  - Analytic From expenses: the quantity is the quantity sum from posted expenses\n"
 "  - Timesheet: the quantity is the sum of hours recorded on tasks linked to this sale line\n"
 "  - Stock Moves: the quantity comes from confirmed pickings\n"
-msgstr ""
-"According to product configuration, the delivered quantity can be automatically computed by mechanism :\n"
-"  - Manual: the quantity is set manually on the line\n"
-"  - Analytic From expenses: the quantity is the quantity sum from posted expenses\n"
-"  - Timesheet: the quantity is the sum of hours recorded on tasks linked to this sale line\n"
-"  - Stock Moves: the quantity comes from confirmed pickings\n"
+""
+msgstr "De acordo com a configuração do produto, a quantidade entregue pode ser calculada automaticamente pelo mecanismo :\n"
+"  - Manual: a quantidade é definida manualmente na linha\n"
+"  - Analítico De despesas: a quantidade é a soma da quantidade das despesas lançadas\n"
+"  - Quadro de horários: a quantidade é a soma das horas registradas nas tarefas vinculadas a esta linha de venda\n"
+"  - Movimentação de estoque: a quantidade é proveniente de picking confirmado\n"
+""
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_payment_acquirer_onboarding_wizard__acc_number
@@ -582,6 +535,11 @@ msgstr "Atividades"
 #: model:ir.model.fields,field_description:sale.field_sale_order__activity_state
 msgid "Activity State"
 msgstr "Estado de Atividade"
+
+#. module: sale
+#: model:ir.model.fields,field_description:sale.field_sale_order__activity_type_icon
+msgid "Activity Type Icon"
+msgstr "Ícone de Tipo de Atividade"
 
 #. module: sale
 #: model:ir.actions.act_window,name:sale.mail_activity_type_action_config_sale
@@ -626,7 +584,7 @@ msgid "Addresses in Sales Orders"
 msgstr "Endereços no Pedido de Venda"
 
 #. module: sale
-#: code:addons/sale/wizard/sale_make_invoice_advance.py:165
+#: code:addons/sale/wizard/sale_make_invoice_advance.py:166
 #, python-format
 msgid "Advance: %s"
 msgstr "Avançar: %s"
@@ -635,9 +593,7 @@ msgstr "Avançar: %s"
 #: model:ir.model.fields,help:sale.field_product_attribute_value__is_custom
 #: model:ir.model.fields,help:sale.field_product_template_attribute_value__is_custom
 msgid "Allow users to input custom values for this attribute value"
-msgstr ""
-"Permitir que os usuários insiram valores personalizados para este valor de "
-"atributo"
+msgstr "Permitir que os usuários insiram valores personalizados para este valor de atributo"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
@@ -645,6 +601,7 @@ msgid "Allows you to send Pro-Forma Invoice to your customers"
 msgstr "Permite-lhe enviar Fatura Pro-Forma aos seus clientes"
 
 #. module: sale
+#: model:ir.model.fields,help:sale.field_contact_config_settings__group_proforma_sales
 #: model:ir.model.fields,help:sale.field_res_config_settings__group_proforma_sales
 msgid "Allows you to send pro-forma invoice."
 msgstr "Permite-lhe enviar uma fatura pró-forma."
@@ -652,18 +609,18 @@ msgstr "Permite-lhe enviar uma fatura pró-forma."
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.report_saleorder_document
 msgid "Amount"
-msgstr "Total"
+msgstr "Valor"
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_order__amount_undiscounted
 msgid "Amount Before Discount"
-msgstr "Total antes do desconto"
+msgstr "Valor antes do desconto"
 
 #. module: sale
 #: code:addons/sale/models/payment.py:90
 #, python-format
 msgid "Amount Mismatch (%s)"
-msgstr "Total incompatível (%s)"
+msgstr "Valor incompatível (%s)"
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_crm_team__quotations_amount
@@ -680,7 +637,7 @@ msgstr "Conta Analítica"
 #. module: sale
 #: selection:sale.order.line,qty_delivered_method:0
 msgid "Analytic From Expenses"
-msgstr "Análises à partir de Despesas"
+msgstr "Analítico de Despesas"
 
 #. module: sale
 #: model:ir.model,name:sale.model_account_analytic_line
@@ -704,22 +661,13 @@ msgstr "Aplicar"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
-msgid ""
-"Apply manual discounts on sales order lines or display discounts computed "
-"from pricelists (option to activate in the pricelist configuration)."
-msgstr ""
-"Aplicar discontos manuais em linhas do pedido ou mostrar descontos "
-"calculados à partir de listas de preço (Ativar opção nas configurações das "
-"listas de preço)."
+msgid "Apply manual discounts on sales order lines or display discounts computed from pricelists (option to activate in the pricelist configuration)."
+msgstr "Aplicar discontos manuais em linhas do pedido ou mostrar descontos calculados à partir de listas de preço (Ativar opção nas configurações das listas de preço)."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
-msgid ""
-"Are you sure you want to void the authorized transaction? This action can't "
-"be undone."
-msgstr ""
-"Tem certeza que quer anular a transação autorizada? Esta ação não pode ser "
-"desfeita."
+msgid "Are you sure you want to void the authorized transaction? This action can't be undone."
+msgstr "Tem certeza que quer anular a transação autorizada? Esta ação não pode ser desfeita."
 
 #. module: sale
 #: selection:product.template,expense_policy:0
@@ -752,6 +700,7 @@ msgid "Authorized Transactions"
 msgstr "Transações Autorizadas"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__automatic_invoice
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__automatic_invoice
 msgid "Automatic Invoice"
 msgstr "Fatura Automática"
@@ -763,7 +712,7 @@ msgstr "Opções Disponíveis:"
 
 #. module: sale
 #. openerp-web
-#: code:addons/sale/static/src/js/product_configurator_controller.js:124
+#: code:addons/sale/static/src/js/product_configurator_controller.js:130
 #, python-format
 msgid "Back"
 msgstr "Voltar"
@@ -774,23 +723,23 @@ msgid "Bank Name"
 msgstr "Nome de Banco"
 
 #. module: sale
-#: code:addons/sale/models/payment.py:14
+#: code:addons/sale/models/payment.py:19
 #: selection:payment.acquirer,so_reference_type:0
 #, python-format
 msgid "Based on Customer ID"
 msgstr "Basedo no ID do Cliente"
 
 #. module: sale
-#: code:addons/sale/models/payment.py:13
+#: code:addons/sale/models/payment.py:18
 #: selection:payment.acquirer,so_reference_type:0
 #, python-format
 msgid "Based on Document Reference"
 msgstr "Baseado na Referência de Documentos"
 
 #. module: sale
-#: model:product.template.attribute.value,name:sale.product_template_attribute_value_5
-msgid "Black"
-msgstr "Preto"
+#: selection:sale.order,state:0
+msgid "Blocked"
+msgstr "Bloqueado"
 
 #. module: sale
 #: selection:product.template,sale_line_warn:0
@@ -800,15 +749,8 @@ msgstr "Mensagem de Bloqueio"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
-msgid ""
-"Boost your sales with two kinds of discount programs: promotions and coupon "
-"codes. Specific conditions can be set (products, customers, minimum purchase"
-" amount, period). Rewards can be discounts (% or amount) or free products."
-msgstr ""
-"Aumente as suas vendas com dois tipos de programas de descontos: promoções e"
-" códigos de cupão. Pode definir condições específicas (produtos, clientes, "
-"quantidade mínima de compra, período). As recompensas podem ser descontos (%"
-" ou um montante fixo) ou artigos gratuitos."
+msgid "Boost your sales with two kinds of discount programs: promotions and coupon codes. Specific conditions can be set (products, customers, minimum purchase amount, period). Rewards can be discounts (% or amount) or free products."
+msgstr "Aumente as suas vendas com dois tipos de programas de descontos: promoções e códigos de cupão. Pode definir condições específicas (produtos, clientes, quantidade mínima de compra, período). As recompensas podem ser descontos (% ou um montante fixo) ou artigos gratuitos."
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_order_line__product_updatable
@@ -824,7 +766,8 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: sale
-#: selection:sale.order,state:0 selection:sale.report,state:0
+#: selection:sale.order,state:0
+#: selection:sale.report,state:0
 msgid "Cancelled"
 msgstr "Cancelado"
 
@@ -834,27 +777,14 @@ msgid "Capture Transaction"
 msgstr "Capturar Transação"
 
 #. module: sale
-#: model:product.template,name:sale.product_product_1_product_template
-msgid "Chair floor protection"
-msgstr "Proteção de piso para cadeiras"
-
-#. module: sale
 #: model:ir.model.fields,help:sale.field_crm_team__use_quotations
-msgid ""
-"Check this box if you send quotations to your customers rather than "
-"confirming orders straight away. This will add specific action buttons to "
-"your dashboard."
-msgstr ""
-"Marque essa caixa se você envia orçamentos para seus clientes ao invés de "
-"confirmar pedidos diretamente. Também adiciona botões de ações específicos "
-"ao seu painel."
+msgid "Check this box if you send quotations to your customers rather than confirming orders straight away. This will add specific action buttons to your dashboard."
+msgstr "Marque essa caixa se você envia orçamentos para seus clientes ao invés de confirmar pedidos diretamente. Também adiciona botões de ações específicos ao seu painel."
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_crm_team__use_invoices
 msgid "Check this box to set an invoicing target for this Sales Team."
-msgstr ""
-"Verifique esta caixa para definir uma meta de faturamento para esta Equipe "
-"de Vendas."
+msgstr "Verifique esta caixa para definir uma meta de faturamento para esta Equipe de Vendas."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_onboarding_order_confirmation_step
@@ -960,7 +890,7 @@ msgstr "Configuração"
 
 #. module: sale
 #. openerp-web
-#: code:addons/sale/static/src/js/product_configurator_controller.js:125
+#: code:addons/sale/static/src/js/product_configurator_controller.js:131
 #, python-format
 msgid "Configure"
 msgstr "Configurar"
@@ -982,7 +912,7 @@ msgstr "Configure seus produtos com variantes e selecione produtos opcionais"
 
 #. module: sale
 #. openerp-web
-#: code:addons/sale/static/src/js/product_configurator_controller.js:123
+#: code:addons/sale/static/src/js/product_configurator_controller.js:129
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 #, python-format
 msgid "Confirm"
@@ -1002,10 +932,9 @@ msgid "Confirmation Date"
 msgstr "Data de Confirmação"
 
 #. module: sale
-#: model:ir.model,name:sale.model_res_partner
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
 msgid "Contact"
-msgstr "Parceiro"
+msgstr "Contato"
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_crm_team__dashboard_graph_model
@@ -1013,6 +942,7 @@ msgid "Content"
 msgstr "Conteúdo"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_sale_coupon
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_sale_coupon
 msgid "Coupons & Promotions"
 msgstr "Cupons e Promoções"
@@ -1078,11 +1008,6 @@ msgid "Currency Rate"
 msgstr "Taxa de Câmbio"
 
 #. module: sale
-#: model:product.attribute.value,name:sale.product_attribute_value_7
-msgid "Custom"
-msgstr "Personalizado"
-
-#. module: sale
 #: selection:sale.payment.acquirer.onboarding.wizard,payment_method:0
 msgid "Custom payment instructions"
 msgstr "Instruções de pagamento personalizado"
@@ -1099,14 +1024,16 @@ msgstr "Valor personalizado"
 #: model_terms:ir.ui.view,arch_db:sale.view_order_product_search
 #: model_terms:ir.ui.view,arch_db:sale.view_sales_order_filter
 msgid "Customer"
-msgstr "Parceiro"
+msgstr "Cliente"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__auth_signup_uninvited
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__auth_signup_uninvited
 msgid "Customer Account"
 msgstr "Conta Cliente"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__group_sale_delivery_address
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__group_sale_delivery_address
 msgid "Customer Addresses"
 msgstr "Endereço do Consumidor"
@@ -1140,14 +1067,7 @@ msgstr "Impostos de Clientes"
 #. module: sale
 #: model:ir.ui.menu,name:sale.res_partner_menu
 msgid "Customers"
-msgstr "Parceiros"
-
-#. module: sale
-#: model:product.product,name:sale.product_product_4e
-#: model:product.product,name:sale.product_product_4f
-#: model:product.template,name:sale.product_product_4e_product_template
-msgid "Customizable Desk"
-msgstr "Mesa Personalizável"
+msgstr "Clientes"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.onboarding_quotation_layout_step
@@ -1160,6 +1080,7 @@ msgid "Customize the look of your quotations."
 msgstr "Personalize o visual de seus orçamentos."
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery_dhl
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery_dhl
 msgid "DHL Connector"
 msgstr "Conector DHL"
@@ -1196,15 +1117,23 @@ msgid "Default Limit:"
 msgstr "Limite Padrão:"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__use_quotation_validity_days
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__use_quotation_validity_days
 msgid "Default Quotation Validity"
 msgstr "Validade Padrão da Cotação"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__quotation_validity_days
 #: model:ir.model.fields,field_description:sale.field_res_company__quotation_validity_days
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__quotation_validity_days
 msgid "Default Quotation Validity (Days)"
 msgstr "Validade Padrão do Orçamento (Dias)"
+
+#. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__use_sale_note
+#: model:ir.model.fields,field_description:sale.field_res_config_settings__use_sale_note
+msgid "Default Terms & Conditions"
+msgstr "Termos e Condições Predefinidos"
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_res_company__sale_note
@@ -1212,6 +1141,7 @@ msgid "Default Terms and Conditions"
 msgstr "Termos e Condições Padrão"
 
 #. module: sale
+#: model:ir.model.fields,help:sale.field_contact_config_settings__deposit_default_product_id
 #: model:ir.model.fields,help:sale.field_res_config_settings__deposit_default_product_id
 msgid "Default product used for payment advances"
 msgstr "Produto padrão usado para adiantamentos de pagamento"
@@ -1227,7 +1157,7 @@ msgid "Delivered Manually"
 msgstr "Entregue Manualmente"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1060
+#: code:addons/sale/models/sale.py:1146
 #: model:ir.model.fields,field_description:sale.field_sale_order_line__qty_delivered
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 #, python-format
@@ -1246,6 +1176,7 @@ msgid "Delivery Address"
 msgstr "Endereço de Entrega"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__group_sale_order_dates
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__group_sale_order_dates
 msgid "Delivery Date"
 msgstr "Data de entrega"
@@ -1267,20 +1198,11 @@ msgstr "Endereço de entrega para o pedido de venda atual."
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__expected_date
-msgid ""
-"Delivery date you can promise to the customer, computed from product lead "
-"times and from the shipping policy of the order."
-msgstr ""
-"Data de entrega que você pode prometer ao cliente, calculada a partir dos "
-"prazos de entrega do produto e da política de remessa do pedido."
+msgid "Delivery date you can promise to the customer, computed from product lead times and from the shipping policy of the order."
+msgstr "Data de entrega que você pode prometer ao cliente, calculada a partir dos prazos de entrega do produto e da política de remessa do pedido."
 
 #. module: sale
-#: model:product.product,name:sale.advance_product_0
-#: model:product.template,name:sale.advance_product_0_product_template
-msgid "Deposit"
-msgstr "Depósito"
-
-#. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__deposit_default_product_id
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__deposit_default_product_id
 msgid "Deposit Product"
 msgstr "Depositar Produto"
@@ -1298,6 +1220,7 @@ msgid "Details"
 msgstr "Detalhes"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_website_sale_digital
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_website_sale_digital
 msgid "Digital Content"
 msgstr "Conteúdo Digital"
@@ -1333,6 +1256,7 @@ msgid "Discount on lines"
 msgstr "Desconto nas linhas"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__group_discount_per_so_line
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__group_discount_per_so_line
 msgid "Discounts"
 msgstr "Descontos"
@@ -1396,12 +1320,8 @@ msgstr "Baixar pagamento de %s%%"
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order_line__is_downpayment
-msgid ""
-"Down payments are made when creating invoices from a sales order. They are "
-"not copied when duplicating a sales order."
-msgstr ""
-"Baixa de pagamentos é feita quando criando faturas de um pedido de venda. "
-"Elas não são copiadas quando há uma duplicação no pedido de venda."
+msgid "Down payments are made when creating invoices from a sales order. They are not copied when duplicating a sales order."
+msgstr "Baixa de pagamentos é feita quando criando faturas de um pedido de venda. Elas não são copiadas quando há uma duplicação no pedido de venda."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
@@ -1414,11 +1334,13 @@ msgid "Draft Quotation"
 msgstr "Orçamento Provisório"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery_easypost
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery_easypost
 msgid "Easypost Connector"
 msgstr "Conector Easypost"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__template_id
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__template_id
 msgid "Email Template"
 msgstr "Modelo de E-mail"
@@ -1431,14 +1353,8 @@ msgstr "Data Prev Calculada"
 #. module: sale
 #: model:ir.model.fields,help:sale.field_product_product__expense_policy
 #: model:ir.model.fields,help:sale.field_product_template__expense_policy
-msgid ""
-"Expenses and vendor bills can be re-invoiced to a customer.With this option,"
-" a validated expense can be re-invoice to a customer at its cost or sales "
-"price."
-msgstr ""
-"Despesas e contas de fornecedores podem ser re-faturadas a um cliente. Com "
-"essa opção, uma despesa validada pode ser re-faturada para um cliente a seu "
-"custo ou preço de venda."
+msgid "Expenses and vendor bills can be re-invoiced to a customer.With this option, a validated expense can be re-invoice to a customer at its cost or sales price."
+msgstr "Despesas e contas de fornecedores podem ser re-faturadas a um cliente. Com essa opção, uma despesa validada pode ser re-faturada para um cliente a seu custo ou preço de venda."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_product_search
@@ -1446,12 +1362,13 @@ msgid "Extended Filters"
 msgstr "Filtros Ampliados"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1034
+#: code:addons/sale/models/sale.py:1120
 #, python-format
 msgid "Extra line with %s "
 msgstr "Linha extra com %s "
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery_fedex
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery_fedex
 msgid "FedEx Connector"
 msgstr "Conector FedEx"
@@ -1477,21 +1394,19 @@ msgid "Followers (Partners)"
 msgstr "Seguidores (Parceiros)"
 
 #. module: sale
+#: model:ir.model.fields,help:sale.field_sale_order__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr "Ícone do Font Awesome. Ex: fa-tasks"
+
+#. module: sale
 #: sql_constraint:sale.order.line:0
 msgid "Forbidden values on non-accountable sale order line"
 msgstr "Valores inválidos em uma linha do pedido não faturável."
 
 #. module: sale
 #: model_terms:ir.actions.act_window,help:sale.action_account_invoice_report_salesteam
-msgid ""
-"From this report, you can have an overview of the amount invoiced to your "
-"customer. The search tool can also be used to personalise your Invoices "
-"reports and so, match this analysis to your needs."
-msgstr ""
-"A partir deste relatório, você pode ter uma visão geral do valor faturado "
-"para o seu cliente. A ferramenta de busca também pode ser usado para "
-"personalizar seus relatórios de faturas e assim, combinar esta análise de "
-"acordo com suas necessidades."
+msgid "From this report, you can have an overview of the amount invoiced to your customer. The search tool can also be used to personalise your Invoices reports and so, match this analysis to your needs."
+msgstr "A partir deste relatório, você pode ter uma visão geral do valor faturado para o seu cliente. A ferramenta de busca também pode ser usado para personalizar seus relatórios de faturas e assim, combinar esta análise de acordo com suas necessidades."
 
 #. module: sale
 #: selection:sale.order,invoice_status:0
@@ -1506,10 +1421,8 @@ msgstr "Atividades Futuras"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
-msgid ""
-"Generate the invoice automatically when the online payment is confirmed"
-msgstr ""
-"Gere a fatura automaticamente quando o pagamento online for confirmado"
+msgid "Generate the invoice automatically when the online payment is confirmed"
+msgstr "Gere a fatura automaticamente quando o pagamento online for confirmado"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
@@ -1543,12 +1456,10 @@ msgstr "Índice de Cores HTML"
 #. module: sale
 #: model:ir.model.fields,help:sale.field_product_attribute_value__html_color
 #: model:ir.model.fields,help:sale.field_product_template_attribute_value__html_color
-msgid ""
-"Here you can set a\n"
+msgid "Here you can set a\n"
 "        specific HTML color index (e.g. #ff0000) to display the color if the\n"
 "        attribute type is 'Color'."
-msgstr ""
-"Aqui você pode definir um\n"
+msgstr "Aqui você pode definir um\n"
 "         índice de cores HTML específico (por exemplo, # ff0000) para exibir a cor se o\n"
 "        tipo de atributo é 'Cor'."
 
@@ -1574,7 +1485,7 @@ msgstr "Como seus clientes podem confirmar um pedido"
 #: model:ir.model.fields,field_description:sale.field_sale_product_configurator__id
 #: model:ir.model.fields,field_description:sale.field_sale_report__id
 msgid "ID"
-msgstr "ID"
+msgstr "Id."
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__message_unread
@@ -1593,42 +1504,28 @@ msgstr "Se marcado, algumas mensagens tem erro de entrega."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
-msgid ""
-"If the sale is locked, you can not modify it anymore. However, you will "
-"still be able to invoice or deliver."
-msgstr ""
-"Se a compra está travada, você não pode mais modificá-la. Porém, você ainda "
-"será capaz de gerar fatura ou entregar."
+msgid "If the sale is locked, you can not modify it anymore. However, you will still be able to invoice or deliver."
+msgstr "Se a compra está travada, você não pode mais modificá-la. Porém, você ainda será capaz de gerar fatura ou entregar."
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:280
+#: code:addons/sale/controllers/portal.py:284
 #, python-format
-msgid ""
-"If we store your payment information on our server, subscription payments "
-"will be made automatically."
-msgstr ""
-"Se nós armazenarmos  suas informações de pagamento em nosso servidor, os "
-"pagamentos de assinaturas serão feitos automaticamente."
+msgid "If we store your payment information on our server, subscription payments will be made automatically."
+msgstr "Se nós armazenarmos  suas informações de pagamento em nosso servidor, os pagamentos de assinaturas serão feitos automaticamente."
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order_line__product_image
-msgid ""
-"Image of the product variant (Big-sized image of product template if false)."
-" It is automatically resized as a 1024x1024px image, with aspect ratio "
-"preserved."
-msgstr ""
-"Imagem da variante do produto (Imagem grande do modelo de produto se for "
-"falso). Será redimensionado automaticamente para uma imagem 1024x1024px, com"
-" a proporção preservada."
+msgid "Image of the product variant (Big-sized image of product template if false). It is automatically resized as a 1024x1024px image, with aspect ratio preserved."
+msgstr "Imagem da variante do produto (Imagem grande do modelo de produto se for falso). Será redimensionado automaticamente para uma imagem 1024x1024px, com a proporção preservada."
 
 #. module: sale
-#: code:addons/sale/models/product_template.py:89
+#: code:addons/sale/models/product_template.py:173
 #, python-format
 msgid "Import Template for Products"
 msgstr "Importar Modelo para Produtos"
 
 #. module: sale
-#: code:addons/sale/models/product_template.py:92
+#: code:addons/sale/models/product_template.py:176
 #, python-format
 msgid "Import Template for Products (with several prices)"
 msgstr "Importar o Template de Produtos (com multiplos preços)"
@@ -1649,19 +1546,19 @@ msgid "Insert your terms & conditions here..."
 msgstr "Insira seus termos e condições aqui..."
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:198
+#: code:addons/sale/controllers/portal.py:202
 #, python-format
 msgid "Invalid order"
 msgstr "Pedido inválido"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:794
+#: code:addons/sale/models/sale.py:880
 #, python-format
 msgid "Invalid token found! Token acquirer %s != %s"
 msgstr "Token inválido encontrado! Adquirente de token %s != %s"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:797
+#: code:addons/sale/models/sale.py:883
 #, python-format
 msgid "Invalid token found! Token partner %s != %s"
 msgstr "Token inválido encontrado! Parceiro de token %s != %s"
@@ -1672,7 +1569,7 @@ msgid "Invoice"
 msgstr "Fatura"
 
 #. module: sale
-#: code:addons/sale/models/account_invoice.py:62
+#: code:addons/sale/models/account_invoice.py:80
 #, python-format
 msgid "Invoice %s paid"
 msgstr "Fatura %s paga"
@@ -1695,7 +1592,7 @@ msgstr "Contagem de fatura"
 #. module: sale
 #: model:mail.message.subtype,name:sale.mt_salesteam_invoice_created
 msgid "Invoice Created"
-msgstr "Fatura criada"
+msgstr "Fatura Criada"
 
 #. module: sale
 #: model:ir.model,name:sale.model_account_invoice_line
@@ -1730,21 +1627,17 @@ msgstr "Endereço de fatura para o pedido de venda atual."
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_crm_team__invoiced
-msgid ""
-"Invoice revenue for the current month. This is the amount the sales channel "
-"has invoiced this month. It is used to compute the progression ratio of the "
-"current and target revenue on the kanban view."
-msgstr ""
-"Montante faturado para o mês corrente. Esse é o montante que o canal de "
-"vendas faturou esse mês. Isso é usado para computar o grau de progressão de "
-"recebimento corrente e alvo na vista kanban."
+msgid "Invoice revenue for the current month. This is the amount the sales channel has invoiced this month. It is used to compute the progression ratio of the current and target revenue on the kanban view."
+msgstr "Montante faturado para o mês corrente. Esse é o montante que o canal de vendas faturou esse mês. Isso é usado para computar o grau de progressão de recebimento corrente e alvo na vista kanban."
 
 #. module: sale
+#: selection:contact.config.settings,default_invoice_policy:0
 #: selection:res.config.settings,default_invoice_policy:0
 msgid "Invoice what is delivered"
 msgstr "Faturar o que é entregue"
 
 #. module: sale
+#: selection:contact.config.settings,default_invoice_policy:0
 #: selection:res.config.settings,default_invoice_policy:0
 msgid "Invoice what is ordered"
 msgstr "Faturar o que é pedido"
@@ -1760,12 +1653,7 @@ msgid "Invoiceable lines (deduct down payments)"
 msgstr "Linhas faturáveis (deduzir pagamentos baixados)"
 
 #. module: sale
-#: selection:sale.report,state:0
-msgid "Invoiced"
-msgstr "Faturado"
-
-#. module: sale
-#: code:addons/sale/models/sale.py:1061
+#: code:addons/sale/models/sale.py:1147
 #: model:ir.model.fields,field_description:sale.field_sale_order_line__qty_invoiced
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 #, python-format
@@ -1798,15 +1686,12 @@ msgstr "Estatísticas das Faturas"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_sale_advance_payment_inv
-msgid ""
-"Invoices will be created in draft so that you can review\n"
+msgid "Invoices will be created in draft so that you can review\n"
 "                        them before validation."
-msgstr ""
-"Faturas serão criadas em rascunho para que você possa revisar antes da "
-"validação."
+msgstr "Faturas serão criadas em rascunho para que você possa revisar antes da validação."
 
 #. module: sale
-#: code:addons/sale/models/sales_team.py:96
+#: code:addons/sale/models/sales_team.py:111
 #, python-format
 msgid "Invoices: Untaxed Total"
 msgstr "Faturas: Total sem os impostos"
@@ -1817,7 +1702,7 @@ msgstr "Faturas: Total sem os impostos"
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 msgid "Invoicing"
-msgstr "Faturamento"
+msgstr "Financeiro"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_content
@@ -1825,6 +1710,7 @@ msgid "Invoicing Address"
 msgstr "Endereço de Faturamento"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__default_invoice_policy
 #: model:ir.model.fields,field_description:sale.field_product_product__invoice_policy
 #: model:ir.model.fields,field_description:sale.field_product_template__invoice_policy
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__default_invoice_policy
@@ -1879,24 +1765,19 @@ msgstr "Está expirado"
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order_line__is_expense
-msgid ""
-"Is true if the sales order line comes from an expense or a vendor bills"
-msgstr ""
-"É verdadeiro se o linha pedido de venda vem de uma despesa ou contas de "
-"fornecedor"
+msgid "Is true if the sales order line comes from an expense or a vendor bills"
+msgstr "É verdadeiro se o linha pedido de venda vem de uma despesa ou contas de fornecedor"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1083
+#: code:addons/sale/models/sale.py:1169
 #, python-format
-msgid ""
-"It is forbidden to modify the following fields in a locked order:\n"
+msgid "It is forbidden to modify the following fields in a locked order:\n"
 "%s"
-msgstr ""
-"É proibito a modificação dos seguintes campos em um pedido trancado:\n"
+msgstr "É proibido a modificação dos seguintes campos em um pedido trancado:\n"
 "%s"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:667
+#: code:addons/sale/models/sale.py:768
 #, python-format
 msgid "It is not allowed to confirm an order in the following states: %s"
 msgstr "Não é permitido confirmar um pedido nas seguintes situações: %s"
@@ -1960,12 +1841,8 @@ msgstr "Permitir seus clientes conectarem para ver os documentos deles"
 #. openerp-web
 #: code:addons/sale/static/src/js/tour.js:24
 #, python-format
-msgid ""
-"Let's create a new quotation.<br/><i>Note that colored buttons usually point"
-" to the next logical actions.</i>"
-msgstr ""
-"Vamos criar uma novo orçamento.<br><i>Observe que botões coloridos geralmente "
-"apontam para as próximas ações lógicas.</i>"
+msgid "Let's create a new quotation.<br/><i>Note that colored buttons usually point to the next logical actions.</i>"
+msgstr "Vamos criar uma novo orçamento.<br><i>Observe que botões coloridos geralmente apontam para as próximas ações lógicas.</i>"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
@@ -1973,6 +1850,7 @@ msgid "Lock"
 msgstr "Trancar"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__auto_done_setting
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__auto_done_setting
 msgid "Lock Confirmed Sales"
 msgstr "Trancar Vendas Confirmadas"
@@ -2010,7 +1888,7 @@ msgstr "Gerenciar promoção e programas de cupom"
 #. module: sale
 #: selection:sale.order.line,qty_delivered_method:0
 msgid "Manual"
-msgstr "Manual"
+msgstr ""
 
 #. module: sale
 #: selection:product.template,service_type:0
@@ -2020,16 +1898,15 @@ msgstr "Definir manualmente quantidades na ordem"
 #. module: sale
 #: model:ir.model.fields,help:sale.field_product_product__service_type
 #: model:ir.model.fields,help:sale.field_product_template__service_type
-msgid ""
-"Manually set quantities on order: Invoice based on the manually entered quantity, without creating an analytic account.\n"
+msgid "Manually set quantities on order: Invoice based on the manually entered quantity, without creating an analytic account.\n"
 "Timesheets on contract: Invoice based on the tracked hours on the related timesheet.\n"
 "Create a task and track hours: Create a task on the sales order validation and track the work hours."
-msgstr ""
-"Definir as quantidades manualmente em pedidos: faturas baseadas em quantidades manuais, sem a criação de uma conta analítica.\n"
-"Planilha de Horas em contratos: Faturas baseadas nas horas registradas nos relatórios de horas relacionados.\n"
-"Criar uma tarefa e registrar as horas: Criar uma tarefa na validação do pedido e registrar as horas trabalhadas."
+msgstr "Definir quantidades manualmente no pedido: fatura com base na quantidade inserida manualmente, sem criar uma conta analítica.\n"
+"Quadros de horários do contrato: fatura com base nas horas rastreadas no quadro de horários relacionado.\n"
+"Crie uma tarefa e acompanhe as horas: crie uma tarefa na validação do pedido de vendas e acompanhe as horas de trabalho."
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_sale_margin
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_sale_margin
 msgid "Margins"
 msgstr "Margens"
@@ -2069,15 +1946,17 @@ msgstr "Método para atualizar a quantidade entregue"
 #. module: sale
 #: sql_constraint:sale.order.line:0
 msgid "Missing required fields on accountable sale order line."
-msgstr ""
-"Campos obrigatórios em falta da contabilidade na linha de ordem de venda."
+msgstr "Campos obrigatórios em falta da contabilidade na linha de ordem de venda."
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__multi_sales_price
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__multi_sales_price
 msgid "Multiple Sales Prices per Product"
 msgstr "Múltiplos Preços de Venda por Produto"
 
 #. module: sale
+#: selection:contact.config.settings,multi_sales_price_method:0
+#: selection:contact.config.settings,sale_pricelist_setting:0
 #: selection:res.config.settings,multi_sales_price_method:0
 #: selection:res.config.settings,sale_pricelist_setting:0
 msgid "Multiple prices per product (e.g. customer segments, currencies)"
@@ -2109,9 +1988,10 @@ msgid "Name of the person that signed the SO."
 msgstr "Nome da pessoa que assinou o PV."
 
 #. module: sale
-#: code:addons/sale/models/sale.py:131 code:addons/sale/models/sale.py:367
-#: code:addons/sale/models/sale.py:369 code:addons/sale/models/sale.py:371
-#: selection:sale.report,state:0
+#: code:addons/sale/models/sale.py:173
+#: code:addons/sale/models/sale.py:419
+#: code:addons/sale/models/sale.py:421
+#: code:addons/sale/models/sale.py:423
 #, python-format
 msgid "New"
 msgstr "Novo"
@@ -2120,6 +2000,11 @@ msgstr "Novo"
 #: model:ir.actions.act_window,name:sale.action_quotation_form
 msgid "New Quotation"
 msgstr "Novo Orçamento"
+
+#. module: sale
+#: model_terms:ir.ui.view,arch_db:sale.view_quotation_tree
+msgid "Next Activity"
+msgstr "Próxima Atividade"
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_order__activity_date_deadline
@@ -2173,7 +2058,7 @@ msgstr "Não finalizado"
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 #: selection:sale.order.line,display_type:0
 msgid "Note"
-msgstr "Nota"
+msgstr "Anotação"
 
 #. module: sale
 #: selection:sale.order,invoice_status:0
@@ -2188,12 +2073,8 @@ msgstr "Número de ações"
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order_line__customer_lead
-msgid ""
-"Number of days between the order confirmation and the shipping of the "
-"products to the customer"
-msgstr ""
-"Número de dias entre a confirmação do pedido e a entrega dos produtos ao "
-"Parceiro"
+msgid "Number of days between the order confirmation and the shipping of the products to the customer"
+msgstr "Número de dias entre a confirmação do pedido e a entrega dos produtos ao Parceiro"
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_order__message_has_error_counter
@@ -2223,12 +2104,7 @@ msgstr "Número de pedidos para faturar"
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__message_unread_counter
 msgid "Number of unread messages"
-msgstr "Quantidade de mensagens não lidas"
-
-#. module: sale
-#: model:product.template,description_sale:sale.product_product_1_product_template
-msgid "Office chairs can harm your floor: protect it."
-msgstr "Cadeiras de escritório podem prejudicar seu piso: proteja-o."
+msgstr "Quantidade de mensagens não lidas."
 
 #. module: sale
 #: model_terms:ir.actions.act_window,help:sale.act_res_partner_2_sale_order
@@ -2236,32 +2112,23 @@ msgstr "Cadeiras de escritório podem prejudicar seu piso: proteja-o."
 #: model_terms:ir.actions.act_window,help:sale.action_quotations
 #: model_terms:ir.actions.act_window,help:sale.action_quotations_salesteams
 #: model_terms:ir.actions.act_window,help:sale.action_quotations_with_onboarding
-msgid ""
-"Once the quotation is confirmed by the customer, it becomes a sales "
-"order.<br> You will be able to create an invoice and collect the payment."
-msgstr ""
-"Uma vez que o orçamento seja confirmado pelo cliente, ela se tornará um pedido"
-" de venda. <br> Você será capaz de criar uma fatura e coletar o pagamento."
+msgid "Once the quotation is confirmed by the customer, it becomes a sales order.<br> You will be able to create an invoice and collect the payment."
+msgstr "Uma vez que o orçamento seja confirmado pelo cliente, ela se tornará um pedido de venda. <br> Você será capaz de criar uma fatura e coletar o pagamento."
 
 #. module: sale
 #: model_terms:ir.actions.act_window,help:sale.action_orders
-msgid ""
-"Once the quotation is confirmed, it becomes a sales order.<br> You will be "
-"able to create an invoice and collect the payment."
-msgstr ""
-"Uma vez que o orçamento seja confirmado, ela se tornará um pedido de venda. "
-"<br> Você será capaz de criar uma fatura e coletar o pagamento."
+msgid "Once the quotation is confirmed, it becomes a sales order.<br> You will be able to create an invoice and collect the payment."
+msgstr "Uma vez que o orçamento seja confirmado, ela se tornará um pedido de venda. <br> Você será capaz de criar uma fatura e coletar o pagamento."
 
 #. module: sale
 #. openerp-web
-#: code:addons/sale/static/src/js/tour.js:65
+#: code:addons/sale/static/src/js/tour.js:64
 #, python-format
 msgid "Once your quotation is ready, you can save, print or send it by email."
-msgstr ""
-"Uma vez que seu orçamento esteja pronto, você pode salvar, imprimir ou enviar "
-"por email."
+msgstr "Uma vez que seu orçamento esteja pronto, você pode salvar, imprimir ou enviar por email."
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__portal_confirmation_pay
 #: model:ir.model.fields,field_description:sale.field_res_company__portal_confirmation_pay
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__portal_confirmation_pay
 #: model:ir.model.fields,field_description:sale.field_sale_order__require_payment
@@ -2269,6 +2136,7 @@ msgid "Online Payment"
 msgstr "Pagamento Online"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__portal_confirmation_sign
 #: model:ir.model.fields,field_description:sale.field_res_company__portal_confirmation_sign
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__portal_confirmation_sign
 #: model:ir.model.fields,field_description:sale.field_sale_order__require_signature
@@ -2296,13 +2164,8 @@ msgstr "Produtos Opcionais"
 #. module: sale
 #: model:ir.model.fields,help:sale.field_product_product__optional_product_ids
 #: model:ir.model.fields,help:sale.field_product_template__optional_product_ids
-msgid ""
-"Optional Products are suggested whenever the customer hits *Add to Cart* "
-"(cross-sell strategy, e.g. for computers: warranty, software, etc.)."
-msgstr ""
-"Produtos opcionais são sugeridos sempre que o cliente clica *Adicionar ao "
-"Carrinho* (estratégia de venda cruzada, por exemplo, para computadores: "
-"garantia, software, etc.)."
+msgid "Optional Products are suggested whenever the customer hits *Add to Cart* (cross-sell strategy, e.g. for computers: warranty, software, etc.)."
+msgstr "Produtos opcionais são sugeridos sempre que o cliente clica *Adicionar ao Carrinho* (estratégia de venda cruzada, por exemplo, para computadores: garantia, software, etc.)."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.product_template_form_view
@@ -2326,10 +2189,14 @@ msgid "Order Count"
 msgstr "Contagem de pedidos"
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:51
-#: code:addons/sale/controllers/portal.py:103
+#: code:addons/sale/controllers/portal.py:52
+#: code:addons/sale/controllers/portal.py:104
 #: model:ir.model.fields,field_description:sale.field_sale_order__date_order
-#: model:ir.model.fields,field_description:sale.field_sale_report__dData da Ordemerit_sale
+#: model:ir.model.fields,field_description:sale.field_sale_report__date
+#: model_terms:ir.ui.view,arch_db:sale.portal_my_orders
+#: model_terms:ir.ui.view,arch_db:sale.portal_my_quotations
+#: model_terms:ir.ui.view,arch_db:sale.sale_order_view_search_inherit_quotation
+#: model_terms:ir.ui.view,arch_db:sale.sale_order_view_search_inherit_sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_product_search
 #: model_terms:ir.ui.view,arch_db:sale.view_sales_order_filter
 #, python-format
@@ -2366,13 +2233,13 @@ msgid "Order Upsell"
 msgstr "Vender pedido"
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:201
+#: code:addons/sale/controllers/portal.py:205
 #, python-format
 msgid "Order is not in a state requiring customer signature."
 msgstr "O pedido não está em uma situação que exige assinatura do cliente."
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:215
+#: code:addons/sale/controllers/portal.py:219
 #, python-format
 msgid "Order signed by %s"
 msgstr "Pedido assinado por %s"
@@ -2388,7 +2255,7 @@ msgid "Ordered Qty"
 msgstr "Qtd Solicitada"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1057
+#: code:addons/sale/models/sale.py:1143
 #: model:ir.model.fields,field_description:sale.field_sale_order_line__product_uom_qty
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 #, python-format
@@ -2398,11 +2265,9 @@ msgstr "Quantidade Solicitada"
 #. module: sale
 #: model:ir.model.fields,help:sale.field_product_product__invoice_policy
 #: model:ir.model.fields,help:sale.field_product_template__invoice_policy
-msgid ""
-"Ordered Quantity: Invoice quantities ordered by the customer.\n"
+msgid "Ordered Quantity: Invoice quantities ordered by the customer.\n"
 "Delivered Quantity: Invoice quantities delivered to the customer."
-msgstr ""
-"Quantidade Solicitada: Quantidades solicitadas da fatura pelo cliente.\n"
+msgstr "Quantidade Solicitada: Quantidades solicitadas da fatura pelo cliente.\n"
 "Quantidade Entregue: Quantidades faturadas entregues ao cliente."
 
 #. module: sale
@@ -2435,8 +2300,7 @@ msgstr "Pedidos para Vender"
 #: code:addons/sale/static/src/js/tour.js:18
 #, python-format
 msgid "Organize your sales activities with the <b>Sales Management app</b>."
-msgstr ""
-"Organize suas atividades e gestão de vendas com o aplicativo<b> Vendas</b>."
+msgstr "Organize suas atividades e gestão de vendas com o aplicativo<b> Vendas</b>."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
@@ -2454,11 +2318,7 @@ msgid "PRO-FORMA Invoice"
 msgstr "Fatura PRÓ-FORMA"
 
 #. module: sale
-#: selection:sale.report,state:0
-msgid "Paid"
-msgstr "Pago"
-
-#. module: sale
+#: model:ir.model,name:sale.model_res_partner
 #: model:ir.model.fields,field_description:sale.field_report_all_channels_sales__partner_id
 msgid "Partner"
 msgstr "Parceiro"
@@ -2469,7 +2329,7 @@ msgid "Partner Country"
 msgstr "País Parceiro"
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:277
+#: code:addons/sale/controllers/portal.py:281
 #, python-format
 msgid "Pay & Confirm"
 msgstr "Pagar & Confirmar"
@@ -2480,7 +2340,7 @@ msgid "Pay &amp; Confirm"
 msgstr "Pagar &amp; Confirmar"
 
 #. module: sale
-#: code:addons/sale/models/payment.py:160
+#: code:addons/sale/models/payment.py:179
 #, python-format
 msgid "Pay Now"
 msgstr "Pagar Agora"
@@ -2519,12 +2379,12 @@ msgstr "Pague com cartão de crédito (via Stripe)"
 #. module: sale
 #: selection:res.company,sale_onboarding_payment_method:0
 msgid "PayPal"
-msgstr "PayPal"
+msgstr ""
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_payment_acquirer_onboarding_wizard__paypal_email_account
 msgid "PayPal Email ID"
-msgstr "ID do email do PayPal"
+msgstr "E-mail ID do Paypal"
 
 #. module: sale
 #: model:ir.model,name:sale.model_payment_acquirer
@@ -2564,12 +2424,12 @@ msgstr "Transação do Pagamento"
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_payment_acquirer_onboarding_wizard__paypal_seller_account
 msgid "Paypal Merchant ID"
-msgstr "Paypal Merchant ID"
+msgstr ""
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_payment_acquirer_onboarding_wizard__paypal_pdt_token
 msgid "Paypal PDT Token"
-msgstr "Paypal PDT Token"
+msgstr ""
 
 #. module: sale
 #: selection:crm.team,dashboard_graph_model:0
@@ -2582,30 +2442,21 @@ msgid "Planned"
 msgstr "Planejado"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:450
+#: code:addons/sale/models/sale.py:508
 #, python-format
 msgid "Please define an accounting sales journal for this company."
-msgstr "Por favor defina um diário contábil de vendas para essa companhia."
+msgstr "Por favor defina um diário contábil de vendas para empresa."
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1318
+#: code:addons/sale/models/sale.py:1423
 #, python-format
-msgid ""
-"Please define income account for this product: \"%s\" (id:%d) - or for its "
-"category: \"%s\"."
-msgstr ""
-"Por favor, defina conta de receitas para este produto: \"%s\" (id:%d) - ou "
-"para esta categoria: \"%s\"."
+msgid "Please define income account for this product: \"%s\" (id:%d) - or for its category: \"%s\"."
+msgstr "Por favor, defina conta de receitas para este produto: \"%s\" (id:%d) - ou para esta categoria: \"%s\"."
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_order__access_url
 msgid "Portal Access URL"
 msgstr "Endereço de Acesso ao Portal"
-
-#. module: sale
-#: selection:sale.report,state:0
-msgid "Posted"
-msgstr "Lançado"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
@@ -2638,6 +2489,7 @@ msgid "Price Subtotal"
 msgstr "Preço Subtotal"
 
 #. module: sale
+#: selection:contact.config.settings,sale_pricelist_setting:0
 #: selection:res.config.settings,sale_pricelist_setting:0
 msgid "Price computed from formulas (discounts, margins, roundings)"
 msgstr "Preço computado de fórmulas (descontos, margens, arredondamentos)"
@@ -2657,6 +2509,7 @@ msgid "Pricelist for current sales order."
 msgstr "Lista de preços para o pedido de venda atual."
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__sale_pricelist_setting
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__sale_pricelist_setting
 #: model:ir.ui.menu,name:sale.menu_product_pricelist_main
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
@@ -2664,11 +2517,13 @@ msgid "Pricelists"
 msgstr "Listas de preços"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__multi_sales_price_method
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__multi_sales_price_method
 msgid "Pricelists Method"
 msgstr "Método de lista de preços"
 
 #. module: sale
+#: selection:contact.config.settings,multi_sales_price_method:0
 #: selection:res.config.settings,multi_sales_price_method:0
 msgid "Prices computed from formulas (discounts, margins, roundings)"
 msgstr "Preços computados de fórmulas(descontos, margens, arredondamentos)"
@@ -2685,6 +2540,7 @@ msgid "Print"
 msgstr "Imprimir"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__group_proforma_sales
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__group_proforma_sales
 msgid "Pro-Forma Invoice"
 msgstr "Fatura pró-forma"
@@ -2745,7 +2601,7 @@ msgstr "Imagem do Produto"
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_report_all_channels_sales__product_qty
 msgid "Product Quantity"
-msgstr "Quantidade do produto"
+msgstr "Qtde Produto"
 
 #. module: sale
 #: model:ir.model,name:sale.model_product_template
@@ -2831,7 +2687,7 @@ msgid "Quantity:"
 msgstr "Quantidade:"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:262
+#: code:addons/sale/models/sale.py:311
 #: model_terms:ir.ui.view,arch_db:sale.crm_team_salesteams_view_kanban
 #: model_terms:ir.ui.view,arch_db:sale.view_quotation_tree
 #: selection:sale.order,state:0
@@ -2866,7 +2722,8 @@ msgid "Quotation Number"
 msgstr "Orçamento Número"
 
 #. module: sale
-#: selection:sale.order,state:0 selection:sale.report,state:0
+#: selection:sale.order,state:0
+#: selection:sale.report,state:0
 msgid "Quotation Sent"
 msgstr "Orçamento Enviado"
 
@@ -2878,23 +2735,23 @@ msgstr "A validade do orçamento é necessária e deve ser superior a 0."
 #. module: sale
 #: model:mail.message.subtype,description:sale.mt_order_confirmed
 msgid "Quotation confirmed"
-msgstr "Orçamento Confirmado"
+msgstr "Orçamento confirmado"
 
 #. module: sale
 #: model:mail.message.subtype,description:sale.mt_order_sent
 #: model:mail.message.subtype,name:sale.mt_order_sent
 #: model:mail.message.subtype,name:sale.mt_salesteam_order_sent
 msgid "Quotation sent"
-msgstr "Orçamento enviado"
+msgstr "Cotação enviada"
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:159
+#: code:addons/sale/controllers/portal.py:163
 #, python-format
 msgid "Quotation viewed by customer"
 msgstr "Orçamento visualizado pelo cliente"
 
 #. module: sale
-#: code:addons/sale/models/sales_team.py:101
+#: code:addons/sale/models/sales_team.py:116
 #: model:ir.actions.act_window,name:sale.action_quotations
 #: model:ir.actions.act_window,name:sale.action_quotations_salesteams
 #: model:ir.actions.act_window,name:sale.action_quotations_with_onboarding
@@ -2928,7 +2785,7 @@ msgstr "Orçamentos e Vendas"
 #. module: sale
 #: selection:product.attribute,type:0
 msgid "Radio"
-msgstr "Radio"
+msgstr ""
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_product_product__expense_policy
@@ -2937,8 +2794,8 @@ msgid "Re-Invoice Policy"
 msgstr "Política Re-Fatura"
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:52
-#: code:addons/sale/controllers/portal.py:104
+#: code:addons/sale/controllers/portal.py:53
+#: code:addons/sale/controllers/portal.py:105
 #, python-format
 msgid "Reference"
 msgstr "Referência"
@@ -2946,8 +2803,7 @@ msgstr "Referência"
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__origin
 msgid "Reference of the document that generated this sales order request."
-msgstr ""
-"Referência para o documento que gerou esta solicitação de pedido de venda."
+msgstr "Referência para o documento que gerou esta solicitação de pedido de venda."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
@@ -2973,12 +2829,8 @@ msgstr "Relatórios"
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__require_signature
-msgid ""
-"Request a online signature to the customer in order to confirm orders "
-"automatically."
-msgstr ""
-"Solicite uma assinatura on-line ao cliente para confirmar os pedidos "
-"automaticamente."
+msgid "Request a online signature to the customer in order to confirm orders automatically."
+msgstr "Solicite uma assinatura on-line ao cliente para confirmar os pedidos automaticamente."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
@@ -2987,12 +2839,8 @@ msgstr "Solicite um pagamento on-line para confirmar pedidos"
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__require_payment
-msgid ""
-"Request an online payment to the customer in order to confirm orders "
-"automatically."
-msgstr ""
-"Solicitar um pagamento online ao cliente para confirmar pedidos "
-"automaticamente."
+msgid "Request an online payment to the customer in order to confirm orders automatically."
+msgstr "Solicitar um pagamento online ao cliente para confirmar pedidos automaticamente."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
@@ -3000,7 +2848,7 @@ msgid "Request an online signature to confirm orders"
 msgstr "Solicite uma assinatura on-line para confirmar pedidos"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:359
+#: code:addons/sale/models/sale.py:411
 #, python-format
 msgid "Requested date is too soon."
 msgstr "A data do pedido é muito próxima!"
@@ -3022,6 +2870,7 @@ msgid "Sale Order Count"
 msgstr "Contagem Pedido de Venda"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__group_warning_sale
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__group_warning_sale
 msgid "Sale Order Warnings"
 msgstr "Avisos do Pedido de Venda"
@@ -3096,12 +2945,12 @@ msgid "Sales Information"
 msgstr "Informação de Vendas"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:271
+#: code:addons/sale/models/sale.py:311
 #: model:ir.model.fields,field_description:sale.field_res_partner__sale_order_ids
-#: model:ir.model.fields,field_description:sale.field_res_users__sale_order_ids
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 #: model_terms:ir.ui.view,arch_db:sale.view_sales_order_filter
-#: selection:sale.order,state:0 selection:sale.report,state:0
+#: selection:sale.order,state:0
+#: selection:sale.report,state:0
 #, python-format
 msgid "Sales Order"
 msgstr "Pedidos de Venda"
@@ -3110,7 +2959,7 @@ msgstr "Pedidos de Venda"
 #: model:mail.message.subtype,name:sale.mt_order_confirmed
 #: model:mail.message.subtype,name:sale.mt_salesteam_order_confirmed
 msgid "Sales Order Confirmed"
-msgstr "Pedido de Venda Confirmado"
+msgstr "Ordem de venda confirmada"
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_account_analytic_line__so_line
@@ -3123,7 +2972,7 @@ msgstr "Item do Pedido de Venda"
 #: model:ir.model.fields,field_description:sale.field_product_product__sale_line_warn
 #: model:ir.model.fields,field_description:sale.field_product_template__sale_line_warn
 msgid "Sales Order Line"
-msgstr "Linha do Pedido de Venda"
+msgstr "Linha do Pedido de Vendas"
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_account_invoice_line__sale_line_ids
@@ -3143,14 +2992,14 @@ msgid "Sales Order Lines related to a Sales Order of mine"
 msgstr "Linhas de Pedido de Venda relacionadas ao meu pedido"
 
 #. module: sale
-#: code:addons/sale/models/payment.py:133
+#: code:addons/sale/models/payment.py:152
 #: model_terms:ir.ui.view,arch_db:sale.transaction_form_inherit_sale
 #, python-format
 msgid "Sales Order(s)"
 msgstr "Pedido(s) de Venda"
 
 #. module: sale
-#: code:addons/sale/models/sales_team.py:102
+#: code:addons/sale/models/sales_team.py:117
 #: model:ir.actions.act_window,name:sale.action_orders
 #: model:ir.actions.act_window,name:sale.action_orders_salesteams
 #: model:ir.actions.act_window,name:sale.action_orders_to_invoice_salesteams
@@ -3218,7 +3067,7 @@ msgid "Sales price"
 msgstr "Preço Vendas"
 
 #. module: sale
-#: code:addons/sale/models/sales_team.py:94
+#: code:addons/sale/models/sales_team.py:109
 #, python-format
 msgid "Sales: Untaxed Total"
 msgstr "Vendas: Total sem Impostos"
@@ -3289,14 +3138,8 @@ msgstr "Selecione um produto ou crie um novo em tempo real."
 #: model:ir.model.fields,help:sale.field_product_template__sale_line_warn
 #: model:ir.model.fields,help:sale.field_res_partner__sale_warn
 #: model:ir.model.fields,help:sale.field_res_users__sale_warn
-msgid ""
-"Selecting the \"Warning\" option will notify user with the message, "
-"Selecting \"Blocking Message\" will throw an exception with the message and "
-"block the flow. The Message has to be written in the next field."
-msgstr ""
-"Selecionando a opção de \"Aviso\" irá notificar o usuário com a mensagem, "
-"marcar \"Mensagem de Bloqueio\" irá lançar uma exceção com a mensagem e "
-"bloquear o fluxo. A mensagem tem de ser escrita no campo a seguir."
+msgid "Selecting the \"Warning\" option will notify user with the message, Selecting \"Blocking Message\" will throw an exception with the message and block the flow. The Message has to be written in the next field."
+msgstr "Selecionando a opção de \"Aviso\" irá notificar o usuário com a mensagem, marcar \"Mensagem de Bloqueio\" irá lançar uma exceção com a mensagem e bloquear o fluxo. A mensagem tem de ser escrita no campo a seguir."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
@@ -3340,15 +3183,8 @@ msgstr "Enviar exemplo"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
-msgid ""
-"Sending an email is useful if you need to share specific information or "
-"content about a product (instructions, rules, links, media, etc.). Create "
-"and set the email template from the product detail form (in Sales tab)."
-msgstr ""
-"Enviar um e-mail é útil se você precisar compartilhar informações ou "
-"conteúdos específicos sobre um produto (instruções, regras, links, mídia, "
-"etc.). Crie e defina o modelo de e-mail do formulário de detalhes do produto"
-" (na guia Vendas)."
+msgid "Sending an email is useful if you need to share specific information or content about a product (instructions, rules, links, media, etc.). Create and set the email template from the product detail form (in Sales tab)."
+msgstr "Enviar um e-mail é útil se você precisar compartilhar informações ou conteúdos específicos sobre um produto (instruções, regras, links, mídia, etc.). Crie e defina o modelo de e-mail do formulário de detalhes do produto (na guia Vendas)."
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_order_line__sequence
@@ -3367,7 +3203,7 @@ msgstr "Defina uma validade padrão em seus orçamentos"
 
 #. module: sale
 #. openerp-web
-#: code:addons/sale/static/src/js/sale.js:25
+#: code:addons/sale/static/src/js/sale.js:26
 #, python-format
 msgid "Set an invoicing target: "
 msgstr "Definir uma meta de faturamento: "
@@ -3409,6 +3245,7 @@ msgid "Shipping"
 msgstr "Entrega"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery
 msgid "Shipping Costs"
 msgstr "Custos de remessa"
@@ -3421,8 +3258,7 @@ msgstr "Informações de entrega"
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_sales_order_filter
 msgid "Show all records which has next action date is before today"
-msgstr ""
-"Mostrar todas as gravações em que a próxima data de ação seja antes de hoje"
+msgstr "Mostrar todas as gravações em que a próxima data de ação seja antes de hoje."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
@@ -3442,7 +3278,7 @@ msgstr "Mostre termos e condições padrão em pedidos"
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.mail_notification_paynow_online
 msgid "Sign and pay online"
-msgstr "Assine e pague online"
+msgstr "Assinar e pagar online"
 
 #. module: sale
 #: selection:res.company,sale_onboarding_payment_method:0
@@ -3457,7 +3293,7 @@ msgid "Signature"
 msgstr "Assinatura"
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:203
+#: code:addons/sale/controllers/portal.py:207
 #, python-format
 msgid "Signature is missing."
 msgstr "Falta a assinatura."
@@ -3490,13 +3326,14 @@ msgid "Source Document"
 msgstr "Documento de Origem"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_product_email_template
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_product_email_template
 msgid "Specific Email"
 msgstr "E-mail Específico"
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:53
-#: code:addons/sale/controllers/portal.py:105
+#: code:addons/sale/controllers/portal.py:54
+#: code:addons/sale/controllers/portal.py:106
 #, python-format
 msgid "Stage"
 msgstr "Estágio"
@@ -3525,22 +3362,14 @@ msgstr "Situação"
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__activity_state
-msgid ""
-"Status based on activities\n"
+msgid "Status based on activities\n"
 "Overdue: Due date is already passed\n"
 "Today: Activity date is today\n"
 "Planned: Future activities."
-msgstr ""
-"Status baseado em atividades\n"
+msgstr "Status baseado em atividades\n"
 "Atrasado: Data definida já passou\n"
 "Hoje: Data de atividade é hoje\n"
 "Planejado: Atividades futuras."
-
-#. module: sale
-#: model:product.template.attribute.value,name:sale.product_template_attribute_value_3
-#: model:product.template.attribute.value,name:sale.product_template_attribute_value_4
-msgid "Steel"
-msgstr "Aço"
 
 #. module: sale
 #: selection:sale.order.line,qty_delivered_method:0
@@ -3550,7 +3379,7 @@ msgstr "Movimentos de Estoque"
 #. module: sale
 #: selection:res.company,sale_onboarding_payment_method:0
 msgid "Stripe"
-msgstr "Stripe"
+msgstr ""
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_payment_acquirer_onboarding_wizard__stripe_publishable_key
@@ -3560,21 +3389,17 @@ msgstr "Chave pública Stripe"
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_payment_acquirer_onboarding_wizard__stripe_secret_key
 msgid "Stripe Secret Key"
-msgstr "Stripe Secret Key"
+msgstr ""
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_order_line__price_subtotal
 msgid "Subtotal"
-msgstr "Subtotal"
+msgstr ""
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_crm_team__invoiced_target
-msgid ""
-"Target of invoice revenue for the current month. This is the amount the "
-"sales channel estimates to be able to invoice this month."
-msgstr ""
-"Meta de receita faturada para o mês corrente. Esse é o valor que o canal de "
-"vendas estima para poder faturar este mês."
+msgid "Target of invoice revenue for the current month. This is the amount the sales channel estimates to be able to invoice this month."
+msgstr "Meta de receita faturada para o mês corrente. Esse é o valor que o canal de vendas estima para poder faturar este mês."
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_order__amount_by_group
@@ -3601,14 +3426,11 @@ msgstr "Campo técnico para propósito de Experiência do Usuário."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
-msgid ""
-"Tell us why you are refusing this quotation, this will help us improve our "
-"services."
-msgstr ""
-"Nos conte porque está recusando este orçamento, isto irá ajudar nós a melhorar"
-" nossos serviços."
+msgid "Tell us why you are refusing this quotation, this will help us improve our services."
+msgstr "Nos conte porque está recusando este orçamento, isto irá ajudar nós a melhorar nossos serviços."
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__sale_note
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__sale_note
 msgid "Terms & Conditions"
 msgstr "Termos e Condições"
@@ -3625,44 +3447,26 @@ msgstr "Termos e condições"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
-msgid ""
-"Terms and conditions... (note: you can setup default ones in the "
-"Configuration menu)"
-msgstr ""
-"Termos e condições... (nota: você pode configurar termos e condições padrões"
-" no menu Configuração)"
+msgid "Terms and conditions... (note: you can setup default ones in the Configuration menu)"
+msgstr "Termos e condições... (nota: você pode configurar termos e condições padrões no menu Configuração)"
+
+#. module: sale
+#: code:addons/sale/models/analytic.py:117
+#, python-format
+msgid "The Sales Order %s linked to the Analytic Account %s is cancelled. You cannot register an expense on a cancelled Sales Order."
+msgstr "O pedido de venda %s vinculado à conta analítica %s está cancelado. Você não pode registrar uma despesa em um Pedido de Vendas cancelado."
 
 #. module: sale
 #: code:addons/sale/models/analytic.py:116
 #, python-format
-msgid ""
-"The Sales Order %s linked to the Analytic Account %s is cancelled. You "
-"cannot register an expense on a cancelled Sales Order."
-msgstr ""
-"O pedido de venda %s vinculado à conta analítica %s está cancelado. Você não"
-" pode registrar uma despesa em um Pedido de Vendas cancelado."
+msgid "The Sales Order %s linked to the Analytic Account %s is currently locked. You cannot register an expense on a locked Sales Order. Please create a new SO linked to this Analytic Account."
+msgstr "O Pedido de Venda %s está vinculado à Conta Analítica %s está bloqueado atualmente. Você não pode registrar uma despesa em um pedido de venda bloqueado. Por favor, crie um novo PV vinculado a esta Conta Analítica."
 
 #. module: sale
-#: code:addons/sale/models/analytic.py:115
+#: code:addons/sale/models/analytic.py:112
 #, python-format
-msgid ""
-"The Sales Order %s linked to the Analytic Account %s is currently locked. "
-"You cannot register an expense on a locked Sales Order. Please create a new "
-"SO linked to this Analytic Account."
-msgstr ""
-"O Pedido de Venda %s está vinculado à Conta Analítica %s está bloqueado "
-"atualmente. Você não pode registrar uma despesa em um pedido de venda "
-"bloqueado. Por favor, crie um novo PV vinculado a esta Conta Analítica."
-
-#. module: sale
-#: code:addons/sale/models/analytic.py:111
-#, python-format
-msgid ""
-"The Sales Order %s linked to the Analytic Account %s must be validated "
-"before registering expenses."
-msgstr ""
-"O Pedido de Venda %s está vinculado à Conta Analítica %s deve ser validado "
-"antes de registrar despesas."
+msgid "The Sales Order %s linked to the Analytic Account %s must be validated before registering expenses."
+msgstr "O Pedido de Venda %s está vinculado à Conta Analítica %s deve ser validado antes de registrar despesas."
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_advance_payment_inv__amount
@@ -3675,49 +3479,38 @@ msgid "The analytic account related to a sales order."
 msgstr "Conta analítica relacionada ao pedido de venda."
 
 #. module: sale
-#: code:addons/sale/models/sale.py:360
+#: code:addons/sale/models/sale.py:412
 #, python-format
-msgid ""
-"The commitment date is sooner than the expected date.You may be unable to "
-"honor the commitment date."
-msgstr ""
-"A data do compromisso é anterior à data prevista. Talvez você não consiga "
-"honrar a data do compromisso."
+msgid "The commitment date is sooner than the expected date.You may be unable to honor the commitment date."
+msgstr "A data do compromisso é anterior à data prevista. Talvez você não consiga honrar a data do compromisso."
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_crm_team__dashboard_graph_model
 msgid "The graph this channel will display in the Dashboard.\n"
+""
 msgstr "O gráfico mostrado pelo canal no Painel.\n"
+""
 
 #. module: sale
+#: model:ir.model.fields,help:sale.field_contact_config_settings__automatic_invoice
 #: model:ir.model.fields,help:sale.field_res_config_settings__automatic_invoice
-msgid ""
-"The invoice is generated automatically and available in the customer portal when the transaction is confirmed by the payment acquirer.\n"
+msgid "The invoice is generated automatically and available in the customer portal when the transaction is confirmed by the payment acquirer.\n"
 "The invoice is marked as paid and the payment is registered in the payment journal defined in the configuration of the payment acquirer.\n"
 "This mode is advised if you issue the final invoice at the order and not after the delivery."
-msgstr ""
-"A fatura é gerada automaticamente e fica disponível no portal do cliente quando a transação é confirmada pelo adquirente do pagamento.\n"
+msgstr "A fatura é gerada automaticamente e fica disponível no portal do cliente quando a transação é confirmada pelo adquirente do pagamento.\n"
 "A fatura é marcada como paga e o pagamento é registrado no diário de pagamentos definido na configuração do adquirente do pagamento.\n"
 "Este modo é recomendado se você emitir a fatura final no pedido e não após a entrega."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
-msgid ""
-"The margin is computed as the sum of product sales prices minus the cost set"
-" in their detail form."
-msgstr ""
-"A margem é calculada a partir da soma dos preços de venda do produto menos o"
-" custo definido."
+msgid "The margin is computed as the sum of product sales prices minus the cost set in their detail form."
+msgstr "A margem é calculada a partir da soma dos preços de venda do produto menos o custo definido."
 
 #. module: sale
-#: code:addons/sale/models/payment.py:97
+#: code:addons/sale/models/payment.py:91
 #, python-format
-msgid ""
-"The order was not confirmed despite response from the acquirer (%s): order "
-"total is %r but acquirer replied with %r."
-msgstr ""
-"O pedido não foi confirmado pela resposta do adquirinte  (%s): o valor total"
-" é %r mas o adquirinte respondeu com %r."
+msgid "The order was not confirmed despite response from the acquirer (%s): order total is %r but acquirer replied with %r."
+msgstr "O pedido não foi confirmado pela resposta do adquirinte  (%s): o valor total é %r mas o adquirinte respondeu com %r."
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__reference
@@ -3725,32 +3518,20 @@ msgid "The payment communication of this sale order."
 msgstr "A comunicação de pagamento deste pedido de venda."
 
 #. module: sale
-#: code:addons/sale/wizard/sale_make_invoice_advance.py:154
+#: code:addons/sale/wizard/sale_make_invoice_advance.py:155
 #, python-format
-msgid ""
-"The product used to invoice a down payment should be of type 'Service'. "
-"Please use another product or update this product."
-msgstr ""
-"O produto usado para faturar um adiantamento deve ser do tipo 'Serviço'. "
-"Utilize outro produto ou atualize este produto."
+msgid "The product used to invoice a down payment should be of type 'Service'. Please use another product or update this product."
+msgstr "O produto usado para faturar um adiantamento deve ser do tipo 'Serviço'. Utilize outro produto ou atualize este produto."
 
 #. module: sale
-#: code:addons/sale/wizard/sale_make_invoice_advance.py:152
+#: code:addons/sale/wizard/sale_make_invoice_advance.py:153
 #, python-format
-msgid ""
-"The product used to invoice a down payment should have an invoice policy set"
-" to \"Ordered quantities\". Please update your deposit product to be able to"
-" create a deposit invoice."
-msgstr ""
-"O produto usado para faturar um adiantamento deve ter uma política definida "
-"para \"Quantidades Solicitadas\". Por favor, atualize seu produto de "
-"depósito para ser capaz de criar uma fatura de depósito."
+msgid "The product used to invoice a down payment should have an invoice policy set to \"Ordered quantities\". Please update your deposit product to be able to create a deposit invoice."
+msgstr "O produto usado para faturar um adiantamento deve ter uma política definida para \"Quantidades Solicitadas\". Por favor, atualize seu produto de depósito para ser capaz de criar uma fatura de depósito."
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__currency_rate
-msgid ""
-"The rate of the currency to the currency of rate 1 applicable at the date of"
-" the order"
+msgid "The rate of the currency to the currency of rate 1 applicable at the date of the order"
 msgstr "A taxa da moeda para a moeda da taxa 1 aplicável na data do pedido"
 
 #. module: sale
@@ -3771,45 +3552,27 @@ msgstr "No presente momento não há orçamentos para sua conta."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
-msgid ""
-"There are two ways to manage pricelists: 1) Multiple prices per product: "
-"must be set in the Sales tab of the product detail form. 2) Price computed "
-"from formulas: must be set in the pricelist form."
-msgstr ""
-"Existem duas vias de gerenciar listas de preços: 1) Múltiplos preços por "
-"produto: deve ser definido na aba de Vendas no formulário de detalhes do "
-"produto. 2) Preço computado por fórmulas: deve ser definido no formulário "
-"lista de preços."
+msgid "There are two ways to manage pricelists: 1) Multiple prices per product: must be set in the Sales tab of the product detail form. 2) Price computed from formulas: must be set in the pricelist form."
+msgstr "Existem duas vias de gerenciar listas de preços: 1) Múltiplos preços por produto: deve ser definido na aba de Vendas no formulário de detalhes do produto. 2) Preço computado por fórmulas: deve ser definido no formulário lista de preços."
 
 #. module: sale
 #: code:addons/sale/wizard/sale_make_invoice_advance.py:76
 #, python-format
-msgid ""
-"There is no income account defined for this product: \"%s\". You may have to"
-" install a chart of account from Accounting app, settings menu."
-msgstr ""
-"Não há nenhuma conta de receitas definida para este produto: \"%s\". Você "
-"pode ter que instalar um plano de contas da Contabilidade, no menu de "
-"configurações."
+msgid "There is no income account defined for this product: \"%s\". You may have to install a chart of account from Accounting app, settings menu."
+msgstr "Não há nenhuma conta de receitas definida para este produto: \"%s\". Você pode ter que instalar um plano de contas da Contabilidade, no menu de configurações."
 
 #. module: sale
-#: code:addons/sale/models/sale.py:549 code:addons/sale/models/sale.py:553
+#: code:addons/sale/models/sale.py:560
+#: code:addons/sale/models/sale.py:657
 #, python-format
-msgid ""
-"There is no invoiceable line. If a product has a Delivered quantities "
-"invoicing policy, please make sure that a quantity has been delivered."
-msgstr ""
-"Não há linha faturável. Se um produto tem uma política de faturamento de "
-"quantidade Entregue , por favor certifique-se de que uma quantidade foi "
-"entregue."
+msgid "There is no invoiceable line. If a product has a Delivered quantities invoicing policy, please make sure that a quantity has been delivered."
+msgstr "Não há linha faturável. Se um produto tem uma política de faturamento de quantidade Entregue , por favor certifique-se de que uma quantidade foi entregue."
 
 #. module: sale
 #: model_terms:ir.actions.act_window,help:sale.action_orders_upselling
-msgid ""
-"These are orders with products invoiced based on ordered quantities,\n"
+msgid "These are orders with products invoiced based on ordered quantities,\n"
 "                in the case you have delivered more than what was ordered."
-msgstr ""
-"São pedidos com produtos faturados com base em quantidades ordenadas,\n"
+msgstr "São pedidos com produtos faturados com base em quantidades ordenadas,\n"
 "                no caso de você ter entregue mais do que o que foi ordenado."
 
 #. module: sale
@@ -3819,34 +3582,19 @@ msgstr "Essa combinação não existe."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
-msgid ""
-"This default value is applied to any new product created. This can be "
-"changed in the product detail form."
-msgstr ""
-"Esse valor padrão é aplicado para cada novo produto criado. Isso pode ser "
-"mudado no formulário detalhe do produto."
+msgid "This default value is applied to any new product created. This can be changed in the product detail form."
+msgstr "Esse valor padrão é aplicado para cada novo produto criado. Isso pode ser mudado no formulário detalhe do produto."
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__commitment_date
-msgid ""
-"This is the delivery date promised to the customer. If set, the delivery "
-"order will be scheduled based on this date rather than product lead times."
-msgstr ""
-"Esta é a data de entrega prometida ao cliente. Se definido, o pedido de "
-"entrega será agendado com base nesta data, em vez de prazos de lead time do "
-"produto."
+msgid "This is the delivery date promised to the customer. If set, the delivery order will be scheduled based on this date rather than product lead times."
+msgstr "Esta é a data de entrega prometida ao cliente. Se definido, o pedido de entrega será agendado com base nesta data, em vez de prazos de lead time do produto."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
 #: model:res.groups,comment:sale.group_sale_order_dates
-msgid ""
-"This option introduces extra fields in the sales order to easily schedule "
-"product deliveries on your own: expected date, commitment date, effective "
-"date."
-msgstr ""
-"Esta opção introduz campos extras no pedido de venda para agendar facilmente"
-" as entregas de produtos por conta própria: data esperada, data de "
-"compromisso, data de vigência."
+msgid "This option introduces extra fields in the sales order to easily schedule product deliveries on your own: expected date, commitment date, effective date."
+msgstr "Esta opção introduz campos extras no pedido de venda para agendar facilmente as entregas de produtos por conta própria: data esperada, data de compromisso, data de vigência."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.product_configurator_configure
@@ -3855,51 +3603,18 @@ msgstr "Este produto não tem uma combinação válida."
 
 #. module: sale
 #: model_terms:ir.actions.act_window,help:sale.action_order_report_all
-msgid ""
-"This report performs analysis on your quotations and sales orders. Analysis "
-"check your sales revenues and sort it by different group criteria (salesman,"
-" partner, product, etc.) Use this report to perform analysis on sales not "
-"having invoiced yet. If you want to analyse your turnover, you should use "
-"the Invoice Analysis report in the Accounting application."
-msgstr ""
-"Este relatório analisa seus orçamentos e pedidos de venda. Avalie suas "
-"receitas sobre vendas e ordene com diferentes critérios de grupo (vendedor, "
-"parceiro, produto, etc). Use este relatório para realizar análises em vendas"
-" que não foram faturadas ainda. Se você quiser analisar o volume de "
-"negócios, seria melhor usar o relatório de Análise de Faturamento no módulo "
-"Contas."
+msgid "This report performs analysis on your quotations and sales orders. Analysis check your sales revenues and sort it by different group criteria (salesman, partner, product, etc.) Use this report to perform analysis on sales not having invoiced yet. If you want to analyse your turnover, you should use the Invoice Analysis report in the Accounting application."
+msgstr "Este relatório analisa seus orçamentos e pedidos de venda. Avalie suas receitas sobre vendas e ordene com diferentes critérios de grupo (vendedor, parceiro, produto, etc). Use este relatório para realizar análises em vendas que não foram faturadas ainda. Se você quiser analisar o volume de negócios, seria melhor usar o relatório de Análise de Faturamento no módulo Contas."
 
 #. module: sale
 #: model_terms:ir.actions.act_window,help:sale.action_order_report_quotation_salesteam
-msgid ""
-"This report performs analysis on your quotations. Analysis check your sales "
-"revenues and sort it by different group criteria (salesman, partner, "
-"product, etc.) Use this report to perform analysis on sales not having "
-"invoiced yet. If you want to analyse your turnover, you should use the "
-"Invoice Analysis report in the Accounting application."
-msgstr ""
-"Este relatório realiza a análise de seus orçamentos. A análise verifica suas "
-"receitas de vendas e as classifica por diferentes critérios do grupo "
-"(vendedores, parceiros, produtos, etc) Use esse relatório para realizar uma "
-"análise sobre as vendas que não foram faturadas ainda. Se você quiser "
-"analisar o seu volume de negócios, você deve usar o relatório de análise da "
-"fatura na aplicação de Contabilidade."
+msgid "This report performs analysis on your quotations. Analysis check your sales revenues and sort it by different group criteria (salesman, partner, product, etc.) Use this report to perform analysis on sales not having invoiced yet. If you want to analyse your turnover, you should use the Invoice Analysis report in the Accounting application."
+msgstr "Este relatório realiza a análise de seus orçamentos. A análise verifica suas receitas de vendas e as classifica por diferentes critérios do grupo (vendedores, parceiros, produtos, etc) Use esse relatório para realizar uma análise sobre as vendas que não foram faturadas ainda. Se você quiser analisar o seu volume de negócios, você deve usar o relatório de análise da fatura na aplicação de Contabilidade."
 
 #. module: sale
 #: model_terms:ir.actions.act_window,help:sale.action_order_report_so_salesteam
-msgid ""
-"This report performs analysis on your sales orders. Analysis check your "
-"sales revenues and sort it by different group criteria (salesman, partner, "
-"product, etc.) Use this report to perform analysis on sales not having "
-"invoiced yet. If you want to analyse your turnover, you should use the "
-"Invoice Analysis report in the Accounting application."
-msgstr ""
-"Este relatório realiza a análise de seus pedidos de vendas. A análise "
-"verifica suas receitas de vendas e as classifica por diferentes critérios do"
-" grupo (vendedores, parceiros, produtos, etc) Use esse relatório para "
-"realizar uma análise sobre as vendas que não foram faturadas ainda. Se você "
-"quiser analisar o seu volume de negócios, você deve usar o relatório de "
-"análise da fatura na aplicação de Contabilidade."
+msgid "This report performs analysis on your sales orders. Analysis check your sales revenues and sort it by different group criteria (salesman, partner, product, etc.) Use this report to perform analysis on sales not having invoiced yet. If you want to analyse your turnover, you should use the Invoice Analysis report in the Accounting application."
+msgstr "Este relatório realiza a análise de seus pedidos de vendas. A análise verifica suas receitas de vendas e as classifica por diferentes critérios do grupo (vendedores, parceiros, produtos, etc) Use esse relatório para realizar uma análise sobre as vendas que não foram faturadas ainda. Se você quiser analisar o seu volume de negócios, você deve usar o relatório de análise da fatura na aplicação de Contabilidade."
 
 #. module: sale
 #: selection:sale.order.line,qty_delivered_method:0
@@ -3909,7 +3624,7 @@ msgstr "Planilhas de Horas"
 #. module: sale
 #: selection:product.template,service_type:0
 msgid "Timesheets on project (one fare per SO/Project)"
-msgstr "Planilhas de tempo no projeto (uma tarifa por OS/Projeto)"
+msgstr "Quadros de horários do projeto (uma tarifa por Pedido/Projeto)"
 
 #. module: sale
 #: model:ir.ui.menu,name:sale.menu_sale_invoicing
@@ -3932,14 +3647,8 @@ msgstr "Para Upsell"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
-msgid ""
-"To send invitations in B2B mode, open a contact or select several ones in "
-"list view and click on 'Portal Access Management' option in the dropdown "
-"menu *Action*."
-msgstr ""
-"Para enviar convites em modo B2B, abra um contato ou selecione na listagem e"
-" clique em 'Gerenciamento de Acesso ao Portal' e selecione o menu dropdown "
-"*Ação*."
+msgid "To send invitations in B2B mode, open a contact or select several ones in list view and click on 'Portal Access Management' option in the dropdown menu *Action*."
+msgstr "Para enviar convites em modo B2B, abra um contato ou selecione na listagem e clique em 'Gerenciamento de Acesso ao Portal' e selecione o menu dropdown *Ação*."
 
 #. module: sale
 #: selection:sale.order,activity_state:0
@@ -3954,13 +3663,12 @@ msgstr "Atividades de Hoje"
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_report_all_channels_sales__price_total
 #: model:ir.model.fields,field_description:sale.field_sale_order__amount_total
-#: model:ir.model.fields,field_description:sale.field_sale_order_line__price_total
 #: model:ir.model.fields,field_description:sale.field_sale_report__price_total
 #: model_terms:ir.ui.view,arch_db:sale.portal_my_orders
 #: model_terms:ir.ui.view,arch_db:sale.portal_my_quotations
 #: model_terms:ir.ui.view,arch_db:sale.view_order_line_tree
 msgid "Total"
-msgstr "Total"
+msgstr ""
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.report_all_channels_sales_view_pivot
@@ -3969,15 +3677,10 @@ msgid "Total Price"
 msgstr "Preço Total"
 
 #. module: sale
-#: model:ir.model.fields,field_description:sale.field_sale_order_line__price_tax
-msgid "Total Tax"
-msgstr "Total de Impostos"
-
-#. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_tree
 #: model_terms:ir.ui.view,arch_db:sale.view_quotation_tree
 msgid "Total Tax Included"
-msgstr "Total de Imposto incluído"
+msgstr "Total de Imposto(s) incluído(s)"
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_product_product__service_type
@@ -4001,20 +3704,16 @@ msgid "Type Name"
 msgstr "Título"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery_ups
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery_ups
 msgid "UPS Connector"
 msgstr "Conector UPS"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery_usps
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery_usps
 msgid "USPS Connector"
 msgstr "Conector USPS"
-
-#. module: sale
-#: code:addons/sale/models/sale.py:734
-#, python-format
-msgid "Uncategorized"
-msgstr "Sem categoria"
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_order_line__price_unit
@@ -4039,16 +3738,6 @@ msgstr "Unidade de Medida"
 #: model:ir.ui.menu,name:sale.menu_product_uom_categ_form_action
 msgid "Unit of Measure Categories"
 msgstr "Categorias de Unidade de Medida"
-
-#. module: sale
-#: model:product.product,uom_name:sale.advance_product_0
-#: model:product.product,uom_name:sale.product_product_4e
-#: model:product.product,uom_name:sale.product_product_4f
-#: model:product.template,uom_name:sale.advance_product_0_product_template
-#: model:product.template,uom_name:sale.product_product_1_product_template
-#: model:product.template,uom_name:sale.product_product_4e_product_template
-msgid "Unit(s)"
-msgstr "UN"
 
 #. module: sale
 #: model:ir.ui.menu,name:sale.menu_product_uom_form_action
@@ -4099,14 +3788,10 @@ msgid "Untaxed Total"
 msgstr "Total não tributado"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:402
+#: code:addons/sale/models/sale.py:456
 #, python-format
-msgid ""
-"Upsell <a href='#' data-oe-model='%s' data-oe-id='%d'>%s</a> for customer <a"
-" href='#' data-oe-model='%s' data-oe-id='%s'>%s</a>"
-msgstr ""
-"Upsell <a href='#' data-oe-model='%s' data-oe-id='%d'>%s</a> para o cliente <a"
-" href='#' data-oe-model='%s' data-oe-id='%s'>%s</a>"
+msgid "Upsell <a href='#' data-oe-model='%s' data-oe-id='%d'>%s</a> for customer <a href='#' data-oe-model='%s' data-oe-id='%s'>%s</a>"
+msgstr "Upsell <a href='#' data-oe-model='%s' data-oe-id='%d'>%s</a> para o cliente <a href='#' data-oe-model='%s' data-oe-id='%s'>%s</a>"
 
 #. module: sale
 #: selection:sale.order,invoice_status:0
@@ -4150,12 +3835,8 @@ msgstr "Validade"
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__validity_date
-msgid ""
-"Validity date of the quotation, after this date, the customer won't be able "
-"to validate the quotation online."
-msgstr ""
-"Data válida do orçamento, após essa data, o cliente não será capaz de validar "
-"o orçamento online."
+msgid "Validity date of the quotation, after this date, the customer won't be able to validate the quotation online."
+msgstr "Data válida do orçamento, após essa data, o cliente não será capaz de validar o orçamento online."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
@@ -4165,7 +3846,12 @@ msgstr "Transação nula"
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_report__volume
 msgid "Volume"
-msgstr "Volume"
+msgstr ""
+
+#. module: sale
+#: selection:sale.order,state:0
+msgid "Waiting Approval"
+msgstr "Esperando Aprovação"
 
 #. module: sale
 #: selection:product.template,sale_line_warn:0
@@ -4174,7 +3860,7 @@ msgid "Warning"
 msgstr "Aviso"
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1417
+#: code:addons/sale/models/sale.py:1569
 #, python-format
 msgid "Warning for %s"
 msgstr "Aviso para %s"
@@ -4214,84 +3900,59 @@ msgstr "Transferência Eletrônica"
 #. openerp-web
 #: code:addons/sale/static/src/js/tour.js:29
 #, python-format
-msgid ""
-"Write the name of your customer to create one on the fly, or select an "
-"existing one."
-msgstr ""
-"Escreva o nome de seu cliente para criar um em tempo de trabalho, ou "
-"selecionar um existente."
+msgid "Write the name of your customer to create one on the fly, or select an existing one."
+msgstr "Escreva o nome de seu cliente para criar um em tempo de trabalho, ou selecionar um existente."
 
 #. module: sale
 #. openerp-web
-#: code:addons/sale/static/src/js/sale.js:32
+#: code:addons/sale/static/src/js/sale.js:49
 #, python-format
 msgid "Wrong value entered!"
-msgstr "Valor errado digitado!"
+msgstr "Valor digitado errado!"
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__partner_id
 #: model:ir.model.fields,help:sale.field_sale_order_line__order_partner_id
 msgid "You can find a customer by its Name, TIN, Email or Internal Reference."
-msgstr ""
-"Você pode encontrar um cliente pelo nome, TIN, E-mail ou Referência Interna."
+msgstr "Você pode encontrar um cliente pelo nome, TIN, E-mail ou Referência Interna."
 
 #. module: sale
-#: code:addons/sale/models/sale.py:268
+#: code:addons/sale/models/sale.py:317
 #, python-format
-msgid ""
-"You can not delete a sent quotation or a confirmed sales order. You must "
-"first cancel it."
-msgstr ""
-"Você não pode deletar um orçamento enviada ou um pedido de venda confirmado. "
-"Você deve primeiro cancelar a mesma."
+msgid "You can not delete a sent quotation or a confirmed sales order. You must first cancel it."
+msgstr "Você não pode deletar um orçamento enviada ou um pedido de venda confirmado. Você deve primeiro cancelar a mesma."
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1491
+#: code:addons/sale/models/sale.py:1620
 #, python-format
-msgid ""
-"You can not remove an order line once the sales order is confirmed.\n"
+msgid "You can not remove an order line once the sales order is confirmed.\n"
 "You should rather set the quantity to 0."
-msgstr ""
-"Você não pode remover uma linha uma vez que um pedido de venda seja confirmada\n"
+msgstr "Você não pode remover uma linha uma vez que um pedido de venda seja confirmada\n"
 "Você pode porém, mudar a quantidade para 0."
 
 #. module: sale
 #: model_terms:ir.actions.act_window,help:sale.action_orders_to_invoice
-msgid ""
-"You can select all orders and invoice them in batch,<br>\n"
+msgid "You can select all orders and invoice them in batch,<br>\n"
 "                or check every order and invoice them one by one."
-msgstr ""
-"Você pode selecionar todos os pedidos e faturar em pacote,<br>\n"
+msgstr "Você pode selecionar todos os pedidos e faturar em pacote,<br>\n"
 "                ou conferir cada pedido e faturá-los de um por um."
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_payment_acquirer__so_reference_type
-msgid ""
-"You can set here the communication type that will appear on sales orders.The"
-" communication will be given to the customer when they choose the payment "
-"method."
-msgstr ""
-"Você pode definir aqui o tipo de comunicação que aparecerá em pedidos de "
-"venda. A comunicação será dada ao cliente quando escolher o método de "
-"pagamento."
+msgid "You can set here the communication type that will appear on sales orders.The communication will be given to the customer when they choose the payment method."
+msgstr "Você pode definir aqui o tipo de comunicação que aparecerá em pedidos de venda. A comunicação será dada ao cliente quando escolher o método de pagamento."
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1115
+#: code:addons/sale/models/sale.py:1154
 #, python-format
-msgid ""
-"You cannot change the type of a sale order line. Instead you should delete "
-"the current line and create a new line of the proper type."
-msgstr ""
-"Você não pode mudar o tipo de linha do pedido de venda. Em vez disso, você "
-"deve excluir a linha atual e criar uma nova linha do tipo adequado."
+msgid "You cannot change the type of a sale order line. Instead you should delete the current line and create a new line of the proper type."
+msgstr "Você não pode mudar o tipo de linha do pedido de venda. Em vez disso, você deve excluir a linha atual e criar uma nova linha do tipo adequado."
 
 #. module: sale
 #: model_terms:ir.actions.act_window,help:sale.product_template_action
-msgid ""
-"You must define a product for everything you purchase,\n"
+msgid "You must define a product for everything you purchase,\n"
 "                    whether it's a physical product, a consumable or services."
-msgstr ""
-"Você deve definir um produto para tudo que você compra,\n"
+msgstr "Você deve definir um produto para tudo que você compra,\n"
 "                    seja um produto físico, um consumível ou serviços."
 
 #. module: sale
@@ -4307,8 +3968,7 @@ msgstr "Seu pedido foi confirmado."
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
 msgid "Your order has been signed but still needs to be paid to be confirmed."
-msgstr ""
-"Seu pedido foi assinado, mas ainda precisa ser pago para ser confirmado."
+msgstr "Seu pedido foi assinado, mas ainda precisa ser pago para ser confirmado."
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
@@ -4321,6 +3981,7 @@ msgid "Your order is not in a state to be rejected."
 msgstr "Seu pedido não está em situação para ser rejeitado."
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery_bpost
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery_bpost
 msgid "bpost Connector"
 msgstr "Conector bpost"
@@ -4343,22 +4004,17 @@ msgid "days"
 msgstr "dias"
 
 #. module: sale
-#: model:product.product,weight_uom_name:sale.advance_product_0
-#: model:product.product,weight_uom_name:sale.product_product_4e
-#: model:product.product,weight_uom_name:sale.product_product_4f
-#: model:product.template,weight_uom_name:sale.advance_product_0_product_template
-#: model:product.template,weight_uom_name:sale.product_product_1_product_template
-#: model:product.template,weight_uom_name:sale.product_product_4e_product_template
-msgid "kg"
-msgstr "kg"
-
-#. module: sale
-#: code:addons/sale/models/sale.py:106
+#: code:addons/sale/models/sale.py:115
 #, python-format
 msgid "sale order"
 msgstr "pedido de venda"
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_sale_order__activity_team_user_ids
+msgid "test field"
+msgstr "campo de teste"
+
+#. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__amount_by_group
 msgid "type: [(name, amount, base, formated amount, formated base)]"
-msgstr "type: [(name, amount, base, formated amount, formated base)]"
+msgstr "tipo: [(nome, valor, base, valor formatado, base formatada)]"

--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-14 07:34+0000\n"
-"PO-Revision-Date: 2019-11-14 07:34+0000\n"
+"POT-Creation-Date: 2023-04-11 17:03+0000\n"
+"PO-Revision-Date: 2023-04-11 17:03+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -55,13 +55,6 @@ msgstr ""
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
 msgid "&amp;times;"
-msgstr ""
-
-#. module: sale
-#: model:product.product,description_sale:sale.product_product_4e
-#: model:product.product,description_sale:sale.product_product_4f
-#: model:product.template,description_sale:sale.product_product_4e_product_template
-msgid "160x80cm, with large legs."
 msgstr ""
 
 #. module: sale
@@ -380,30 +373,31 @@ msgid "<strong>Your Reference:</strong>"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:811
+#: code:addons/sale/models/sale.py:897
 #, python-format
 msgid "A journal must be specified of the acquirer %s."
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:804
+#: code:addons/sale/models/sale.py:890
 #, python-format
 msgid "A payment acquirer is required to create a transaction."
 msgstr ""
 
 #. module: sale
+#: selection:contact.config.settings,sale_pricelist_setting:0
 #: selection:res.config.settings,sale_pricelist_setting:0
 msgid "A single sales price per product"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:775
+#: code:addons/sale/models/sale.py:861
 #, python-format
 msgid "A transaction can't be linked to sales orders having different currencies."
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:780
+#: code:addons/sale/models/sale.py:866
 #, python-format
 msgid "A transaction can't be linked to sales orders having different partners."
 msgstr ""
@@ -476,6 +470,11 @@ msgid "Activity State"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_sale_order__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: sale
 #: model:ir.actions.act_window,name:sale.mail_activity_type_action_config_sale
 #: model:ir.ui.menu,name:sale.sale_menu_config_activity_type
 msgid "Activity Types"
@@ -518,7 +517,7 @@ msgid "Addresses in Sales Orders"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/wizard/sale_make_invoice_advance.py:165
+#: code:addons/sale/wizard/sale_make_invoice_advance.py:166
 #, python-format
 msgid "Advance: %s"
 msgstr ""
@@ -535,6 +534,7 @@ msgid "Allows you to send Pro-Forma Invoice to your customers"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,help:sale.field_contact_config_settings__group_proforma_sales
 #: model:ir.model.fields,help:sale.field_res_config_settings__group_proforma_sales
 msgid "Allows you to send pro-forma invoice."
 msgstr ""
@@ -633,6 +633,7 @@ msgid "Authorized Transactions"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__automatic_invoice
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__automatic_invoice
 msgid "Automatic Invoice"
 msgstr ""
@@ -644,7 +645,7 @@ msgstr ""
 
 #. module: sale
 #. openerp-web
-#: code:addons/sale/static/src/js/product_configurator_controller.js:124
+#: code:addons/sale/static/src/js/product_configurator_controller.js:130
 #, python-format
 msgid "Back"
 msgstr ""
@@ -655,22 +656,22 @@ msgid "Bank Name"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/payment.py:14
+#: code:addons/sale/models/payment.py:19
 #: selection:payment.acquirer,so_reference_type:0
 #, python-format
 msgid "Based on Customer ID"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/payment.py:13
+#: code:addons/sale/models/payment.py:18
 #: selection:payment.acquirer,so_reference_type:0
 #, python-format
 msgid "Based on Document Reference"
 msgstr ""
 
 #. module: sale
-#: model:product.template.attribute.value,name:sale.product_template_attribute_value_5
-msgid "Black"
+#: selection:sale.order,state:0
+msgid "Blocked"
 msgstr ""
 
 #. module: sale
@@ -706,11 +707,6 @@ msgstr ""
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 msgid "Capture Transaction"
-msgstr ""
-
-#. module: sale
-#: model:product.template,name:sale.product_product_1_product_template
-msgid "Chair floor protection"
 msgstr ""
 
 #. module: sale
@@ -827,7 +823,7 @@ msgstr ""
 
 #. module: sale
 #. openerp-web
-#: code:addons/sale/static/src/js/product_configurator_controller.js:125
+#: code:addons/sale/static/src/js/product_configurator_controller.js:131
 #, python-format
 msgid "Configure"
 msgstr ""
@@ -849,7 +845,7 @@ msgstr ""
 
 #. module: sale
 #. openerp-web
-#: code:addons/sale/static/src/js/product_configurator_controller.js:123
+#: code:addons/sale/static/src/js/product_configurator_controller.js:129
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 #, python-format
 msgid "Confirm"
@@ -869,7 +865,6 @@ msgid "Confirmation Date"
 msgstr ""
 
 #. module: sale
-#: model:ir.model,name:sale.model_res_partner
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
 msgid "Contact"
 msgstr ""
@@ -880,6 +875,7 @@ msgid "Content"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_sale_coupon
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_sale_coupon
 msgid "Coupons & Promotions"
 msgstr ""
@@ -945,11 +941,6 @@ msgid "Currency Rate"
 msgstr ""
 
 #. module: sale
-#: model:product.attribute.value,name:sale.product_attribute_value_7
-msgid "Custom"
-msgstr ""
-
-#. module: sale
 #: selection:sale.payment.acquirer.onboarding.wizard,payment_method:0
 msgid "Custom payment instructions"
 msgstr ""
@@ -969,11 +960,13 @@ msgid "Customer"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__auth_signup_uninvited
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__auth_signup_uninvited
 msgid "Customer Account"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__group_sale_delivery_address
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__group_sale_delivery_address
 msgid "Customer Addresses"
 msgstr ""
@@ -1010,13 +1003,6 @@ msgid "Customers"
 msgstr ""
 
 #. module: sale
-#: model:product.product,name:sale.product_product_4e
-#: model:product.product,name:sale.product_product_4f
-#: model:product.template,name:sale.product_product_4e_product_template
-msgid "Customizable Desk"
-msgstr ""
-
-#. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.onboarding_quotation_layout_step
 msgid "Customize"
 msgstr ""
@@ -1027,6 +1013,7 @@ msgid "Customize the look of your quotations."
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery_dhl
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery_dhl
 msgid "DHL Connector"
 msgstr ""
@@ -1063,17 +1050,20 @@ msgid "Default Limit:"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__use_quotation_validity_days
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__use_quotation_validity_days
 msgid "Default Quotation Validity"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__quotation_validity_days
 #: model:ir.model.fields,field_description:sale.field_res_company__quotation_validity_days
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__quotation_validity_days
 msgid "Default Quotation Validity (Days)"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__use_sale_note
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__use_sale_note
 msgid "Default Terms & Conditions"
 msgstr ""
@@ -1084,6 +1074,7 @@ msgid "Default Terms and Conditions"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,help:sale.field_contact_config_settings__deposit_default_product_id
 #: model:ir.model.fields,help:sale.field_res_config_settings__deposit_default_product_id
 msgid "Default product used for payment advances"
 msgstr ""
@@ -1099,7 +1090,7 @@ msgid "Delivered Manually"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1060
+#: code:addons/sale/models/sale.py:1146
 #: model:ir.model.fields,field_description:sale.field_sale_order_line__qty_delivered
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 #, python-format
@@ -1118,6 +1109,7 @@ msgid "Delivery Address"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__group_sale_order_dates
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__group_sale_order_dates
 msgid "Delivery Date"
 msgstr ""
@@ -1143,12 +1135,7 @@ msgid "Delivery date you can promise to the customer, computed from product lead
 msgstr ""
 
 #. module: sale
-#: model:product.product,name:sale.advance_product_0
-#: model:product.template,name:sale.advance_product_0_product_template
-msgid "Deposit"
-msgstr ""
-
-#. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__deposit_default_product_id
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__deposit_default_product_id
 msgid "Deposit Product"
 msgstr ""
@@ -1166,6 +1153,7 @@ msgid "Details"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_website_sale_digital
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_website_sale_digital
 msgid "Digital Content"
 msgstr ""
@@ -1201,6 +1189,7 @@ msgid "Discount on lines"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__group_discount_per_so_line
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__group_discount_per_so_line
 msgid "Discounts"
 msgstr ""
@@ -1278,11 +1267,13 @@ msgid "Draft Quotation"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery_easypost
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery_easypost
 msgid "Easypost Connector"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__template_id
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__template_id
 msgid "Email Template"
 msgstr ""
@@ -1304,12 +1295,13 @@ msgid "Extended Filters"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1034
+#: code:addons/sale/models/sale.py:1120
 #, python-format
 msgid "Extra line with %s "
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery_fedex
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery_fedex
 msgid "FedEx Connector"
 msgstr ""
@@ -1332,6 +1324,11 @@ msgstr ""
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_order__message_partner_ids
 msgid "Followers (Partners)"
+msgstr ""
+
+#. module: sale
+#: model:ir.model.fields,help:sale.field_sale_order__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
 msgstr ""
 
 #. module: sale
@@ -1442,7 +1439,7 @@ msgid "If the sale is locked, you can not modify it anymore. However, you will s
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:280
+#: code:addons/sale/controllers/portal.py:284
 #, python-format
 msgid "If we store your payment information on our server, subscription payments will be made automatically."
 msgstr ""
@@ -1453,13 +1450,13 @@ msgid "Image of the product variant (Big-sized image of product template if fals
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/product_template.py:89
+#: code:addons/sale/models/product_template.py:173
 #, python-format
 msgid "Import Template for Products"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/product_template.py:92
+#: code:addons/sale/models/product_template.py:176
 #, python-format
 msgid "Import Template for Products (with several prices)"
 msgstr ""
@@ -1480,19 +1477,19 @@ msgid "Insert your terms & conditions here..."
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:198
+#: code:addons/sale/controllers/portal.py:202
 #, python-format
 msgid "Invalid order"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:794
+#: code:addons/sale/models/sale.py:880
 #, python-format
 msgid "Invalid token found! Token acquirer %s != %s"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:797
+#: code:addons/sale/models/sale.py:883
 #, python-format
 msgid "Invalid token found! Token partner %s != %s"
 msgstr ""
@@ -1503,7 +1500,7 @@ msgid "Invoice"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/account_invoice.py:62
+#: code:addons/sale/models/account_invoice.py:80
 #, python-format
 msgid "Invoice %s paid"
 msgstr ""
@@ -1565,11 +1562,13 @@ msgid "Invoice revenue for the current month. This is the amount the sales chann
 msgstr ""
 
 #. module: sale
+#: selection:contact.config.settings,default_invoice_policy:0
 #: selection:res.config.settings,default_invoice_policy:0
 msgid "Invoice what is delivered"
 msgstr ""
 
 #. module: sale
+#: selection:contact.config.settings,default_invoice_policy:0
 #: selection:res.config.settings,default_invoice_policy:0
 msgid "Invoice what is ordered"
 msgstr ""
@@ -1585,12 +1584,7 @@ msgid "Invoiceable lines (deduct down payments)"
 msgstr ""
 
 #. module: sale
-#: selection:sale.report,state:0
-msgid "Invoiced"
-msgstr ""
-
-#. module: sale
-#: code:addons/sale/models/sale.py:1061
+#: code:addons/sale/models/sale.py:1147
 #: model:ir.model.fields,field_description:sale.field_sale_order_line__qty_invoiced
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 #, python-format
@@ -1628,7 +1622,7 @@ msgid "Invoices will be created in draft so that you can review\n"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sales_team.py:96
+#: code:addons/sale/models/sales_team.py:111
 #, python-format
 msgid "Invoices: Untaxed Total"
 msgstr ""
@@ -1647,6 +1641,7 @@ msgid "Invoicing Address"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__default_invoice_policy
 #: model:ir.model.fields,field_description:sale.field_product_product__invoice_policy
 #: model:ir.model.fields,field_description:sale.field_product_template__invoice_policy
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__default_invoice_policy
@@ -1705,14 +1700,14 @@ msgid "Is true if the sales order line comes from an expense or a vendor bills"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1083
+#: code:addons/sale/models/sale.py:1169
 #, python-format
 msgid "It is forbidden to modify the following fields in a locked order:\n"
 "%s"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:667
+#: code:addons/sale/models/sale.py:768
 #, python-format
 msgid "It is not allowed to confirm an order in the following states: %s"
 msgstr ""
@@ -1785,6 +1780,7 @@ msgid "Lock"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__auto_done_setting
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__auto_done_setting
 msgid "Lock Confirmed Sales"
 msgstr ""
@@ -1838,6 +1834,7 @@ msgid "Manually set quantities on order: Invoice based on the manually entered q
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_sale_margin
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_sale_margin
 msgid "Margins"
 msgstr ""
@@ -1880,11 +1877,14 @@ msgid "Missing required fields on accountable sale order line."
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__multi_sales_price
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__multi_sales_price
 msgid "Multiple Sales Prices per Product"
 msgstr ""
 
 #. module: sale
+#: selection:contact.config.settings,multi_sales_price_method:0
+#: selection:contact.config.settings,sale_pricelist_setting:0
 #: selection:res.config.settings,multi_sales_price_method:0
 #: selection:res.config.settings,sale_pricelist_setting:0
 msgid "Multiple prices per product (e.g. customer segments, currencies)"
@@ -1916,11 +1916,10 @@ msgid "Name of the person that signed the SO."
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:131
-#: code:addons/sale/models/sale.py:367
-#: code:addons/sale/models/sale.py:369
-#: code:addons/sale/models/sale.py:371
-#: selection:sale.report,state:0
+#: code:addons/sale/models/sale.py:173
+#: code:addons/sale/models/sale.py:419
+#: code:addons/sale/models/sale.py:421
+#: code:addons/sale/models/sale.py:423
 #, python-format
 msgid "New"
 msgstr ""
@@ -1928,6 +1927,11 @@ msgstr ""
 #. module: sale
 #: model:ir.actions.act_window,name:sale.action_quotation_form
 msgid "New Quotation"
+msgstr ""
+
+#. module: sale
+#: model_terms:ir.ui.view,arch_db:sale.view_quotation_tree
+msgid "Next Activity"
 msgstr ""
 
 #. module: sale
@@ -2031,11 +2035,6 @@ msgid "Number of unread messages"
 msgstr ""
 
 #. module: sale
-#: model:product.template,description_sale:sale.product_product_1_product_template
-msgid "Office chairs can harm your floor: protect it."
-msgstr ""
-
-#. module: sale
 #: model_terms:ir.actions.act_window,help:sale.act_res_partner_2_sale_order
 #: model_terms:ir.actions.act_window,help:sale.action_orders_salesteams
 #: model_terms:ir.actions.act_window,help:sale.action_quotations
@@ -2051,12 +2050,13 @@ msgstr ""
 
 #. module: sale
 #. openerp-web
-#: code:addons/sale/static/src/js/tour.js:65
+#: code:addons/sale/static/src/js/tour.js:64
 #, python-format
 msgid "Once your quotation is ready, you can save, print or send it by email."
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__portal_confirmation_pay
 #: model:ir.model.fields,field_description:sale.field_res_company__portal_confirmation_pay
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__portal_confirmation_pay
 #: model:ir.model.fields,field_description:sale.field_sale_order__require_payment
@@ -2064,6 +2064,7 @@ msgid "Online Payment"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__portal_confirmation_sign
 #: model:ir.model.fields,field_description:sale.field_res_company__portal_confirmation_sign
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__portal_confirmation_sign
 #: model:ir.model.fields,field_description:sale.field_sale_order__require_signature
@@ -2116,8 +2117,8 @@ msgid "Order Count"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:51
-#: code:addons/sale/controllers/portal.py:103
+#: code:addons/sale/controllers/portal.py:52
+#: code:addons/sale/controllers/portal.py:104
 #: model:ir.model.fields,field_description:sale.field_sale_order__date_order
 #: model:ir.model.fields,field_description:sale.field_sale_report__date
 #: model_terms:ir.ui.view,arch_db:sale.portal_my_orders
@@ -2160,13 +2161,13 @@ msgid "Order Upsell"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:201
+#: code:addons/sale/controllers/portal.py:205
 #, python-format
 msgid "Order is not in a state requiring customer signature."
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:215
+#: code:addons/sale/controllers/portal.py:219
 #, python-format
 msgid "Order signed by %s"
 msgstr ""
@@ -2182,7 +2183,7 @@ msgid "Ordered Qty"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1057
+#: code:addons/sale/models/sale.py:1143
 #: model:ir.model.fields,field_description:sale.field_sale_order_line__product_uom_qty
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 #, python-format
@@ -2244,11 +2245,7 @@ msgid "PRO-FORMA Invoice"
 msgstr ""
 
 #. module: sale
-#: selection:sale.report,state:0
-msgid "Paid"
-msgstr ""
-
-#. module: sale
+#: model:ir.model,name:sale.model_res_partner
 #: model:ir.model.fields,field_description:sale.field_report_all_channels_sales__partner_id
 msgid "Partner"
 msgstr ""
@@ -2259,7 +2256,7 @@ msgid "Partner Country"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:277
+#: code:addons/sale/controllers/portal.py:281
 #, python-format
 msgid "Pay & Confirm"
 msgstr ""
@@ -2270,7 +2267,7 @@ msgid "Pay &amp; Confirm"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/payment.py:160
+#: code:addons/sale/models/payment.py:179
 #, python-format
 msgid "Pay Now"
 msgstr ""
@@ -2372,13 +2369,13 @@ msgid "Planned"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:450
+#: code:addons/sale/models/sale.py:508
 #, python-format
 msgid "Please define an accounting sales journal for this company."
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1318
+#: code:addons/sale/models/sale.py:1423
 #, python-format
 msgid "Please define income account for this product: \"%s\" (id:%d) - or for its category: \"%s\"."
 msgstr ""
@@ -2386,11 +2383,6 @@ msgstr ""
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_sale_order__access_url
 msgid "Portal Access URL"
-msgstr ""
-
-#. module: sale
-#: selection:sale.report,state:0
-msgid "Posted"
 msgstr ""
 
 #. module: sale
@@ -2424,6 +2416,7 @@ msgid "Price Subtotal"
 msgstr ""
 
 #. module: sale
+#: selection:contact.config.settings,sale_pricelist_setting:0
 #: selection:res.config.settings,sale_pricelist_setting:0
 msgid "Price computed from formulas (discounts, margins, roundings)"
 msgstr ""
@@ -2443,6 +2436,7 @@ msgid "Pricelist for current sales order."
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__sale_pricelist_setting
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__sale_pricelist_setting
 #: model:ir.ui.menu,name:sale.menu_product_pricelist_main
 #: model_terms:ir.ui.view,arch_db:sale.res_config_settings_view_form
@@ -2450,11 +2444,13 @@ msgid "Pricelists"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__multi_sales_price_method
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__multi_sales_price_method
 msgid "Pricelists Method"
 msgstr ""
 
 #. module: sale
+#: selection:contact.config.settings,multi_sales_price_method:0
 #: selection:res.config.settings,multi_sales_price_method:0
 msgid "Prices computed from formulas (discounts, margins, roundings)"
 msgstr ""
@@ -2471,6 +2467,7 @@ msgid "Print"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__group_proforma_sales
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__group_proforma_sales
 msgid "Pro-Forma Invoice"
 msgstr ""
@@ -2617,7 +2614,7 @@ msgid "Quantity:"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:262
+#: code:addons/sale/models/sale.py:311
 #: model_terms:ir.ui.view,arch_db:sale.crm_team_salesteams_view_kanban
 #: model_terms:ir.ui.view,arch_db:sale.view_quotation_tree
 #: selection:sale.order,state:0
@@ -2675,13 +2672,13 @@ msgid "Quotation sent"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:159
+#: code:addons/sale/controllers/portal.py:163
 #, python-format
 msgid "Quotation viewed by customer"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sales_team.py:101
+#: code:addons/sale/models/sales_team.py:116
 #: model:ir.actions.act_window,name:sale.action_quotations
 #: model:ir.actions.act_window,name:sale.action_quotations_salesteams
 #: model:ir.actions.act_window,name:sale.action_quotations_with_onboarding
@@ -2724,8 +2721,8 @@ msgid "Re-Invoice Policy"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:52
-#: code:addons/sale/controllers/portal.py:104
+#: code:addons/sale/controllers/portal.py:53
+#: code:addons/sale/controllers/portal.py:105
 #, python-format
 msgid "Reference"
 msgstr ""
@@ -2778,7 +2775,7 @@ msgid "Request an online signature to confirm orders"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:359
+#: code:addons/sale/models/sale.py:411
 #, python-format
 msgid "Requested date is too soon."
 msgstr ""
@@ -2800,6 +2797,7 @@ msgid "Sale Order Count"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__group_warning_sale
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__group_warning_sale
 msgid "Sale Order Warnings"
 msgstr ""
@@ -2874,9 +2872,8 @@ msgid "Sales Information"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:271
+#: code:addons/sale/models/sale.py:311
 #: model:ir.model.fields,field_description:sale.field_res_partner__sale_order_ids
-#: model:ir.model.fields,field_description:sale.field_res_users__sale_order_ids
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 #: model_terms:ir.ui.view,arch_db:sale.view_sales_order_filter
 #: selection:sale.order,state:0
@@ -2922,14 +2919,14 @@ msgid "Sales Order Lines related to a Sales Order of mine"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/payment.py:133
+#: code:addons/sale/models/payment.py:152
 #: model_terms:ir.ui.view,arch_db:sale.transaction_form_inherit_sale
 #, python-format
 msgid "Sales Order(s)"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sales_team.py:102
+#: code:addons/sale/models/sales_team.py:117
 #: model:ir.actions.act_window,name:sale.action_orders
 #: model:ir.actions.act_window,name:sale.action_orders_salesteams
 #: model:ir.actions.act_window,name:sale.action_orders_to_invoice_salesteams
@@ -2997,7 +2994,7 @@ msgid "Sales price"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sales_team.py:94
+#: code:addons/sale/models/sales_team.py:109
 #, python-format
 msgid "Sales: Untaxed Total"
 msgstr ""
@@ -3133,7 +3130,7 @@ msgstr ""
 
 #. module: sale
 #. openerp-web
-#: code:addons/sale/static/src/js/sale.js:25
+#: code:addons/sale/static/src/js/sale.js:26
 #, python-format
 msgid "Set an invoicing target: "
 msgstr ""
@@ -3175,6 +3172,7 @@ msgid "Shipping"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery
 msgid "Shipping Costs"
 msgstr ""
@@ -3222,7 +3220,7 @@ msgid "Signature"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:203
+#: code:addons/sale/controllers/portal.py:207
 #, python-format
 msgid "Signature is missing."
 msgstr ""
@@ -3255,13 +3253,14 @@ msgid "Source Document"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_product_email_template
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_product_email_template
 msgid "Specific Email"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/controllers/portal.py:53
-#: code:addons/sale/controllers/portal.py:105
+#: code:addons/sale/controllers/portal.py:54
+#: code:addons/sale/controllers/portal.py:106
 #, python-format
 msgid "Stage"
 msgstr ""
@@ -3294,12 +3293,6 @@ msgid "Status based on activities\n"
 "Overdue: Due date is already passed\n"
 "Today: Activity date is today\n"
 "Planned: Future activities."
-msgstr ""
-
-#. module: sale
-#: model:product.template.attribute.value,name:sale.product_template_attribute_value_3
-#: model:product.template.attribute.value,name:sale.product_template_attribute_value_4
-msgid "Steel"
 msgstr ""
 
 #. module: sale
@@ -3361,6 +3354,7 @@ msgid "Tell us why you are refusing this quotation, this will help us improve ou
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__sale_note
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__sale_note
 msgid "Terms & Conditions"
 msgstr ""
@@ -3381,19 +3375,19 @@ msgid "Terms and conditions... (note: you can setup default ones in the Configur
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/analytic.py:116
+#: code:addons/sale/models/analytic.py:117
 #, python-format
 msgid "The Sales Order %s linked to the Analytic Account %s is cancelled. You cannot register an expense on a cancelled Sales Order."
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/analytic.py:115
+#: code:addons/sale/models/analytic.py:116
 #, python-format
 msgid "The Sales Order %s linked to the Analytic Account %s is currently locked. You cannot register an expense on a locked Sales Order. Please create a new SO linked to this Analytic Account."
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/analytic.py:111
+#: code:addons/sale/models/analytic.py:112
 #, python-format
 msgid "The Sales Order %s linked to the Analytic Account %s must be validated before registering expenses."
 msgstr ""
@@ -3409,7 +3403,7 @@ msgid "The analytic account related to a sales order."
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:360
+#: code:addons/sale/models/sale.py:412
 #, python-format
 msgid "The commitment date is sooner than the expected date.You may be unable to honor the commitment date."
 msgstr ""
@@ -3421,6 +3415,7 @@ msgid "The graph this channel will display in the Dashboard.\n"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,help:sale.field_contact_config_settings__automatic_invoice
 #: model:ir.model.fields,help:sale.field_res_config_settings__automatic_invoice
 msgid "The invoice is generated automatically and available in the customer portal when the transaction is confirmed by the payment acquirer.\n"
 "The invoice is marked as paid and the payment is registered in the payment journal defined in the configuration of the payment acquirer.\n"
@@ -3433,7 +3428,7 @@ msgid "The margin is computed as the sum of product sales prices minus the cost 
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/payment.py:97
+#: code:addons/sale/models/payment.py:91
 #, python-format
 msgid "The order was not confirmed despite response from the acquirer (%s): order total is %r but acquirer replied with %r."
 msgstr ""
@@ -3444,13 +3439,13 @@ msgid "The payment communication of this sale order."
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/wizard/sale_make_invoice_advance.py:154
+#: code:addons/sale/wizard/sale_make_invoice_advance.py:155
 #, python-format
 msgid "The product used to invoice a down payment should be of type 'Service'. Please use another product or update this product."
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/wizard/sale_make_invoice_advance.py:152
+#: code:addons/sale/wizard/sale_make_invoice_advance.py:153
 #, python-format
 msgid "The product used to invoice a down payment should have an invoice policy set to \"Ordered quantities\". Please update your deposit product to be able to create a deposit invoice."
 msgstr ""
@@ -3488,8 +3483,8 @@ msgid "There is no income account defined for this product: \"%s\". You may have
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:549
-#: code:addons/sale/models/sale.py:553
+#: code:addons/sale/models/sale.py:560
+#: code:addons/sale/models/sale.py:657
 #, python-format
 msgid "There is no invoiceable line. If a product has a Delivered quantities invoicing policy, please make sure that a quantity has been delivered."
 msgstr ""
@@ -3588,7 +3583,6 @@ msgstr ""
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_report_all_channels_sales__price_total
 #: model:ir.model.fields,field_description:sale.field_sale_order__amount_total
-#: model:ir.model.fields,field_description:sale.field_sale_order_line__price_total
 #: model:ir.model.fields,field_description:sale.field_sale_report__price_total
 #: model_terms:ir.ui.view,arch_db:sale.portal_my_orders
 #: model_terms:ir.ui.view,arch_db:sale.portal_my_quotations
@@ -3600,11 +3594,6 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:sale.report_all_channels_sales_view_pivot
 #: model_terms:ir.ui.view,arch_db:sale.report_saleorder_document
 msgid "Total Price"
-msgstr ""
-
-#. module: sale
-#: model:ir.model.fields,field_description:sale.field_sale_order_line__price_tax
-msgid "Total Tax"
 msgstr ""
 
 #. module: sale
@@ -3635,19 +3624,15 @@ msgid "Type Name"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery_ups
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery_ups
 msgid "UPS Connector"
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery_usps
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery_usps
 msgid "USPS Connector"
-msgstr ""
-
-#. module: sale
-#: code:addons/sale/models/sale.py:734
-#, python-format
-msgid "Uncategorized"
 msgstr ""
 
 #. module: sale
@@ -3672,16 +3657,6 @@ msgstr ""
 #. module: sale
 #: model:ir.ui.menu,name:sale.menu_product_uom_categ_form_action
 msgid "Unit of Measure Categories"
-msgstr ""
-
-#. module: sale
-#: model:product.product,uom_name:sale.advance_product_0
-#: model:product.product,uom_name:sale.product_product_4e
-#: model:product.product,uom_name:sale.product_product_4f
-#: model:product.template,uom_name:sale.advance_product_0_product_template
-#: model:product.template,uom_name:sale.product_product_1_product_template
-#: model:product.template,uom_name:sale.product_product_4e_product_template
-msgid "Unit(s)"
 msgstr ""
 
 #. module: sale
@@ -3733,7 +3708,7 @@ msgid "Untaxed Total"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:402
+#: code:addons/sale/models/sale.py:456
 #, python-format
 msgid "Upsell <a href='#' data-oe-model='%s' data-oe-id='%d'>%s</a> for customer <a href='#' data-oe-model='%s' data-oe-id='%s'>%s</a>"
 msgstr ""
@@ -3800,7 +3775,7 @@ msgid "Warning"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1417
+#: code:addons/sale/models/sale.py:1569
 #, python-format
 msgid "Warning for %s"
 msgstr ""
@@ -3845,7 +3820,7 @@ msgstr ""
 
 #. module: sale
 #. openerp-web
-#: code:addons/sale/static/src/js/sale.js:32
+#: code:addons/sale/static/src/js/sale.js:49
 #, python-format
 msgid "Wrong value entered!"
 msgstr ""
@@ -3857,13 +3832,13 @@ msgid "You can find a customer by its Name, TIN, Email or Internal Reference."
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:268
+#: code:addons/sale/models/sale.py:317
 #, python-format
 msgid "You can not delete a sent quotation or a confirmed sales order. You must first cancel it."
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1491
+#: code:addons/sale/models/sale.py:1620
 #, python-format
 msgid "You can not remove an order line once the sales order is confirmed.\n"
 "You should rather set the quantity to 0."
@@ -3881,7 +3856,7 @@ msgid "You can set here the communication type that will appear on sales orders.
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:1115
+#: code:addons/sale/models/sale.py:1154
 #, python-format
 msgid "You cannot change the type of a sale order line. Instead you should delete the current line and create a new line of the proper type."
 msgstr ""
@@ -3918,6 +3893,7 @@ msgid "Your order is not in a state to be rejected."
 msgstr ""
 
 #. module: sale
+#: model:ir.model.fields,field_description:sale.field_contact_config_settings__module_delivery_bpost
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__module_delivery_bpost
 msgid "bpost Connector"
 msgstr ""
@@ -3940,23 +3916,17 @@ msgid "days"
 msgstr ""
 
 #. module: sale
-#: model:product.product,weight_uom_name:sale.advance_product_0
-#: model:product.product,weight_uom_name:sale.product_product_4e
-#: model:product.product,weight_uom_name:sale.product_product_4f
-#: model:product.template,weight_uom_name:sale.advance_product_0_product_template
-#: model:product.template,weight_uom_name:sale.product_product_1_product_template
-#: model:product.template,weight_uom_name:sale.product_product_4e_product_template
-msgid "kg"
+#: code:addons/sale/models/sale.py:115
+#, python-format
+msgid "sale order"
 msgstr ""
 
 #. module: sale
-#: code:addons/sale/models/sale.py:106
-#, python-format
-msgid "sale order"
+#: model:ir.model.fields,field_description:sale.field_sale_order__activity_team_user_ids
+msgid "test field"
 msgstr ""
 
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__amount_by_group
 msgid "type: [(name, amount, base, formated amount, formated base)]"
 msgstr ""
-

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -200,6 +200,7 @@
                     <field name="date_order" string="Quotation Date"/>
                     <field name="commitment_date" groups="sale.group_sale_order_dates"/>
                     <field name="expected_date" widget="date" groups="sale.group_sale_order_dates"/>
+                    <field name="activity_ids" string="Next Activity" widget="list_activity"/>
                     <field name="partner_id"/>
                     <field name="user_id"/>
                     <field name="amount_total" sum="Total Tax Included" widget="monetary"/>


### PR DESCRIPTION
# Descrição

[Adiciona widget="list_activity" módulo 'mail'](https://github.com/multidadosti-erp/odoo/commit/af4dcf537d881dfe34b64655c345e2d92e4e6ce0) 

- Objetivo poder visualizar a Próxima Atividade na Visão Tree.
 
[Adiciona Tree de Compras Prox Atividade módulo 'purchase'](https://github.com/multidadosti-erp/odoo/commit/98961bf1266f3093ea4d473bcb6e0404dea48dbd) 

- Atualiza tradução pt_br do módulo.
- Atualiza arquivo pot de traduções.
 
[Adiciona Tree de Compras Prox Atividade módulo 'sale'](https://github.com/multidadosti-erp/odoo/commit/18d824469d1468ed6e39c207231619ba7f55eb8b) 

- Atualiza tradução pt_br do módulo
- Atualiza arquivo pot de traduções.
 
[Ajusta CSS para dar destaque nos ICONES das Atividades módulo 'mail'](https://github.com/multidadosti-erp/odoo/commit/68fc19a740b3385b514010ca5bbb304205c43cec)

# Informações adicionais

Dados da tarefa: [T7197 ](https://multi.multidados.tech/web?#id=7606&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)
