### PR TITLE
T7842 - Ajustes no Widget Thread após a separação de mensagens e logs

### DIFF
--- a/addons/mail/static/src/js/models/threads/thread.js
+++ b/addons/mail/static/src/js/models/threads/thread.js
@@ -16,7 +16,7 @@ var ServicesMixin = require('web.ServicesMixin');
  */
 var Thread = AbstractThread.extend(ServicesMixin, {
     // max number of fetched messages from the server
-    _FETCH_LIMIT: 30,
+    _FETCH_LIMIT: 60,
     /**
      * @override
      * @param {Object} params


### PR DESCRIPTION
# Descrição

- Muda a quantidade de mensagens a mostrar no Thread (30 -> 60)

# Informações adicionais

- [T7842](https://multi.multidados.tech/web?#id=8251&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1306)