### PR TITLE
T7795 - Duplicação de itens

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -134,10 +134,13 @@ class PickingType(models.Model):
             self.default_location_src_id = self.env.ref('stock.stock_location_stock').id
             self.default_location_dest_id = self.env.ref('stock.stock_location_customers').id
 
-    @api.onchange('show_operations')
-    def onchange_show_operations(self):
-        if self.show_operations is True:
-            self.show_reserved = True
+    # Comentado pela Multidados:
+    # o campo 'show_reserved' não deve depender do 'show_operations'
+    #
+    # @api.onchange('show_operations')
+    # def onchange_show_operations(self):
+    #     if self.show_operations is True:
+    #         self.show_reserved = True
 
     def _get_action(self, action_xmlid):
         # TDE TODO check to have one view + custo in methods

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -51,7 +51,9 @@
                                 <field name="code"/>
                                 <field attrs='{"invisible": [("code", "not in", ["incoming", "outgoing", "internal"])]}' name="return_picking_type_id"/>
                                 <field name="show_operations"/>
-                                <field name="show_reserved" attrs="{'invisible': [('show_operations', '!=', False)]}"/>
+                                <!--field name="show_reserved" attrs="{'invisible': [('show_operations', '!=', False)]}"/-->
+                                <!-- Multidados: Alerado para desvincular campo 'show_reserved' do 'show_operations'-->
+                                <field name="show_reserved"/>
                             </group>
                         </group>
                         <group>


### PR DESCRIPTION
# Descrição

- Correções no módulo 'Stock'
  - Remove onchange do lot para zerar a quantidade concluida e o lote caso tenha dado erro
  - Remove dependência de campos 'show_reserved' e 'show_operation'

# Informações adicionais

- [T7795](https://multi.multidados.tech/web#id=8204&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1290)