### PR TITLE
T7954 - Adicionar forma de impossibilitar o ordenamento em tree

### DIFF
--- a/addons/web/static/src/js/views/list/list_renderer.js
+++ b/addons/web/static/src/js/views/list/list_renderer.js
@@ -546,6 +546,8 @@ var ListRenderer = BasicRenderer.extend({
         var order = this.state.orderedBy;
         var isNodeSorted = order[0] && order[0].name === name;
         var field = this.state.fields[name];
+        var fieldsInfo = this.state.fieldsInfo['list'] || {};
+        var fieldInfo = fieldsInfo[name] || {options: {}};
         var $th = $('<th>');
         if (!field) {
             return $th;
@@ -557,11 +559,15 @@ var ListRenderer = BasicRenderer.extend({
         if (description === undefined) {
             description = node.attrs.string || field.string;
         }
+        
+        var is_sortable = fieldInfo.options.sortable === undefined ? true : fieldInfo.options.sortable;
+        is_sortable = is_sortable && field.sortable;
+
         $th.text(description)
             .data('name', name)
             .toggleClass('o-sort-down', isNodeSorted ? !order[0].asc : false)
             .toggleClass('o-sort-up', isNodeSorted ? order[0].asc : false)
-            .addClass(field.sortable && 'o_column_sortable');
+            .addClass(is_sortable && 'o_column_sortable');
 
         if (isNodeSorted) {
             $th.attr('aria-sort', order[0].asc ? 'ascending' : 'descending');


### PR DESCRIPTION
# Descrição

- Habilita opção de não permitir ordenamento pelo campo na tree
  - Por default o sortable é = True
  - Adiciona código para verificar se o campo tem no atributo options a flag {'sortable': True}

# Informações adicionais

- [T7954](https://multi.multidados.tech/web?#id=8363&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)