### PR TITLE
T7847 - Ajustes no Widget Thread "Mostrar Mensagens Antigas"

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2237,6 +2237,17 @@ class MailThread(models.AbstractModel):
         message = self.env['mail.message'].sudo().create(message_values)
         return message
 
+    @api.multi
+    def fetch_messages_by_subtype(self):
+        """ Developed by Multidados
+        Método para obter as mensagens do registro, divididas
+        pelos subtipos utilizados pelo thread widget.
+        """
+        MailMessage = self.env['mail.message']
+        message_ids = [] if not self else self.read(['message_ids'])[0]['message_ids']  # noqa
+        grouped_messages = MailMessage.group_by_thread_subtype(message_ids)
+        return grouped_messages
+
     # ------------------------------------------------------
     # Followers API
     # ------------------------------------------------------
@@ -2415,7 +2426,7 @@ class MailThread(models.AbstractModel):
 
         new_partners, new_channels = dict(), dict()
 
-        # return data related to auto subscription based on subtype matching (aka: 
+        # return data related to auto subscription based on subtype matching (aka:
         # default task subtypes or subtypes from project triggering task subtypes)
         updated_relation = dict()
         child_ids, def_ids, all_int_ids, parent, relation = self.env['mail.message.subtype']._get_auto_subscription_subtypes(self._name)

--- a/addons/mail/static/src/js/discuss.js
+++ b/addons/mail/static/src/js/discuss.js
@@ -717,6 +717,7 @@ var Discuss = AbstractAction.extend(ControlPanelMixin, {
         this._threadWidget = new ThreadWidget(this, {
             areMessageAttachmentsDeletable: false,
             loadMoreOnScroll: true,
+            dontCollapseSubtype: true,
         });
 
         this._threadWidget

--- a/addons/mail/static/src/js/models/threads/document_thread.js
+++ b/addons/mail/static/src/js/models/threads/document_thread.js
@@ -190,11 +190,12 @@ var DocumentThread = Thread.extend({
      * Useful in order to handle message history of the document thread,
      * in particular to fetch messages when necessary and/or display 'load more'.
      *
-     * @param {integer[]} messageIDs
+     * @param {Object} messagesGrouped
+     * @param {integer[]} messagesGrouped.all
      */
-    setMessageIDs: function (messageIDs) {
+    setMessageIDs: function (messagesGrouped) {
         this._mustFetchMessageIDs = false;
-        this._messageIDs = messageIDs;
+        this._messageIDs = messagesGrouped.all;
     },
     /**
      * Set the name of this document thread
@@ -257,15 +258,25 @@ var DocumentThread = Thread.extend({
         if (!resID || !this._mustFetchMessageIDs) {
             return $.when();
         }
+        /** Alterado pela Multidados
+         * Ao inves de chamar o RPC na função read, chama o método
+         * 'fetch_messages_by_subtype' definido no mixin 'mail.thread'
+         * para obter as mensagens separadamente pelo subtipo separado
+         * no Widget Thread.
+         *
+         * O método setMessageIDs também foi alterado para agir de
+         * acordo com o novo retorno do RPC.
+         */
         return this._rpc({
             model: this.getDocumentModel(),
-            method: 'read',
-            args: [[resID], ['message_ids']],
+            method: 'fetch_messages_by_subtype',
+            args: [[resID]],
         }).then(function (result) {
-            self.setMessageIDs(result[0].message_ids);
+            self.setMessageIDs(result);
         });
     },
     /**
+     * @Multidados No módulo 'br_mail' a função foi sobrescrita
      * @override
      * @private
      * @param {Object} options

--- a/addons/mail/static/src/js/services/mail_document_thread_manager.js
+++ b/addons/mail/static/src/js/services/mail_document_thread_manager.js
@@ -113,7 +113,12 @@ MailManager.include({
             this._threads.push(thread);
         } else {
             if ('messageIDs' in params) {
-                thread.setMessageIDs(params.messageIDs);
+                /* Alterado pela Multidados
+                 * Altera parâmetro passado para a função 'setMessageIDs'. Após a alteração
+                 * no widget thread, não é mais passado a lista com os IDs para a função, e
+                 * sim listas agrupadas com os ids, sendo a lista geral passada no atributo 'all'.
+                 */
+                thread.setMessageIDs({all: params.messageIDs});
             }
             if ('name' in params && params.name) {
                 // document thread may have a change of name

--- a/addons/mail/static/src/js/thread_windows/abstract_thread_window.js
+++ b/addons/mail/static/src/js/thread_windows/abstract_thread_window.js
@@ -82,6 +82,7 @@ var AbstractThreadWindow = Widget.extend({
             areMessageAttachmentsDeletable: false,
             displayMarkAsRead: false,
             displayStars: this.options.displayStars,
+            dontCollapseSubtype: true,
         });
 
         if (this.isFolded()) {


### PR DESCRIPTION
# Descrição

- Separação de mensagens por subtipos no Thread Widget
  - para possibilitar o uso de carregar mais mensagens, o widget Thread foi modificado para separar os ids das mensagens por tipos.
  - Entre os tipos utilizados no widget estão ['note', 'log', 'discussion']

- Adiciona tag para o thread que não deve colapsar subtipos
  - No Widget Thread foi adicionado no 'br_mail' a opção de não colapsar os subtipos de mensagem, e é adicionado fixo ao ver as mensagens pelo módulo de mensagens e quando está com um bate-papo aberto.

# Informações adicionais

- [T7847](https://multi.multidados.tech/web?#id=8256&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1311)