### PR TITLE
T7811 - Ajustar o Módulo de Atividades

### DIFF
--- a/addons/mail/static/src/js/activity.js
+++ b/addons/mail/static/src/js/activity.js
@@ -83,7 +83,7 @@ var setDelayLabel = function (activities){
     var today = moment().startOf('day');
     var activities_to_show = [];
     _.each(activities, function (activity){
-        if (activity.status == 'active'){
+        if (activity.status == 'active' || activity.status === undefined){
             var toDisplay = '';
             var diff = activity.date_deadline.diff(today, 'days', true); // true means no rounding
             if (diff === 0){

--- a/addons/project_timesheet_holidays/tests/__init__.py
+++ b/addons/project_timesheet_holidays/tests/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_timesheet_holidays
+# from . import test_timesheet_holidays


### PR DESCRIPTION
# Descrição

- Corrige erro quando atividade nao tem status
  - O campo status foi adicionado no módulo da oca/social 'mail_activity_done', mas a verificação foi adicionada no core para facilitar.
  - O módulo mail_activity_done sempre estará instalado nos ambientes dos clientes, mas trata para quando nao estiver.
  - Foi percebido a necessidade da verificação quando criei um banco de testes e a funcionalidade sem o módulo 'mail_activity_done' intalado não estava correta.

# Informações adicionais

- [T7811](https://multi.multidados.tech/web?#id=8220&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [oca/social](https://github.com/multidadosti-erp/social/pull/14)
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1296)
- [private-addons](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/861)