### PR TITLE
T7792 - Criar no modelo de relatório padrão Tag Clausulas para Configuração

### DIFF
--- a/odoo/import_xml.rng
+++ b/odoo/import_xml.rng
@@ -174,6 +174,7 @@
     <rng:define name="template">
         <rng:element name="template">
             <rng:optional><rng:attribute name="id"/></rng:optional>
+            <rng:optional><rng:attribute name="noupdate"/></rng:optional>
             <rng:optional><rng:attribute name="t-name"/></rng:optional>
             <rng:optional><rng:attribute name="name"/></rng:optional>
             <rng:optional><rng:attribute name="forcecreate"/></rng:optional>

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -587,7 +587,9 @@ form: module.record_id""" % (xml_id,)
         # in update mode, the record won't be updated if the data node explicitly
         # opt-out using @noupdate="1". A second check will be performed in
         # model._load_records() using the record's ir.model.data `noupdate` field.
-        if self.isnoupdate(data_node) and self.mode != 'init':
+        #
+        # Multidados: Adicionado isnoupdate do rec para verificar se atualiza
+        if (self.isnoupdate(data_node) or self.isnoupdate(rec)) and self.mode != 'init':
             # check if the xml record has no id, skip
             if not rec_id:
                 return None
@@ -690,7 +692,7 @@ form: module.record_id""" % (xml_id,)
             'id': tpl_id,
             'model': model,
         }
-        for att in ['forcecreate', 'context']:
+        for att in ['forcecreate', 'context', 'noupdate']:
             if att in el.attrib:
                 record_attrs[att] = el.attrib.pop(att)
 
@@ -847,7 +849,7 @@ def convert_csv_import(cr, module, fname, csvcontent, idref=None, mode='init',
 def convert_xml_import(cr, module, xmlfile, idref=None, mode='init', noupdate=False, report=None):
     doc = etree.parse(xmlfile)
     relaxng = etree.RelaxNG(
-        etree.parse(os.path.join(config['root_path'],'import_xml.rng' )))
+        etree.parse(os.path.join(config['root_path'], 'import_xml.rng')))
     try:
         relaxng.assert_(doc)
     except Exception:


### PR DESCRIPTION
# Descrição

Adiciona tag 'noupdate' no XML/Template módulo 'odoo'
- Adicionado para poder selecionar se o template deve ou não ser atualizado pelo odoo no update.

# Informações adicionais

Dados da tarefa: [T7792](https://multi.multidados.tech/web?#id=8201&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [297](https://github.com/multidadosti-erp/multidadosti-report-addons/pull/297)
