### PR TITLE
T7873 - Correções no chatter (Mostrar mais mensagens está aparecendo sempre)

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -497,7 +497,7 @@ class Message(models.Model):
 
         # Get Messages IDs and Subtypes of 'ids' list
         query = "SELECT id, subtype_id FROM mail_message " \
-                "WHERE id in %s"
+                "WHERE id in %s ORDER BY id desc"
         self._cr.execute(query, [tuple(ids)])
         fetch_results = self._cr.dictfetchall()
 

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -506,14 +506,13 @@ class Message(models.Model):
         for result in fetch_results:
             subtype_id = result['subtype_id']
 
-            if subtype_id in mt_thread_subtypes['log']:
-                grouped_messages_ids['logs'].append(result['id'])
-
-            elif subtype_id in mt_thread_subtypes['note']:
+            if subtype_id in mt_thread_subtypes['note']:
                 grouped_messages_ids['notes'].append(result['id'])
 
             elif subtype_id in mt_thread_subtypes['discussion']:
                 grouped_messages_ids['discussions'].append(result['id'])
+            else:
+                grouped_messages_ids['logs'].append(result['id'])
 
         return grouped_messages_ids
 


### PR DESCRIPTION
# Descrição

- Corrige ordenação de mensagens ao Mostrar mais

- Corrige erro de 'Mostrar mensagens antigas'
  - O erro ocorria porque tinham tipos de mensagens personalizados por módulos. O correto seria ao adicionar um novo subtipo, incluir ele no retorno da função de agrupamento das mensagens, porém, como ja existem varios subtipos criados, optamos por incluir como log esses subtipos que não forem incluídos no agrupamento.

# Informações adicionais

- [T7873](https://multi.multidados.tech/web?#id=8282&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1316)