### PR TITLE
T7834 - Sistema assumindo a equipe de vendas errada e não permite trocar para a correta

### DIFF
--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -31,15 +31,20 @@ class CrmTeam(models.Model):
         ], limit=1)
         if not team_id and 'default_team_id' in self.env.context:
             team_id = self.env['crm.team'].browse(self.env.context.get('default_team_id'))
-        if not team_id:
-            default_team_id = self.env.ref('sales_team.team_sales_department', raise_if_not_found=False)
-            if default_team_id:
-                try:
-                    default_team_id.check_access_rule('read')
-                except AccessError:
-                    return self.env['crm.team']
-                if (self.env.context.get('default_type') != 'lead' or default_team_id.use_leads) and default_team_id.active:
-                    team_id = default_team_id
+
+        # Comentado pela Multidados ...
+        # Não é correto pegar a equipe criada por padrão 'sales_team.team_sales_department'
+        # devido a utilização de multi empresas.
+        #
+        # if not team_id:
+        #     default_team_id = self.env.ref('sales_team.team_sales_department', raise_if_not_found=False)
+        #     if default_team_id:
+        #         try:
+        #             default_team_id.check_access_rule('read')
+        #         except AccessError:
+        #             return self.env['crm.team']
+        #         if (self.env.context.get('default_type') != 'lead' or default_team_id.use_leads) and default_team_id.active:
+        #             team_id = default_team_id
         return team_id
 
     def _get_default_favorite_user_ids(self):

--- a/addons/sales_team/tests/test_default_team.py
+++ b/addons/sales_team/tests/test_default_team.py
@@ -41,8 +41,12 @@ class TestDefaultTeam(common.SavepointCase):
         self.team_1.member_ids = [(5,)]
         # Case 1.
         team = self.CrmTeam.sudo(self.user)._get_default_team_id()
-        self.assertEqual(team, self.team_2)
+        self.assertEqual(team, self.CrmTeam)
         # Case 2.
+        self.team_2.member_ids |= self.user
+        team = self.CrmTeam.sudo(self.user)._get_default_team_id()
+        self.assertEqual(team, self.team_2)
+        # Case 3.
         self.team_2.active = False
         team = self.CrmTeam.sudo(self.user)._get_default_team_id()
         self.assertEqual(team, self.CrmTeam)


### PR DESCRIPTION
# Descrição

- Corrige obtenção de Equipe de Vendas Padrão
  - O método de obter a equipe de vendas padrão estava obtendo a equipe de forma errada. O search era feito corretamente, obtendo uma equipe dependendo da empresa do usuário ativo, e se ele é membro ou lider da equipe. Quando não obtinha nenhuma equipe, estava selecionando a equipe criada por padrão: 'sales_team.team_sales_department'

# Informações adicionais

- [T7834](https://multi.multidados.tech/web?#id=8243&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)