### PR TITLE
T7716 - Odoo está apagando stock_quant dos lot zerados, causando problemas nos relatórios

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -307,7 +307,9 @@ class StockQuant(models.Model):
         """
         precision_digits = max(6, self.env.ref('product.decimal_product_uom').digits * 2)
         # Use a select instead of ORM search for UoM robustness.
-        query = """SELECT id FROM stock_quant WHERE round(quantity::numeric, %s) = 0 AND round(reserved_quantity::numeric, %s) = 0;"""
+        # Multidados: Adicionado no WHERE lot_id is null para não remover o produtos controlados
+        # por Número de Série e Lote
+        query = """SELECT id FROM stock_quant WHERE lot_id is null and round(quantity::numeric, %s) = 0 AND round(reserved_quantity::numeric, %s) = 0;"""
         params = (precision_digits, precision_digits)
         self.env.cr.execute(query, params)
         quant_ids = self.env['stock.quant'].browse([quant['id'] for quant in self.env.cr.dictfetchall()])


### PR DESCRIPTION
# Descrição

Ajusta metodo '_unlink_zero_quants(self)' módulo 'stock'
- Adicionado no WHERE lot_id is null para não remover o produtos controlados por Número de Série e Lote.

# Informações adicionais

Dados da tarefa: [T7716](https://multi.multidados.tech/web?debug=#id=8125&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

