### PR TITLE
T7806 - Separar os Logs, Anotações e Mensagens

### DIFF
--- a/addons/mail/static/src/js/composers/chatter_composer.js
+++ b/addons/mail/static/src/js/composers/chatter_composer.js
@@ -35,6 +35,11 @@ var ChatterComposer = BasicComposer.extend({
             this.options.sendText = _t("Log");
         }
         this.notInline = true;
+
+        // Multidados
+        // Adicionado o atributo '_noteSubtype' para indicar qual será
+        // o tipo definido para anotações
+        this._noteSubtype = 'mail.mt_note'
     },
 
     //--------------------------------------------------------------------------
@@ -201,7 +206,11 @@ var ChatterComposer = BasicComposer.extend({
 
             // Subtype
             if (self.options.isLog) {
-                message.subtype = 'mail.mt_note';
+                /* Alterado pela Multidados
+                Altera o subtipo para pegar o atributo da classe do Composer.
+                Herdado no br_mail para utilizar outro subtipo para anotações.
+                */
+                message.subtype = self._noteSubtype;
             }
 
             // Partner_ids


### PR DESCRIPTION
# Descrição

- Adiciona atributo '_noteSubgroup' no widget chatter composer
  - O atributo foi adicionado para herança em outros modulos e alterar qual é o subtipo das mensagens de Anotações.

- Adiciona função para facilitar herança do widget de mensagens
  - Os parâmetros passados para a função 'read' dentro da função message_format, foram substituidos por uma função para obtê-los, facilitando a herança em outros módulos.

# Informações adicionais

- [T7806](https://multi.multidados.tech/web?#id=8215&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1303)