### PR TITLE
T7975 - Cancelamento de pedidos PDV - Conciliação financeira e Estoque.

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -639,6 +639,21 @@ class PosOrder(models.Model):
         readonly=True,
         states={'draft': [('readonly', False)]},
     )
+    origin_order_id = fields.Many2one(
+        comodel_name='pos.order',
+        string='Origin Order',
+        readonly=True,
+        help="If some order had been refunded, it will be referenced here "
+             "to the return order."
+    )
+    return_order_id = fields.Many2one(
+        comodel_name='pos.order',
+        string='Return Order',
+        readonly=True,
+        help="If some order had been refunded, order created for returning "
+             "will be referenced here."
+    )
+
 
     @api.onchange('statement_ids', 'lines')
     def _onchange_amount_all(self):
@@ -1069,7 +1084,9 @@ class PosOrder(models.Model):
                 'amount_tax': -order.amount_tax,
                 'amount_total': -order.amount_total,
                 'amount_paid': 0,
+                'origin_order_id': order.id,
             })
+            order.return_order_id = clone
             for line in order.lines:
                 clone_line = line.copy({
                     # required=True, copy=False

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -28,7 +28,7 @@ class PosSession(models.Model):
 
             move = self.env['pos.order'].with_context(force_company=company_id)._create_account_move(session.start_at, session.name, int(journal_id), company_id)
             orders.with_context(force_company=company_id)._create_account_move_line(session, move)
-            for order in session.order_ids.filtered(lambda o: o.state not in ['done', 'invoiced']):
+            for order in session.order_ids.filtered(lambda o: o.state not in ['done', 'invoiced', 'cancel']):
                 if order.state not in ('paid'):
                     raise UserError(
                         _("You cannot confirm all orders of this session, because they have not the 'paid' status.\n"


### PR DESCRIPTION
# Descrição

- Adiciona campos para determinar se os pedidos sao ou existem devoluções
  - O campo 'origin_order_id' indica o pedido que foi devolvido.
  - O campo 'return_order_id' indica o pedido ref a devolução.

# Informações adicionais

- [T7975](https://multi.multidados.tech/web?#id=8384&action=323&active_id=61&model=project.task&view_type=form&menu_id=)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1348)