### PR TITLE
T7237 - Criar parametro port para Criação do Banco de Dados no Odoo

### DIFF
--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -91,7 +91,8 @@ def _initialize_db(id, db_name, demo, lang, user_password, login='admin', countr
         _logger.exception('CREATE DATABASE failed:')
 
 def _create_empty_database(name):
-    db = odoo.sql_db.db_connect('postgres')
+    # Multidados: forçando a porta para evitar erro do pg_bouncer
+    db = odoo.sql_db.db_connect('postgres', db_port='5432')
     with closing(db.cursor()) as cr:
         chosen_template = odoo.tools.config['db_template']
         cr.execute("SELECT datname FROM pg_database WHERE datname = %s",

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -695,7 +695,7 @@ def connection_info_for(db_or_uri):
 
 _Pool = None
 
-def db_connect(to, allow_uri=False):
+def db_connect(to, allow_uri=False, db_port=False):
     global _Pool
     if _Pool is None:
         _Pool = ConnectionPool(int(tools.config['db_maxconn']))
@@ -703,6 +703,12 @@ def db_connect(to, allow_uri=False):
     db, info = connection_info_for(to)
     if not allow_uri and db != to:
         raise ValueError('URI connections not allowed')
+
+    # Multidados: Adicionado db_port para forçar a conexão a porta principal
+    # do postgre em alguns momentos, por exemplo: criação do banco de dados
+    if db_port:
+        info['port'] = db_port
+
     return Connection(_Pool, db, info)
 
 def close_db(db_name):


### PR DESCRIPTION
# Descrição

Adiciona 'db_port' para criação do Banco de Dados
- Objetivo é forçar a porta principal do postgre para evitar erros de conexão com o uso do pg_bouncer.


# Informações adicionais

Dados da tarefa: [T7237 ](https://multi.multidados.tech/web?debug=#id=7646&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)
