### PR TITLE
T7991 - Ajustar vizualização no parceiro para totalizar oportunidade do pipeline e do pipeline pós venda

### DIFF
--- a/addons/crm/i18n/crm.pot
+++ b/addons/crm/i18n/crm.pot
@@ -1681,6 +1681,12 @@ msgid "Opportunity Won"
 msgstr ""
 
 #. module: crm
+#: code:addons/crm/models/res_partner.py:74
+#, python-format
+msgid "Opportunity(s)"
+msgstr ""
+
+#. module: crm
 #: model:mail.message.subtype,description:crm.mt_lead_create
 msgid "Opportunity created"
 msgstr ""

--- a/addons/crm/i18n/pt_BR.po
+++ b/addons/crm/i18n/pt_BR.po
@@ -1701,6 +1701,12 @@ msgid "Opportunity Won"
 msgstr "Oportunidade Ganha"
 
 #. module: crm
+#: code:addons/crm/models/res_partner.py:74
+#, python-format
+msgid "Opportunity(s)"
+msgstr "Oportunidade(s)"
+
+#. module: crm
 #: model:mail.message.subtype,description:crm.mt_lead_create
 msgid "Opportunity created"
 msgstr "Oportunidade Criada"

--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 
 
 class Partner(models.Model):
@@ -56,3 +56,39 @@ class Partner(models.Model):
             'default_partner_ids': partner_ids,
         }
         return action
+
+    def action_show_opportunity(self):
+        """ Open kanban view to display opportunity.
+            :return dict: dictionary value for created kanban view
+        """
+        self.ensure_one()
+
+        form_view = self.env.ref('crm.crm_case_form_view_oppor')
+        tree_view = self.env.ref('crm.crm_case_tree_view_leads')
+
+        # the opportunity count should counts the opportunities of this
+        # company and all its contacts
+        operator = 'child_of' if self.is_company else '='
+
+        return {
+            'name': _('Opportunity(s)'),
+            'type': 'ir.actions.act_window',
+            'view_type': 'form',
+            'view_mode': 'tree,form',
+            'res_model': 'crm.lead',
+            'view_id': False,
+            'domain': [
+                ('partner_id', operator, self.id),
+                ('type', '=', 'opportunity')
+            ],
+            'context': {
+                'create': False,
+                'edit': False,
+            },
+            'views': [
+                (tree_view.id, 'tree'),
+                (form_view.id, 'form'),
+                (False, 'calendar'),
+                (False, 'graph')
+            ],
+        }

--- a/addons/crm/views/res_partner_views.xml
+++ b/addons/crm/views/res_partner_views.xml
@@ -99,9 +99,9 @@
             <field name="arch" type="xml">
                 <data>
                     <button name="toggle_active" position="before">
-                        <button class="oe_stat_button o_res_partner_tip_opp" type="action"
+                        <button class="oe_stat_button o_res_partner_tip_opp" type="object"
                             attrs="{'invisible': [('customer', '=', False)]}"
-                            name="%(crm.crm_lead_opportunities)d"
+                            name="action_show_opportunity"
                             icon="fa-star"
                             groups="sales_team.group_sale_salesman"
                             context="{'search_default_partner_id': active_id}">


### PR DESCRIPTION
# Descrição

Substitui Botão XML de 'action' por 'object' módulo 'crm'

- Objetivo é poder herdar o método e ajustar o domain.
- Atualiza tradução pt_br do módulo.

# Informações adicionais

Dados da tarefa: [T7991](https://multi.multidados.tech/web#id=8400&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [1351](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1351)
