### PR TITLE
T7995 - Melhorias no Multiphono (menus, testes)

### DIFF
--- a/addons/crm/i18n/pt_BR.po
+++ b/addons/crm/i18n/pt_BR.po
@@ -2,44 +2,18 @@
 # This file contains the translation of the following modules:
 # * crm
 #
-# Translators:
-# Luciano Giacomazzi <lucianogiacomazzi@gmail.com>, 2018
-# danimaribeiro <danimaribeiro@gmail.com>, 2018
-# Adriel Kotviski <kotviski@gmail.com>, 2018
-# falexandresilva <falexandresilva@gmail.com>, 2018
-# André Augusto Firmino Cordeiro <a.cordeito@gmail.com>, 2018
-# Rodrigo de Almeida Sottomaior Macedo <rmsolucoeseminformatica@protonmail.com>, 2018
-# Sidnei Brianti <scbrianti@gmail.com>, 2018
-# Hildeberto Abreu Magalhães <hildeberto@gmail.com>, 2018
-# Silmar <pinheirosilmar@gmail.com>, 2018
-# Martin Trigaux, 2018
-# Mateus Lopes <mateus1@gmail.com>, 2018
-# grazziano <gra.negocia@gmail.com>, 2018
-# Fernando Alencar <fernando@fernandoalencar.com.br>, 2018
-# Marcel Savegnago <marcel.savegnago@gmail.com>, 2019
-# Ramiro Pereira de Magalhães <ramiro.p.magalhaes@gmail.com>, 2019
-# Luiz Fernando <lfpsgs@outlook.com>, 2020
-# Kevin Harrings <kha@odoo.com>, 2020
-# Eduardo Aparicio <eduardo.caparica@gmail.com>, 2020
-# Fernando Colus <fcolus1@gmail.com>, 2020
-# Maurício Liell <mauricio@liell.com.br>, 2020
-# PopSolutions Cooperativa Digital <popsolutions.co@gmail.com>, 2020
-# Tiago Rigo <tiagomrigo@gmail.com>, 2020
-# Éder Brito <britoederr@gmail.com>, 2021
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-09 10:31+0000\n"
-"PO-Revision-Date: 2018-08-24 09:17+0000\n"
-"Last-Translator: Éder Brito <britoederr@gmail.com>, 2021\n"
-"Language-Team: Portuguese (Brazil) (https://www.transifex.com/odoo/teams/41243/pt_BR/)\n"
+"POT-Creation-Date: 2023-12-21 19:22+0000\n"
+"PO-Revision-Date: 2023-12-21 19:22+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: pt_BR\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__meeting_count
@@ -96,7 +70,7 @@ msgstr "<i class=\"fa fa-ban\" style=\"color: red;\" role=\"img\" title=\"Este e
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 msgid "<i class=\"fa fa-ban\" style=\"color: red;\" role=\"img\" title=\"This email is blacklisted for mass mailing\" aria-label=\"Blacklisted\" attrs=\"{'invisible': [('is_blacklisted', '=', False)]}\" groups=\"base.group_user\"/>"
-msgstr "<i class=\"fa fa-ban\" style=\"color: red;\" role=\"img\" title=\"Este e-mail está na lista negra para envio em massa\" aria-label=\"Blacklisted\" attrs=\"{'invisible': [('is_blacklisted', '=', False)]}\" groups=\"base.group_user\"/>"
+msgstr "<i class=\"fa fa-ban\" style=\"color: red;\" role=\"img\" title=\"Este e-mail está na lista de bloqueio para envio em massa\" aria-label=\"Lista de Bloqueio\" attrs=\"{'invisible': [('is_blacklisted', '=', False)]}\" groups=\"base.group_user\"/>"
 
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_lead_kanban
@@ -144,16 +118,6 @@ msgid "<p>As you don't belong to any Sales Team, Odoo opens the first one by def
 msgstr "<p><b>Obs.:</b>Como você não pertence a nenhuma equipe de vendas, o sistema abre a primeira por padrão.</p>"
 
 #. module: crm
-#: code:addons/crm/models/crm_team.py:152
-#, python-format
-msgid ""
-"<p>As you don't belong to any Sales Team, Odoo opens the first one by "
-"default.</p>"
-msgstr ""
-"<p>Como você não pertence a nenhuma Equipe de Vendas, o Odoo abrirá a "
-"primeira por padrão.</p>"
-
-#. module: crm
 #. openerp-web
 #: code:addons/crm/static/src/js/tour.js:52
 #, python-format
@@ -179,6 +143,7 @@ msgstr "Aceitar E-mails de"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_needaction
+#: model:ir.model.fields,field_description:crm.field_crm_stage__message_needaction
 msgid "Action Needed"
 msgstr "Ação Necessária"
 
@@ -191,6 +156,7 @@ msgstr "Ativo"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__activity_ids
+#: model:ir.model.fields,field_description:crm.field_crm_stage__activity_ids
 #: model:ir.ui.menu,name:crm.crm_activity_report_menu
 msgid "Activities"
 msgstr "Atividades"
@@ -218,6 +184,7 @@ msgstr "Atividades a Fazer"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__activity_state
+#: model:ir.model.fields,field_description:crm.field_crm_stage__activity_state
 msgid "Activity State"
 msgstr "Estado de Atividade"
 
@@ -227,12 +194,18 @@ msgid "Activity Type"
 msgstr "Tipo de Atividade"
 
 #. module: crm
+#: model:ir.model.fields,field_description:crm.field_crm_lead__activity_type_icon
+#: model:ir.model.fields,field_description:crm.field_crm_stage__activity_type_icon
+msgid "Activity Type Icon"
+msgstr "Ícone de Tipo de Atividade"
+
+#. module: crm
 #: model:ir.ui.menu,name:crm.crm_team_menu_config_activity_types
 msgid "Activity Types"
 msgstr "Tipos de Atividades"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:957
+#: code:addons/crm/models/crm_lead.py:960
 #, python-format
 msgid "Add a new lead"
 msgstr "Novo lead"
@@ -286,8 +259,9 @@ msgstr "Data da Atribuição"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_attachment_count
+#: model:ir.model.fields,field_description:crm.field_crm_stage__message_attachment_count
 msgid "Attachment Count"
-msgstr "Contar Anexo"
+msgstr "Contagem de Anexos"
 
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_tree_view_oppor
@@ -297,7 +271,7 @@ msgstr "Média de Probabilidade"
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__is_blacklisted
 msgid "Blacklist"
-msgstr "Lista negra"
+msgstr "Lista Bloqueios"
 
 #. module: crm
 #: code:addons/crm/models/crm_lead.py:424
@@ -326,6 +300,11 @@ msgstr "Análise de Atividade CRM"
 #: model:ir.model,name:crm.model_crm_stage
 msgid "CRM Stages"
 msgstr "Estágios do CRM"
+
+#. module: crm
+#: model:mail.activity.type,name:crm.mail_activity_demo_call_demo
+msgid "Call for Demo"
+msgstr "Ligar para Demonstração"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__campaign_id
@@ -463,6 +442,16 @@ msgid "Congratulations! You just beat %s opportunities won!"
 msgstr "Parabéns! Você acabou de bater a marca de %s oportunidades ganhas!"
 
 #. module: crm
+#: model:crm.lead.tag,name:crm.categ_oppor7
+msgid "Consulting"
+msgstr "Consultando"
+
+#. module: crm
+#: model:ir.model,name:crm.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__contact_name
 msgid "Contact Name"
 msgstr "Nome do Contato"
@@ -529,7 +518,7 @@ msgid "Convert to opportunities"
 msgstr "Converter para oportunidades"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1140
+#: code:addons/crm/models/crm_lead.py:1143
 #: selection:crm.lead2opportunity.partner,name:0
 #: selection:crm.lead2opportunity.partner.mass,name:0
 #: model:ir.actions.act_window,name:crm.action_crm_lead2opportunity_partner
@@ -570,7 +559,6 @@ msgid "Create & Edit"
 msgstr "Criar & Editar"
 
 #. module: crm
-#: model:ir.model.fields,field_description:crm.field_contact_config_settings__module_crm_reveal
 #: model:ir.model.fields,field_description:crm.field_res_config_settings__module_crm_reveal
 msgid "Create Leads/Opportunities from your website's traffic"
 msgstr "Criar Leads/Oportunidades a partir do tráfego do seu site"
@@ -609,7 +597,7 @@ msgid "Create an new opportunity related to this customer"
 msgstr "Criar uma nova oportunidade relacionada a este cliente"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:959
+#: code:addons/crm/models/crm_lead.py:962
 #, python-format
 msgid "Create an opportunity in your pipeline"
 msgstr "Crie uma nova oportunidade em seu pipeline"
@@ -669,7 +657,7 @@ msgid "Currency"
 msgstr "Moeda"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1192
+#: code:addons/crm/models/crm_lead.py:1195
 #: model:ir.model.fields,field_description:crm.field_crm_lead2opportunity_partner__partner_id
 #: model:ir.model.fields,field_description:crm.field_crm_lead2opportunity_partner_mass__partner_id
 #: model:ir.model.fields,field_description:crm.field_crm_lead__partner_id
@@ -684,7 +672,7 @@ msgid "Customer"
 msgstr "Parceiro"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1194
+#: code:addons/crm/models/crm_lead.py:1197
 #, python-format
 msgid "Customer Email"
 msgstr "E-mail do Cliente"
@@ -723,7 +711,6 @@ msgid "Days to Close"
 msgstr "Dias para concluir"
 
 #. module: crm
-#: model:ir.model.fields,field_description:crm.field_contact_config_settings__crm_alias_prefix
 #: model:ir.model.fields,field_description:crm.field_res_config_settings__crm_alias_prefix
 msgid "Default Alias Name for Leads"
 msgstr "Apelido Padrão para os Prospectos"
@@ -742,6 +729,11 @@ msgstr "Excluir"
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 msgid "Describe the lead..."
 msgstr "Descreva o prospecto..."
+
+#. module: crm
+#: model:crm.lead.tag,name:crm.categ_oppor5
+msgid "Design"
+msgstr ""
 
 #. module: crm
 #: model:ir.model,name:crm.model_digest_digest
@@ -897,17 +889,30 @@ msgid "Folded in Pipeline"
 msgstr "Dobrado no Pipeline"
 
 #. module: crm
+#: model:ir.model.fields,field_description:crm.field_crm_stage__fold_is_empty
+msgid "Folded in Pipeline When Emptyin"
+msgstr "Dobrado no Pipeline quando Vazio"
+
+#. module: crm
+#: model:mail.activity.type,name:crm.mail_activity_demo_followup_quote
+msgid "Follow-up Quote"
+msgstr "Acompanhamento de Orçamento"
+
+#. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_follower_ids
+#: model:ir.model.fields,field_description:crm.field_crm_stage__message_follower_ids
 msgid "Followers"
 msgstr "Seguidores"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_channel_ids
+#: model:ir.model.fields,field_description:crm.field_crm_stage__message_channel_ids
 msgid "Followers (Channels)"
 msgstr "Seguidores (Canais)"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_partner_ids
+#: model:ir.model.fields,field_description:crm.field_crm_stage__message_partner_ids
 msgid "Followers (Partners)"
 msgstr "Seguidores (Parceiros)"
 
@@ -915,6 +920,12 @@ msgstr "Seguidores (Parceiros)"
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
 msgid "Followup"
 msgstr "Acompanhar"
+
+#. module: crm
+#: model:ir.model.fields,help:crm.field_crm_lead__activity_type_icon
+#: model:ir.model.fields,help:crm.field_crm_stage__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr "Ícone do Font Awesome. Ex: fa-tasks"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead2opportunity_partner_mass__force_assignation
@@ -927,7 +938,7 @@ msgid "Format phone numbers based on national conventions"
 msgstr "Formatar números de telefone com base em convenções nacionais"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:630
+#: code:addons/crm/models/crm_lead.py:633
 #, python-format
 msgid "From %s : %s"
 msgstr "De %s : %s"
@@ -1001,7 +1012,7 @@ msgstr "Alta"
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_team__dashboard_graph_group_pipeline
 msgid "How this channel's dashboard graph will group the results."
-msgstr "Como o gráfico do painel de instrumentos deste canal irá agrupar os resultados."
+msgstr "Como o gráfico do painel deste canal irá agrupar os resultados."
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_activity_report__id
@@ -1015,20 +1026,23 @@ msgstr "Como o gráfico do painel de instrumentos deste canal irá agrupar os re
 #: model:ir.model.fields,field_description:crm.field_crm_partner_binding__id
 #: model:ir.model.fields,field_description:crm.field_crm_stage__id
 msgid "ID"
-msgstr "Id."
+msgstr ""
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_lead__message_unread
+#: model:ir.model.fields,help:crm.field_crm_stage__message_unread
 msgid "If checked new messages require your attention."
 msgstr "Se marcado, novas mensagens solicitarão sua atenção."
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_lead__message_needaction
+#: model:ir.model.fields,help:crm.field_crm_stage__message_needaction
 msgid "If checked, new messages require your attention."
 msgstr "Se selecionado, novas mensagens exigirão sua atenção."
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_lead__message_has_error
+#: model:ir.model.fields,help:crm.field_crm_stage__message_has_error
 msgid "If checked, some messages have a delivery error."
 msgstr "Se selecionado, algumas mensagens terão um erro de entrega."
 
@@ -1055,7 +1069,7 @@ msgid "Import & Synchronize"
 msgstr "Importar e Sincronizar"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1258
+#: code:addons/crm/models/crm_lead.py:1261
 #, python-format
 msgid "Import Template for Leads & Opportunities"
 msgstr "Modelo de Importação para Leads & Oportunidades"
@@ -1064,6 +1078,11 @@ msgstr "Modelo de Importação para Leads & Oportunidades"
 #: model_terms:ir.ui.view,arch_db:crm.crm_lost_reason_view_search
 msgid "Include archived"
 msgstr "Incluir arquivados"
+
+#. module: crm
+#: model:crm.lead.tag,name:crm.categ_oppor4
+msgid "Information"
+msgstr "Informação"
 
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
@@ -1077,14 +1096,10 @@ msgid "Internal Notes"
 msgstr "Anotações Internas"
 
 #. module: crm
-#: selection:crm.team,dashboard_graph_model:0
-msgid "Invoices"
-msgstr "Faturas"
-
-#. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_is_follower
+#: model:ir.model.fields,field_description:crm.field_crm_stage__message_is_follower
 msgid "Is Follower"
-msgstr "É Seguidor"
+msgstr "É um Seguidor"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__function
@@ -1163,7 +1178,7 @@ msgid "Late Activities"
 msgstr "Últimas Atividades"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:937
+#: code:addons/crm/models/crm_lead.py:940
 #: selection:crm.activity.report,lead_type:0
 #: selection:crm.lead,type:0
 #: model:ir.model.fields,field_description:crm.field_crm_activity_report__lead_id
@@ -1193,7 +1208,6 @@ msgstr "Prospecção/Oportunidade"
 #. module: crm
 #: model:ir.actions.act_window,name:crm.crm_case_form_view_salesteams_lead
 #: model:ir.actions.act_window,name:crm.crm_lead_all_leads
-#: model:ir.model.fields,field_description:crm.field_contact_config_settings__group_use_lead
 #: model:ir.model.fields,field_description:crm.field_crm_team__use_leads
 #: model:ir.model.fields,field_description:crm.field_res_config_settings__group_use_lead
 #: model:ir.ui.menu,name:crm.crm_menu_leads
@@ -1269,7 +1283,7 @@ msgid "Linked partner (optional). Usually created when converting the lead. You 
 msgstr "Parceiro vinculado (opcional). Normalmente criado ao converter o lead. Você podeencontrar um parceiro pelo seu nome, TIN, e-mail ou referência interna."
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1146
+#: code:addons/crm/models/crm_lead.py:1149
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
 #: model_terms:ir.ui.view,arch_db:crm.crm_opportunity_report_view_search
@@ -1303,11 +1317,16 @@ msgstr "Baixa"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_main_attachment_id
+#: model:ir.model.fields,field_description:crm.field_crm_stage__message_main_attachment_id
 msgid "Main Attachment"
 msgstr "Anexo Principal"
 
 #. module: crm
-#: model:ir.model.fields,field_description:crm.field_contact_config_settings__generate_lead_from_alias
+#: model:mail.activity.type,name:crm.mail_activity_demo_make_quote
+msgid "Make Quote"
+msgstr "Fazer Orçamento"
+
+#. module: crm
 #: model:ir.model.fields,field_description:crm.field_res_config_settings__generate_lead_from_alias
 msgid "Manual Assignation of Emails"
 msgstr "Atribuição Manual de Emails"
@@ -1350,7 +1369,7 @@ msgstr "Marcar como perdido"
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
 msgid "Marketing"
-msgstr "Marketing"
+msgstr ""
 
 #. module: crm
 #: selection:crm.lead,priority:0
@@ -1361,7 +1380,7 @@ msgid "Medium"
 msgstr "Mídia"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:982
+#: code:addons/crm/models/crm_lead.py:985
 #, python-format
 msgid "Meeting scheduled at '%s'<br> Subject: %s <br> Duration: %s hour(s)"
 msgstr "Reunião agendada para '%s'<br> Assunto: %s <br> Duração: %s hora(s)"
@@ -1408,36 +1427,38 @@ msgid "Merge with existing opportunities"
 msgstr "Mesclar com uma oportunidade existente"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:580
+#: code:addons/crm/models/crm_lead.py:583
 #, python-format
 msgid "Merged lead"
 msgstr "Mesclar prospecto"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:612
+#: code:addons/crm/models/crm_lead.py:615
 #, python-format
 msgid "Merged leads"
 msgstr "Prospectos mesclados"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:612
+#: code:addons/crm/models/crm_lead.py:615
 #, python-format
 msgid "Merged opportunities"
 msgstr "Oportunidades mescladas"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:580
+#: code:addons/crm/models/crm_lead.py:583
 #, python-format
 msgid "Merged opportunity"
 msgstr "Oportunidade mesclada"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_has_error
+#: model:ir.model.fields,field_description:crm.field_crm_stage__message_has_error
 msgid "Message Delivery error"
 msgstr "Erro de Entrega de Mensagem"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_ids
+#: model:ir.model.fields,field_description:crm.field_crm_stage__message_ids
 msgid "Messages"
 msgstr "Mensagens"
 
@@ -1481,6 +1502,11 @@ msgid "Name"
 msgstr "Nome"
 
 #. module: crm
+#: model:crm.stage,name:crm.stage_lead1
+msgid "New"
+msgstr "Novo"
+
+#. module: crm
 #: model:ir.model.fields,field_description:crm.field_digest_digest__kpi_crm_lead_created
 msgid "New Leads/Opportunities"
 msgstr "Novos Leads/Oportunidades"
@@ -1498,16 +1524,19 @@ msgstr "Próximas Atividades"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__activity_date_deadline
+#: model:ir.model.fields,field_description:crm.field_crm_stage__activity_date_deadline
 msgid "Next Activity Deadline"
 msgstr "Prazo final para Próxima Atividade"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__activity_summary
+#: model:ir.model.fields,field_description:crm.field_crm_stage__activity_summary
 msgid "Next Activity Summary"
-msgstr "Próximo Sumário de Atividade"
+msgstr "Resumo da Próxima Atividade"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__activity_type_id
+#: model:ir.model.fields,field_description:crm.field_crm_stage__activity_type_id
 msgid "Next Activity Type"
 msgstr "Tipo da Próxima Atividade"
 
@@ -1522,7 +1551,7 @@ msgid "Next activity late"
 msgstr "Próxima atividade atrasada"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1214
+#: code:addons/crm/models/crm_lead.py:1217
 #, python-format
 msgid "No Subject"
 msgstr "Sem Assunto"
@@ -1554,21 +1583,25 @@ msgstr "Anotações"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_needaction_counter
+#: model:ir.model.fields,field_description:crm.field_crm_stage__message_needaction_counter
 msgid "Number of Actions"
 msgstr "Número de Ações"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_has_error_counter
+#: model:ir.model.fields,field_description:crm.field_crm_stage__message_has_error_counter
 msgid "Number of error"
-msgstr "Número de erro"
+msgstr "Número de erros"
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_lead__message_needaction_counter
+#: model:ir.model.fields,help:crm.field_crm_stage__message_needaction_counter
 msgid "Number of messages which requires an action"
 msgstr "Número de mensagens que exigem uma atenção"
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_lead__message_has_error_counter
+#: model:ir.model.fields,help:crm.field_crm_stage__message_has_error_counter
 msgid "Number of messages with delivery error"
 msgstr "Número de mensagens com erro de entrega"
 
@@ -1579,6 +1612,7 @@ msgstr "Número de oportunidades abertas"
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_lead__message_unread_counter
+#: model:ir.model.fields,help:crm.field_crm_stage__message_unread_counter
 msgid "Number of unread messages"
 msgstr "Número de mensagens não lidas"
 
@@ -1656,8 +1690,8 @@ msgid "Opportunities with a date of Expected Closing which is in the past"
 msgstr "Oportunidades com uma data de Encerramento Prevista que está no passado"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:470
-#: code:addons/crm/models/crm_lead.py:912
+#: code:addons/crm/models/crm_lead.py:473
+#: code:addons/crm/models/crm_lead.py:915
 #: selection:crm.activity.report,lead_type:0
 #: selection:crm.lead,type:0
 #: model:ir.model.fields,field_description:crm.field_calendar_event__opportunity_id
@@ -1701,12 +1735,6 @@ msgid "Opportunity Won"
 msgstr "Oportunidade Ganha"
 
 #. module: crm
-#: code:addons/crm/models/res_partner.py:74
-#, python-format
-msgid "Opportunity(s)"
-msgstr "Oportunidade(s)"
-
-#. module: crm
 #: model:mail.message.subtype,description:crm.mt_lead_create
 msgid "Opportunity created"
 msgstr "Oportunidade Criada"
@@ -1722,7 +1750,13 @@ msgid "Opportunity won"
 msgstr "Oportunidade ganha"
 
 #. module: crm
+#: model:crm.lead.tag,name:crm.categ_oppor8
+msgid "Other"
+msgstr "Outros"
+
+#. module: crm
 #: selection:crm.lead,activity_state:0
+#: selection:crm.stage,activity_state:0
 msgid "Overdue"
 msgstr "Vencido"
 
@@ -1732,11 +1766,6 @@ msgid "Overdue Opportunities"
 msgstr "Oportunidades em atraso"
 
 #. module: crm
-#: model:ir.model,name:crm.model_res_partner
-msgid "Partner"
-msgstr "Parceiro"
-
-#. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__partner_address_email
 msgid "Partner Contact Email"
 msgstr "E-mail de Contato do Parceiro"
@@ -1744,7 +1773,7 @@ msgstr "E-mail de Contato do Parceiro"
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__partner_address_mobile
 msgid "Partner Contact Mobile"
-msgstr "Celular do Contato do Parceiro"
+msgstr "Celular de Contato do Parceiro"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__partner_address_name
@@ -1772,13 +1801,17 @@ msgid "Partner/Customer"
 msgstr "Parceiro/Cliente"
 
 #. module: crm
+#: model:ir.ui.menu,name:crm.crm_partner_categ
+msgid "Partners"
+msgstr "Parceiros"
+
+#. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__phone
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
 msgid "Phone"
 msgstr "Telefone"
 
 #. module: crm
-#: model:ir.model.fields,field_description:crm.field_contact_config_settings__module_crm_phone_validation
 #: model:ir.model.fields,field_description:crm.field_res_config_settings__module_crm_phone_validation
 msgid "Phone Formatting"
 msgstr "Formatação do telefone"
@@ -1792,7 +1825,7 @@ msgstr "Formatação do telefone"
 #: model:ir.ui.menu,name:crm.menu_crm_config_lead
 #, python-format
 msgid "Pipeline"
-msgstr "Pipeline"
+msgstr ""
 
 #. module: crm
 #: model:ir.actions.act_window,name:crm.action_report_crm_opportunity_salesteam
@@ -1838,11 +1871,12 @@ msgstr "Pipeline: Receita esperada"
 
 #. module: crm
 #: selection:crm.lead,activity_state:0
+#: selection:crm.stage,activity_state:0
 msgid "Planned"
 msgstr "Planejado"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:684
+#: code:addons/crm/models/crm_lead.py:687
 #, python-format
 msgid "Please select more than one element (lead or opportunity) from the list view."
 msgstr "Por favor escolha mais de um item (prospecto ou oportunidade) na listagem."
@@ -1869,9 +1903,24 @@ msgid "Probability (%)"
 msgstr "Probabilidade (%)"
 
 #. module: crm
+#: model:crm.lead.tag,name:crm.categ_oppor1
+msgid "Product"
+msgstr "Produto"
+
+#. module: crm
+#: model:crm.stage,name:crm.stage_lead3
+msgid "Proposition"
+msgstr "Proposta"
+
+#. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__expected_revenue
 msgid "Prorated Revenue"
 msgstr "Receita rateada"
+
+#. module: crm
+#: model:crm.stage,name:crm.stage_lead2
+msgid "Qualified"
+msgstr "Qualificado"
 
 #. module: crm
 #. openerp-web
@@ -1906,6 +1955,7 @@ msgstr "Pré-requisitos"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__activity_user_id
+#: model:ir.model.fields,field_description:crm.field_crm_stage__activity_user_id
 msgid "Responsible User"
 msgstr "Usuário Responsável"
 
@@ -1916,7 +1966,6 @@ msgid "Restore"
 msgstr "Restaurar"
 
 #. module: crm
-#: selection:crm.team,dashboard_graph_model:0
 #: model:ir.ui.menu,name:crm.crm_menu_sales
 msgid "Sales"
 msgstr "Comercial"
@@ -1947,7 +1996,7 @@ msgid "Sales Team"
 msgstr "Equipe de Vendas"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1149
+#: code:addons/crm/models/crm_lead.py:1152
 #, python-format
 msgid "Sales Team Settings"
 msgstr "Configurações da Equipe de Vendas"
@@ -2002,6 +2051,11 @@ msgid "Sequence"
 msgstr "Seqüência"
 
 #. module: crm
+#: model:crm.lead.tag,name:crm.categ_oppor3
+msgid "Services"
+msgstr "Serviços"
+
+#. module: crm
 #: model_terms:ir.actions.act_window,help:crm.crm_stage_action
 msgid "Set a new stage in your opportunity pipeline"
 msgstr "Definir um novo estágio no seu pipeline de oportunidades"
@@ -2039,6 +2093,11 @@ msgstr "Mostrar somente o prospecto"
 #: model_terms:ir.ui.view,arch_db:crm.crm_opportunity_report_view_search
 msgid "Show only opportunity"
 msgstr "Mostrar apenas oportunidades"
+
+#. module: crm
+#: model:crm.lead.tag,name:crm.categ_oppor2
+msgid "Software"
+msgstr ""
 
 #. module: crm
 #: model_terms:ir.actions.act_window,help:crm.crm_lost_reason_action
@@ -2091,6 +2150,7 @@ msgstr "Estágio Alterado"
 
 #. module: crm
 #: model:ir.actions.act_window,name:crm.crm_stage_action
+#: model:ir.ui.menu,name:crm.menu_crm_lead_stage_act
 #: model_terms:ir.ui.view,arch_db:crm.crm_stage_tree
 msgid "Stages"
 msgstr "Estágios"
@@ -2111,6 +2171,7 @@ msgstr "Estado"
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_lead__activity_state
+#: model:ir.model.fields,help:crm.field_crm_stage__activity_state
 msgid "Status based on activities\n"
 "Overdue: Due date is already passed\n"
 "Today: Activity date is today\n"
@@ -2255,7 +2316,12 @@ msgid "This stage is folded in the kanban view."
 msgstr "Este estágio fica dobrado na visão kanban."
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1112
+#: model:ir.model.fields,help:crm.field_crm_stage__fold_is_empty
+msgid "This stage is folded when empty in the kanban view when there are no records in that stage to display."
+msgstr "Este estágio fica dobrado na visão kanban, quando não existem registros com este estágio para mostrar."
+
+#. module: crm
+#: code:addons/crm/models/crm_lead.py:1115
 #, python-format
 msgid "This target does not exist."
 msgstr "Este destino não existe."
@@ -2269,6 +2335,7 @@ msgstr "Título"
 
 #. module: crm
 #: selection:crm.lead,activity_state:0
+#: selection:crm.stage,activity_state:0
 msgid "Today"
 msgstr "Hoje"
 
@@ -2287,6 +2354,11 @@ msgstr "Muito caro"
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 msgid "Tracking"
 msgstr "Acompanhamento"
+
+#. module: crm
+#: model:crm.lead.tag,name:crm.categ_oppor6
+msgid "Training"
+msgstr "Treinamento"
 
 #. module: crm
 #: model_terms:digest.tip,tip_description:crm.digest_tip_crm_0
@@ -2322,7 +2394,6 @@ msgid "Unassigned Leads"
 msgstr "Leads não atribuídos"
 
 #. module: crm
-#. openerp-web
 #: code:addons/crm/models/crm_team.py:209
 #, python-format
 msgid "Undefined"
@@ -2330,6 +2401,7 @@ msgstr "Indefinido"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_unread
+#: model:ir.model.fields,field_description:crm.field_crm_stage__message_unread
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_kanban_view_leads
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_case_opportunities_filter
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_lead_kanban
@@ -2338,8 +2410,9 @@ msgstr "Mensagens não lidas"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_unread_counter
+#: model:ir.model.fields,field_description:crm.field_crm_stage__message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contagem de Mensagens Não Lidas"
+msgstr "Contador de Mensagens Não Lidas"
 
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.res_config_settings_view_form
@@ -2413,8 +2486,8 @@ msgstr "Usuários"
 
 #. module: crm
 #: selection:crm.lead,priority:0
-msgid "Very Low"
-msgstr "Muito Baixa"
+msgid "Very High"
+msgstr "Muito Elevada"
 
 #. module: crm
 #: model:crm.lost.reason,name:crm.lost_reason_2
@@ -2433,11 +2506,13 @@ msgstr "Website Geração de Líderes"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__website_message_ids
+#: model:ir.model.fields,field_description:crm.field_crm_stage__website_message_ids
 msgid "Website Messages"
 msgstr "Mensagens do Site"
 
 #. module: crm
 #: model:ir.model.fields,help:crm.field_crm_lead__website_message_ids
+#: model:ir.model.fields,help:crm.field_crm_stage__website_message_ids
 msgid "Website communication history"
 msgstr "Histórico de Comunicação do Site"
 
@@ -2467,7 +2542,8 @@ msgid "Within a Year"
 msgstr "Dentro de um ano"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:1145
+#: code:addons/crm/models/crm_lead.py:1148
+#: model:crm.stage,name:crm.stage_lead4
 #: model_terms:ir.ui.view,arch_db:crm.crm_activity_report_view_search
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
@@ -2537,11 +2613,6 @@ msgid "Zip"
 msgstr "CEP"
 
 #. module: crm
-#: model:ir.ui.menu,name:crm.menu_crm_lead_stage_act
-msgid "crm.menu_crm_lead_stage_act"
-msgstr ""
-
-#. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.view_create_opportunity_simplified
 msgid "e.g. Customer Deal"
 msgstr "Ex: Acordo com o cliente"
@@ -2555,10 +2626,10 @@ msgstr "Ex: Preço do Produto"
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_oppor
 msgid "e.g. https://www.odoo.com"
-msgstr "e.x. https://www.example.com"
+msgstr "e.x. https://www.odoo.com"
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:970
+#: code:addons/crm/models/crm_lead.py:973
 #, python-format
 msgid "or send an email to %s"
 msgstr "ou envie um e-mail para %s"
@@ -2569,17 +2640,8 @@ msgid "team_count"
 msgstr ""
 
 #. module: crm
-#: code:addons/crm/models/crm_lead.py:976
+#: code:addons/crm/models/crm_lead.py:979
 #, python-format
 msgid "unknown"
 msgstr "desconhecido"
 
-#. module: crm
-#: model:ir.model.fields,field_description:crm.field_crm_stage__fold
-msgid "Folded in Pipeline"
-msgstr "Dobrado no Pipeline"
-
-#. module: crm
-#: model:ir.model.fields,field_description:crm.field_crm_stage__fold_is_empty
-msgid "Folded in Pipeline When Emptyin"
-msgstr "Dobrado na Pipeline quando Vazio"

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -883,9 +883,14 @@ for rec in records:
             action="sales_team.crm_team_salesteams_act"
             sequence="4"/>
 
+        <menuitem id="crm_partner_categ"
+            name="Partners"
+            parent="crm_menu_root"
+            sequence="5"/>
+
         <menuitem id="res_partner_menu_customer"
             name="Customers"
-            parent="crm_menu_sales"
+            parent="crm_partner_categ"
             action="base.action_partner_form"
             sequence="5"/>
 

--- a/addons/mail/i18n/pt_BR.po
+++ b/addons/mail/i18n/pt_BR.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-23 14:05+0000\n"
-"PO-Revision-Date: 2023-10-23 14:05+0000\n"
+"POT-Creation-Date: 2023-12-21 18:15+0000\n"
+"PO-Revision-Date: 2023-12-21 18:15+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -768,6 +768,13 @@ msgid "Assigned user %s has no access to the document and is not able to handle 
 msgstr "O usuário atribuído %s não tem acesso ao documento e não pode lidar com esta atividade."
 
 #. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/xml/systray.xml:94
+#, python-format
+msgid "Atrasado"
+msgstr ""
+
+#. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.email_compose_message_wizard_form
 msgid "Attach a file"
 msgstr "Anexar um arquivo"
@@ -806,11 +813,6 @@ msgstr "Anexos"
 #: model:ir.model.fields,help:mail.field_mail_message__attachment_ids
 msgid "Attachments are linked to a document through model / res_id and to the message through this field."
 msgstr "Anexos estão ligados a um documento através de modelo / res_id e à mensagem através deste campo."
-
-#. module: mail
-#: selection:mail.alias,alias_contact:0
-msgid "Authenticated Employees"
-msgstr "Funcionários Autenticados"
 
 #. module: mail
 #: selection:mail.alias,alias_contact:0
@@ -1284,6 +1286,11 @@ msgid "Connection failed (outgoing mail server problem)"
 msgstr "Falha na conexão (problema no servidor de saída)"
 
 #. module: mail
+#: model:ir.model,name:mail.model_res_partner
+msgid "Contact"
+msgstr "Contato"
+
+#. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.email_template_form
 #: model_terms:ir.ui.view,arch_db:mail.view_message_search
 msgid "Content"
@@ -1428,18 +1435,6 @@ msgid "Current user is a moderator of the channel"
 msgstr "O usuário atual é um moderador do canal"
 
 #. module: mail
-#: selection:ir.actions.act_window.view,view_mode:0
-#: selection:ir.ui.view,type:0
-msgid "Custom Info"
-msgstr "Informação Personalizada"
-
-#. module: mail
-#: selection:ir.actions.act_window.view,view_mode:0
-#: selection:ir.ui.view,type:0
-msgid "Dashboard"
-msgstr "Painel"
-
-#. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__date
 #: model:ir.model.fields,field_description:mail.field_mail_mail__date
 #: model:ir.model.fields,field_description:mail.field_mail_message__date
@@ -1461,7 +1456,7 @@ msgstr "Dias"
 
 #. module: mail
 #. openerp-web
-#: code:addons/mail/static/src/xml/web_kanban_activity.xml:52
+#: code:addons/mail/static/src/xml/web_kanban_activity.xml:54
 #: model_terms:ir.ui.view,arch_db:mail.mail_activity_view_search
 #, python-format
 msgid "Deadline"
@@ -1723,6 +1718,13 @@ msgstr "Documento não baixável"
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/xml/activity.xml:101
+#, python-format
+msgid "Done"
+msgstr "Concluído"
+
+#. module: mail
+#. openerp-web
 #: code:addons/mail/static/src/xml/activity.xml:105
 #: model_terms:ir.ui.view,arch_db:mail.mail_activity_view_form_popup
 #, python-format
@@ -1736,15 +1738,6 @@ msgstr "Concluído e iniciar Próximo"
 #, python-format
 msgid "Done & Schedule Next"
 msgstr "Pronto e Programar Próximo"
-
-#. module: mail
-#. openerp-web
-#: code:addons/mail/static/src/xml/activity.xml:101
-#: model_terms:ir.ui.view,arch_db:mail.mail_activity_view_form_popup
-#: selection:mail.activity,state:0
-#, python-format
-msgid "Done"
-msgstr "Concluído"
 
 #. module: mail
 #. openerp-web
@@ -2243,6 +2236,13 @@ msgid "Future Activities"
 msgstr "Atividades Futuras"
 
 #. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/xml/systray.xml:98
+#, python-format
+msgid "Futuro"
+msgstr ""
+
+#. module: mail
 #: selection:ir.actions.act_window.view,view_mode:0
 #: selection:ir.ui.view,type:0
 msgid "Gantt"
@@ -2369,6 +2369,13 @@ msgid "Hide the subtype in the follower options"
 msgstr "Esconder o subtipo nas opções dos seguidores"
 
 #. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/xml/systray.xml:96
+#, python-format
+msgid "Hoje"
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,field_description:mail.field_email_template_preview__id
 #: model:ir.model.fields,field_description:mail.field_mail_activity__id
 #: model:ir.model.fields,field_description:mail.field_mail_activity_mixin__id
@@ -2396,7 +2403,7 @@ msgstr "Esconder o subtipo nas opções dos seguidores"
 #: model:ir.model.fields,field_description:mail.field_mail_wizard_invite__id
 #: model:ir.model.fields,field_description:mail.field_publisher_warranty_contract__id
 msgid "ID"
-msgstr "Id."
+msgstr ""
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_mail_alias__alias_parent_thread_id
@@ -2878,7 +2885,7 @@ msgstr "Carregando mensagens anteriores..."
 
 #. module: mail
 #. openerp-web
-#: code:addons/mail/static/src/xml/web_kanban_activity.xml:21
+#: code:addons/mail/static/src/xml/web_kanban_activity.xml:23
 #, python-format
 msgid "Loading..."
 msgstr "Carregando..."
@@ -2886,7 +2893,7 @@ msgstr "Carregando..."
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/js/composers/chatter_composer.js:35
-#: code:addons/mail/static/src/xml/web_kanban_activity.xml:47
+#: code:addons/mail/static/src/xml/web_kanban_activity.xml:49
 #: model_terms:ir.ui.view,arch_db:mail.email_compose_message_wizard_form
 #, python-format
 msgid "Log"
@@ -2932,7 +2939,7 @@ msgstr "Registrar ou agendar uma atividade"
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/xml/activity.xml:68
-#: code:addons/mail/static/src/xml/web_kanban_activity.xml:57
+#: code:addons/mail/static/src/xml/web_kanban_activity.xml:59
 #: model:ir.model.fields,field_description:mail.field_mail_notification__mail_id
 #, python-format
 msgid "Mail"
@@ -3076,7 +3083,7 @@ msgstr "Marcar como Para Fazer"
 
 #. module: mail
 #. openerp-web
-#: code:addons/mail/static/src/xml/web_kanban_activity.xml:77
+#: code:addons/mail/static/src/xml/web_kanban_activity.xml:79
 #, python-format
 msgid "Mark as done"
 msgstr "Marcar como Completo"
@@ -3104,7 +3111,6 @@ msgid "Medium-sized photo of the group. It is automatically resized as a 128x128
 msgstr "Foto de tamanho médio para o grupo. Ela será automaticamente redimensionada para 128x128 pixels, com a relação de aspecto preservada. Utilize este campo nas visões de formulário ou em algumas visões kanban."
 
 #. module: mail
-#: selection:mail.activity.type,category:0
 #: model:mail.activity.type,name:mail.mail_activity_data_meeting
 msgid "Meeting"
 msgstr "Reunião"
@@ -3600,7 +3606,7 @@ msgstr "Sem erro"
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/xml/systray.xml:68
-#: code:addons/mail/static/src/xml/web_kanban_activity.xml:26
+#: code:addons/mail/static/src/xml/web_kanban_activity.xml:28
 #, python-format
 msgid "No activities planned."
 msgstr "Nenhuma atividade agendada"
@@ -3778,7 +3784,7 @@ msgstr "MultiERP"
 #: code:addons/mail/static/src/xml/discuss.xml:158
 #, python-format
 msgid "Offline"
-msgstr ""
+msgstr "Desligado"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_tracking_value__old_value_char
@@ -4040,7 +4046,6 @@ msgid "Parent subtype, used for automatic subscription. This field is not correc
 msgstr "Subtipo pai, usado para a subscrição automática. Este campo não está corretamente identificado. Por exemplo, em um projeto, o parent_id dos subtipos do projeto refere-se a subtipos relacionados a tarefas."
 
 #. module: mail
-#: model:ir.model,name:mail.model_res_partner
 #: model:ir.model.fields,field_description:mail.field_mail_resend_partner__partner_id
 msgid "Partner"
 msgstr "Parceiro"
@@ -4235,7 +4240,7 @@ msgstr "Endereço de resposta preferido (placeholders podem ser usados aqui)"
 #. openerp-web
 #: code:addons/mail/static/src/xml/activity.xml:70
 #: code:addons/mail/static/src/xml/discuss.xml:276
-#: code:addons/mail/static/src/xml/web_kanban_activity.xml:60
+#: code:addons/mail/static/src/xml/web_kanban_activity.xml:62
 #: model_terms:ir.ui.view,arch_db:mail.email_template_form
 #, python-format
 msgid "Preview"
@@ -4375,11 +4380,6 @@ msgid "References"
 msgstr "Referências"
 
 #. module: mail
-#: selection:ir.actions.server,state:0
-msgid "Refresh Views"
-msgstr "Atualizar Visualizações"
-
-#. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_bounce_catchall
 msgid "Regards,"
 msgstr "Saudações,"
@@ -4451,11 +4451,6 @@ msgstr "Parceiro Relacionado"
 #: model:ir.model.fields,field_description:mail.field_mail_message_subtype__relation_field
 msgid "Relation field"
 msgstr "Campo da relação"
-
-#. module: mail
-#: selection:mail.activity.type,category:0
-msgid "Reminder"
-msgstr "Lembrar"
 
 #. module: mail
 #. openerp-web
@@ -4619,7 +4614,7 @@ msgstr "Agendar uma atividade"
 
 #. module: mail
 #. openerp-web
-#: code:addons/mail/static/src/xml/web_kanban_activity.xml:88
+#: code:addons/mail/static/src/xml/web_kanban_activity.xml:90
 #, python-format
 msgid "Schedule an activity"
 msgstr "Agendar uma atividade"
@@ -4719,7 +4714,7 @@ msgstr "Enviar E-mail (%s)"
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/xml/activity.xml:72
-#: code:addons/mail/static/src/xml/web_kanban_activity.xml:62
+#: code:addons/mail/static/src/xml/web_kanban_activity.xml:64
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_form
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_tree
 #, python-format
@@ -5488,18 +5483,13 @@ msgid "Use your own email servers"
 msgstr "Use seus próprios servidores de email"
 
 #. module: mail
-#: model:ir.model.fields,help:mail.field_mail_activity__display_name
-msgid "Used to diplay a name for the activity based on partner's name."
-msgstr "Usado para exibir um nome para a atividade com base no nome do parceiro."
-
-#. module: mail
 #: model:ir.model.fields,help:mail.field_mail_message_subtype__sequence
 msgid "Used to order subtypes."
 msgstr "Utilizar para os demais subtipos"
 
 #. module: mail
 #. openerp-web
-#: code:addons/mail/static/src/xml/web_kanban_activity.xml:67
+#: code:addons/mail/static/src/xml/web_kanban_activity.xml:69
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_alias_search
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_form
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_tree
@@ -5938,6 +5928,11 @@ msgid "assigned you an activity"
 msgstr "atribuiu a você uma atividade"
 
 #. module: mail
+#: model:mail.channel,name:mail.channel_2
+msgid "board-meetings"
+msgstr ""
+
+#. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/xml/activity.xml:43
 #: model_terms:ir.ui.view,arch_db:mail.message_notification_email
@@ -6087,7 +6082,7 @@ msgstr "ligado"
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/xml/activity.xml:71
-#: code:addons/mail/static/src/xml/web_kanban_activity.xml:61
+#: code:addons/mail/static/src/xml/web_kanban_activity.xml:63
 #, python-format
 msgid "or"
 msgstr "ou"
@@ -6103,6 +6098,11 @@ msgstr "postar uma mensagem sem modelo deve ser com um res_id nulo (mensagem pri
 #, python-format
 msgid "posting a message without model should be with a parent_id (private message)"
 msgstr "postar uma mensagem sem modelo deve ser com um parent_id (mensagem privada)"
+
+#. module: mail
+#: model:mail.channel,name:mail.channel_3
+msgid "rd"
+msgstr ""
 
 #. module: mail
 #. openerp-web
@@ -6160,6 +6160,11 @@ msgid "restricted to known authors"
 msgstr "restrito a autores conhecidos"
 
 #. module: mail
+#: model:mail.channel,name:mail.channel_1
+msgid "sales"
+msgstr ""
+
+#. module: mail
 #: code:addons/mail/models/mail_thread.py:1039
 #: code:addons/mail/models/mail_thread.py:1057
 #: code:addons/mail/models/mail_thread.py:1060
@@ -6215,3 +6220,4 @@ msgstr "usando"
 #: selection:mail.activity.type,delay_unit:0
 msgid "weeks"
 msgstr "semanas"
+

--- a/addons/mail/static/src/xml/web_kanban_activity.xml
+++ b/addons/mail/static/src/xml/web_kanban_activity.xml
@@ -4,7 +4,9 @@
 <t t-name="mail.KanbanActivity">
     <div class="o_kanban_inline_block dropdown o_kanban_selection o_mail_activity">
         <a class="dropdown-toggle o-no-caret o_activity_btn" data-toggle="dropdown" role="button">
-            <span class="fa fa-clock-o fa-lg fa-fw" t-att-title="widget.selection[widget.activityState]" role="img" t-att-aria-label="widget.selection[widget.activity_state]"/>
+            <span class="fa fa-clock-o fa-lg fa-fw" role="img"
+                  t-att-title="widget.selection[widget.activityState] || 'No Activities'"
+                  t-att-aria-label="widget.selection[widget.activity_state] || 'No Activities'"/>
         </a>
         <div class="dropdown-menu o_activity" role="menu"/>
     </div>

--- a/addons/stock/i18n/pt_BR.po
+++ b/addons/stock/i18n/pt_BR.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-20 18:22+0000\n"
-"PO-Revision-Date: 2022-12-20 18:22+0000\n"
+"POT-Creation-Date: 2023-12-21 18:21+0000\n"
+"PO-Revision-Date: 2023-12-21 18:21+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -426,6 +426,12 @@ msgid "Activity State"
 msgstr "Estado de Atividade"
 
 #. module: stock
+#: model:ir.model.fields,field_description:stock.field_stock_picking__activity_type_icon
+#: model:ir.model.fields,field_description:stock.field_stock_production_lot__activity_type_icon
+msgid "Activity Type Icon"
+msgstr "Ícone de Tipo de Atividade"
+
+#. module: stock
 #: model_terms:ir.actions.act_window,help:stock.action_production_lot_form
 msgid "Add a lot/serial number"
 msgstr "Adicione número de lote/série"
@@ -729,11 +735,6 @@ msgid "Bulk Content"
 msgstr "Conteúdo em Massa"
 
 #. module: stock
-#: selection:stock.rule,action:0
-msgid "Buy"
-msgstr "Comprar"
-
-#. module: stock
 #: selection:product.template,tracking:0
 msgid "By Lots"
 msgstr "Por Lotes"
@@ -758,6 +759,12 @@ msgstr "Por padrão, o sistema terá de o estoque no local de origem e passivame
 #: model:ir.model.fields,help:stock.field_stock_location__active
 msgid "By unchecking the active field, you may hide a location without deleting it."
 msgstr "Desmarcando o campo Ativo, você pode esconder o local sem excluí-lo."
+
+#. module: stock
+#: model:product.product,name:stock.product_cable_management_box
+#: model:product.template,name:stock.product_cable_management_box_product_template
+msgid "Cable Management Box"
+msgstr ""
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_picking_calendar
@@ -812,11 +819,6 @@ msgstr "Movimentos Cancelados"
 #, python-format
 msgid "Cannot set the done quantity from this stock move, work directly with the move lines."
 msgstr "Não é possível definir a quantidade feita a partir deste movimento de estoque, trabalhar diretamente com as linhas de movimento."
-
-#. module: stock
-#: selection:barcode.rule,type:0
-msgid "Cashier"
-msgstr "Caixa"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_replenish__product_uom_category_id
@@ -892,7 +894,7 @@ msgid "Choose a date to get the inventory at that date"
 msgstr "Escolha uma data para obter o inventário nessa data"
 
 #. module: stock
-#: code:addons/stock/models/stock_picking.py:1029
+#: code:addons/stock/models/stock_picking.py:1032
 #, python-format
 msgid "Choose destination location"
 msgstr "Escolha a localização do destino"
@@ -906,11 +908,6 @@ msgstr "Escolha analisar o inventário atual ou a partir de uma data específica
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_quantity_history
 msgid "Choose your date"
 msgstr "Escolha a sua data"
-
-#. module: stock
-#: selection:barcode.rule,type:0
-msgid "Client"
-msgstr "Cliente"
 
 #. module: stock
 #. openerp-web
@@ -1028,6 +1025,11 @@ msgid "Consume Line"
 msgstr "Linha de Consumo"
 
 #. module: stock
+#: model:ir.model,name:stock.model_res_partner
+msgid "Contact"
+msgstr "Contato"
+
+#. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_location__child_ids
 msgid "Contains"
 msgstr "Contém"
@@ -1101,7 +1103,7 @@ msgid "Create Backorder"
 msgstr "Criar nova Movimentação"
 
 #. module: stock
-#: code:addons/stock/models/stock_picking.py:779
+#: code:addons/stock/models/stock_picking.py:782
 #, python-format
 msgid "Create Backorder?"
 msgstr "Criar nova Movimentação?"
@@ -1333,8 +1335,8 @@ msgstr "Clientes"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__module_delivery_dhl
-msgid "DHL Connector"
-msgstr "Conector DHL"
+msgid "DHL USA"
+msgstr ""
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_report_stock_forecast__date
@@ -1504,6 +1506,7 @@ msgstr "Entregas"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:783
+#: model:stock.picking.type,name:stock.chi_picking_type_out
 #: model:stock.picking.type,name:stock.picking_type_out
 #, python-format
 msgid "Delivery Orders"
@@ -1654,11 +1657,6 @@ msgid "Discard"
 msgstr "Descartar"
 
 #. module: stock
-#: selection:barcode.rule,type:0
-msgid "Discounted Product"
-msgstr "Produto Descontado"
-
-#. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__group_lot_on_delivery_slip
 msgid "Display Lots & Serial Numbers"
 msgstr "Exibir Lotes e Números de Série"
@@ -1716,7 +1714,7 @@ msgstr "Exibir Número de Série e de Lote nas Guias de Remessa"
 #: model_terms:ir.ui.view,arch_db:stock.stock_move_line_view_search
 #: model_terms:ir.ui.view,arch_db:stock.stock_scrap_form_view2
 #: model_terms:ir.ui.view,arch_db:stock.view_move_search
-#: model_terms:ir.ui.view,arch_db:stock.view_picking_form
+#: model_terms:ir.ui.view,arch_db:stock.view_picking_details_move_tree
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_internal_search
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_move_tree
 #: selection:stock.move,state:0
@@ -1758,8 +1756,8 @@ msgstr "Movimentos Provisórios"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__module_delivery_easypost
-msgid "Easypost Connector"
-msgstr "Conector Easypost"
+msgid "Easypost"
+msgstr ""
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
@@ -1780,11 +1778,6 @@ msgstr "Certifique-se da rastreabilidade de um produto estocável em seu armazé
 #: code:addons/stock/models/stock_warehouse.py:463
 #, python-format
 msgid "Entrada"
-msgstr ""
-
-#. module: stock
-#: model:stock.picking.type,name:stock.picking_type_in
-msgid "Entradas"
 msgstr ""
 
 #. module: stock
@@ -1846,8 +1839,8 @@ msgstr ""
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__module_delivery_fedex
-msgid "FedEx Connector"
-msgstr "Conector FedEx"
+msgid "FedEx"
+msgstr ""
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_package_destination__filtered_location
@@ -1908,6 +1901,12 @@ msgstr "Seguidores (Canais)"
 #: model:ir.model.fields,field_description:stock.field_stock_production_lot__message_partner_ids
 msgid "Followers (Partners)"
 msgstr "Seguidores (Parceiros)"
+
+#. module: stock
+#: model:ir.model.fields,help:stock.field_stock_picking__activity_type_icon
+#: model:ir.model.fields,help:stock.field_stock_production_lot__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr "Ícone do Font Awesome. Ex: fa-tasks"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_product_category__removal_strategy_id
@@ -2118,7 +2117,7 @@ msgstr "Aqui você pode receber produtos individuais, não importa\n"
 #: model:ir.model.fields,field_description:stock.field_stock_warn_insufficient_qty__id
 #: model:ir.model.fields,field_description:stock.field_stock_warn_insufficient_qty_scrap__id
 msgid "ID"
-msgstr "Id."
+msgstr ""
 
 #. module: stock
 #: code:addons/stock/models/stock_inventory.py:436
@@ -2147,7 +2146,7 @@ msgstr "Se marcado, novas mensagens solicitarão sua atenção."
 #: model:ir.model.fields,help:stock.field_stock_picking__message_needaction
 #: model:ir.model.fields,help:stock.field_stock_production_lot__message_needaction
 msgid "If checked, new messages require your attention."
-msgstr "Se marcado novas mensagens solicitarão sua atenção."
+msgstr "Se marcado, novas mensagens solicitarão sua atenção."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking__message_has_error
@@ -2241,7 +2240,7 @@ msgid "Immediate Transfer"
 msgstr "Transferir Imediatamente"
 
 #. module: stock
-#: code:addons/stock/models/stock_picking.py:742
+#: code:addons/stock/models/stock_picking.py:745
 #, python-format
 msgid "Immediate Transfer?"
 msgstr "Transferir Imediatamente ?"
@@ -2297,7 +2296,7 @@ msgstr "Remessas Recebidas"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__product_uom_qty
 #: model_terms:ir.ui.view,arch_db:stock.view_move_kandan
-#: model_terms:ir.ui.view,arch_db:stock.view_picking_form
+#: model_terms:ir.ui.view,arch_db:stock.view_picking_details_move_tree
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_move_tree
 msgid "Initial Demand"
 msgstr "Demanda Inicial"
@@ -2567,12 +2566,6 @@ msgstr "É uma quantidade concluída editável"
 #, python-format
 msgid "It is not possible to reserve more products of %s than you have in stock."
 msgstr "Não é possível reservar mais produtos de %s do que você tem em estoque."
-
-#. module: stock
-#: code:addons/stock/models/stock_quant.py:274
-#, python-format
-msgid "It is not possible to unreserve more products of %s than you have in stock."
-msgstr "Não é possível conservar sem reservas mais produtos de %s do que os que você tem em estoque."
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__product_packaging
@@ -3025,11 +3018,6 @@ msgid "Mark as Todo"
 msgstr "Marcar como Para Fazer"
 
 #. module: stock
-#: model:ir.model.fields,help:stock.field_stock_inventory__exhausted
-msgid "Marque para que também sejam incluídos produtos sem estoque (quantidade em estoque zeradas)."
-msgstr ""
-
-#. module: stock
 #: model:ir.ui.menu,name:stock.menu_stock_inventory_control
 msgid "Master Data"
 msgstr "Dados Principais"
@@ -3214,7 +3202,7 @@ msgstr "Novo"
 
 #. module: stock
 #: code:addons/stock/models/stock_move_line.py:182
-#: code:addons/stock/models/stock_picking.py:627
+#: code:addons/stock/models/stock_picking.py:630
 #, python-format
 msgid "New Move:"
 msgstr "Novo Movimento:"
@@ -3239,7 +3227,7 @@ msgstr "Prazo final para Próxima Atividade"
 #: model:ir.model.fields,field_description:stock.field_stock_picking__activity_summary
 #: model:ir.model.fields,field_description:stock.field_stock_production_lot__activity_summary
 msgid "Next Activity Summary"
-msgstr "Próximo Sumário de Atividade"
+msgstr "Resumo da Próxima Atividade"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__activity_type_id
@@ -3333,7 +3321,7 @@ msgid "Notes"
 msgstr "Anotações"
 
 #. module: stock
-#: code:addons/stock/models/stock_picking.py:577
+#: code:addons/stock/models/stock_picking.py:580
 #, python-format
 msgid "Nothing to check the availability for."
 msgstr "Nada para verificar a disponibilidade para."
@@ -3342,7 +3330,7 @@ msgstr "Nada para verificar a disponibilidade para."
 #: model:ir.model.fields,field_description:stock.field_stock_picking__message_needaction_counter
 #: model:ir.model.fields,field_description:stock.field_stock_production_lot__message_needaction_counter
 msgid "Number of Actions"
-msgstr "Número de ações"
+msgstr "Número de Ações"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_warehouse_orderpoint__lead_days
@@ -3767,7 +3755,6 @@ msgid "Partially Available"
 msgstr "Parcialmente Disponível"
 
 #. module: stock
-#: model:ir.model,name:stock.model_res_partner
 #: model:ir.model.fields,field_description:stock.field_procurement_group__partner_id
 #: model:ir.model.fields,field_description:stock.field_stock_picking__partner_id
 #: model_terms:ir.ui.view,arch_db:stock.view_move_search
@@ -3874,7 +3861,7 @@ msgid "Planned Transfer"
 msgstr "Transferência Planejada"
 
 #. module: stock
-#: code:addons/stock/models/stock_picking.py:714
+#: code:addons/stock/models/stock_picking.py:717
 #, python-format
 msgid "Please add some items to move."
 msgstr "Por favor, adicione alguns itens para mover."
@@ -3886,7 +3873,7 @@ msgid "Please check the following serial number (name, id): "
 msgstr "Verifique o seguinte número de série (nome, id): "
 
 #. module: stock
-#: code:addons/stock/wizard/stock_picking_return.py:159
+#: code:addons/stock/wizard/stock_picking_return.py:174
 #, python-format
 msgid "Please specify at least one non-zero quantity."
 msgstr "Por favor espeficique pelo menos uma quantidade diferente de zero."
@@ -3910,11 +3897,6 @@ msgstr "Rotas Preferencial"
 #: model:ir.model.fields,help:stock.field_stock_move__route_ids
 msgid "Preferred route"
 msgstr "Rota preferida"
-
-#. module: stock
-#: selection:barcode.rule,type:0
-msgid "Priced Product"
-msgstr "Produto Precificado"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
@@ -4413,6 +4395,8 @@ msgstr "Rota de Recebimento"
 
 #. module: stock
 #: code:addons/stock/models/stock_warehouse.py:775
+#: model:stock.picking.type,name:stock.chi_picking_type_in
+#: model:stock.picking.type,name:stock.picking_type_in
 #, python-format
 msgid "Receipts"
 msgstr "Recebimentos"
@@ -4500,7 +4484,7 @@ msgstr "Registrar um recibo de produto"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_move_kandan
-#: model_terms:ir.ui.view,arch_db:stock.view_picking_form
+#: model_terms:ir.ui.view,arch_db:stock.view_picking_details_move_tree
 msgid "Register lots, packs, location"
 msgstr "Registre lotes, pacotes, localização"
 
@@ -4599,7 +4583,7 @@ msgstr "Reservas"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__product_uom_qty
 #: model_terms:ir.ui.view,arch_db:stock.view_move_picking_form
-#: model_terms:ir.ui.view,arch_db:stock.view_picking_form
+#: model_terms:ir.ui.view,arch_db:stock.view_picking_details_move_tree
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_move_tree
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_quant_tree
 #: selection:stock.package_level,state:0
@@ -4676,13 +4660,13 @@ msgid "Return Picking Line"
 msgstr "Linha de Retorno de Coleta"
 
 #. module: stock
-#: code:addons/stock/wizard/stock_picking_return.py:116
+#: code:addons/stock/wizard/stock_picking_return.py:122
 #, python-format
 msgid "Return of %s"
 msgstr "Retorno de %s"
 
 #. module: stock
-#: code:addons/stock/wizard/stock_picking_return.py:180
+#: code:addons/stock/wizard/stock_picking_return.py:195
 #, python-format
 msgid "Returned Picking"
 msgstr "Separação Devolvida"
@@ -4793,7 +4777,7 @@ msgid "Scheduled time for the first part of the shipment to be processed. Settin
 msgstr "Hora agendada para a primeira parte da remessa a ser processada. Definir manualmente um valor aqui seria defini-lo como data prevista para todas as movimentações estoque."
 
 #. module: stock
-#: code:addons/stock/models/stock_picking.py:1100
+#: code:addons/stock/models/stock_picking.py:1103
 #: model:ir.model,name:stock.model_stock_scrap
 #: model:ir.model.fields,field_description:stock.field_stock_move__scrap_ids
 #: model:ir.model.fields,field_description:stock.field_stock_warn_insufficient_qty_scrap__scrap_id
@@ -5240,7 +5224,7 @@ msgstr "Movimento de Estoque"
 #: model_terms:ir.ui.view,arch_db:stock.view_move_picking_form
 #: model_terms:ir.ui.view,arch_db:stock.view_move_picking_tree
 #: model_terms:ir.ui.view,arch_db:stock.view_move_search
-#: model_terms:ir.ui.view,arch_db:stock.view_picking_form
+#: model_terms:ir.ui.view,arch_db:stock.view_picking_details_move_tree
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_move_tree
 msgid "Stock Moves"
 msgstr "Movimentos de Estoque"
@@ -5449,7 +5433,7 @@ msgid "The 'Manual Operation' value will create a stock move after the current o
 msgstr "O valor 'Operação Manual' criará um movimento de estoque após o atual. Com a opção 'Sem acréscimo automático de etapas', a localização é substituída na movimentação original."
 
 #. module: stock
-#: code:addons/stock/models/stock_picking.py:848
+#: code:addons/stock/models/stock_picking.py:851
 #, python-format
 msgid "The backorder <a href=# data-oe-model=stock.picking data-oe-id=%d>%s</a> has been created."
 msgstr "O pedido em atraso <a href=# data-oe-model=stock.picking data-oe-id=%d>%s</a> foi criado."
@@ -5870,13 +5854,13 @@ msgstr "Tipo de operação"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__module_delivery_ups
-msgid "UPS Connector"
-msgstr "Conector UPS"
+msgid "UPS"
+msgstr ""
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__module_delivery_usps
-msgid "USPS Connector"
-msgstr "Conector USPS"
+msgid "USPS"
+msgstr ""
 
 #. module: stock
 #. openerp-web
@@ -5922,7 +5906,7 @@ msgstr "Produto Unitário"
 #: model_terms:ir.ui.view,arch_db:stock.view_move_tree
 #: model_terms:ir.ui.view,arch_db:stock.view_move_tree_receipt_picking
 #: model_terms:ir.ui.view,arch_db:stock.view_move_tree_receipt_picking_board
-#: model_terms:ir.ui.view,arch_db:stock.view_picking_form
+#: model_terms:ir.ui.view,arch_db:stock.view_picking_details_move_tree
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_move_tree
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_move_line_kanban
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_move_line_operation_tree
@@ -5950,13 +5934,13 @@ msgid "Unity of measure"
 msgstr "Unidade de medida"
 
 #. module: stock
-#: code:addons/stock/models/stock_picking.py:909
+#: code:addons/stock/models/stock_picking.py:912
 #, python-format
 msgid "Unknow stream."
 msgstr "Fluxo de desconhecimento."
 
 #. module: stock
-#: code:addons/stock/models/stock_quant.py:356
+#: code:addons/stock/models/stock_quant.py:359
 #, python-format
 msgid "Unknown Pack"
 msgstr "Pacote Desconhecido"
@@ -6335,6 +6319,11 @@ msgid "Whether the move was added after the picking's confirmation"
 msgstr "Se a mudança foi adicionada após a confirmação da coleta"
 
 #. module: stock
+#: model_terms:ir.ui.view,arch_db:stock.quant_search_view
+msgid "With Stock"
+msgstr "Com Saldo"
+
+#. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_return_picking_line__wizard_id
 #: model:ir.model.fields,field_description:stock.field_stock_track_line__wizard_id
 msgid "Wizard"
@@ -6515,13 +6504,13 @@ msgid "You cannot use the same serial number twice. Please correct the serial nu
 msgstr "Não se pode usar o mesmo número de série duas vezes. Por favor, corrija os números de série codificados."
 
 #. module: stock
-#: code:addons/stock/models/stock_picking.py:722
+#: code:addons/stock/models/stock_picking.py:725
 #, python-format
 msgid "You cannot validate a transfer if no quantites are reserved nor done. To force the transfer, switch in edit more and encode the done quantities."
 msgstr "Não é possível validar uma transferência se nenhuma quantidade for reservada ou feita. Para forçar a transferência, mude para editar mais e codificar as quantidades feitas."
 
 #. module: stock
-#: code:addons/stock/wizard/stock_picking_return.py:125
+#: code:addons/stock/wizard/stock_picking_return.py:140
 #, python-format
 msgid "You have manually created product lines, please delete them to proceed."
 msgstr "Você criou manualmente linhas de produtos, por favor, apague-as para prosseguir."
@@ -6551,7 +6540,7 @@ msgid "You have products in stock that have no lot number.  You can assign seria
 msgstr "Você tem produtos no estoque que não têm número de lote. Você pode atribuir números de série, fazendo um inventário.  "
 
 #. module: stock
-#: code:addons/stock/models/stock_picking.py:893
+#: code:addons/stock/models/stock_picking.py:896
 #, python-format
 msgid "You have to define a groupby and sorted method and pass them as arguments."
 msgstr "Você tem que definir um método agrupado e classificado e passá-los como argumentos."
@@ -6587,14 +6576,14 @@ msgid "You must define a warehouse for the company: %s."
 msgstr "É necessário definir um armazém para a empresa: %s."
 
 #. module: stock
-#: code:addons/stock/models/stock_picking.py:1083
+#: code:addons/stock/models/stock_picking.py:1086
 #, python-format
 msgid "You must first set the quantity you will put in the pack."
 msgstr "É necessário definir a quantidade que será colocado na embalagem."
 
 #. module: stock
 #: code:addons/stock/models/stock_move_line.py:419
-#: code:addons/stock/models/stock_picking.py:736
+#: code:addons/stock/models/stock_picking.py:739
 #, python-format
 msgid "You need to supply a Lot/Serial number for product %s."
 msgstr "Você precisa fornecer um número de lote/série para o produto %s."
@@ -6631,8 +6620,8 @@ msgstr "_Cancelar"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_res_config_settings__module_delivery_bpost
-msgid "bpost Connector"
-msgstr "Conector bpost"
+msgid "bpost"
+msgstr ""
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_template_property_form
@@ -6671,6 +6660,14 @@ msgid "is not available in sufficient quantity"
 msgstr "não está disponível em quantidade suficiente"
 
 #. module: stock
+#: model:product.product,uom_name:stock.product_cable_management_box
+#: model:product.product,weight_uom_name:stock.product_cable_management_box
+#: model:product.template,uom_name:stock.product_cable_management_box_product_template
+#: model:product.template,weight_uom_name:stock.product_cable_management_box_product_template
+msgid "kg"
+msgstr ""
+
+#. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_warehouse_orderpoint_form
 msgid "manually to trigger the reordering rules right now."
 msgstr "manualmente para acionar as regras de reordenação agora mesmo."
@@ -6690,7 +6687,3 @@ msgstr "processado em vez de"
 msgid "⇒ Set quantities to 0"
 msgstr "⇒ Definir quantidades para 0"
 
-#. module: stock
-#: model_terms:ir.ui.view,arch_db:stock.quant_search_view
-msgid "With Stock"
-msgstr "Com Saldo"

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -98,6 +98,43 @@
             </field>
         </record>
 
+        <record id="view_picking_details_move_tree" model="ir.ui.view">
+            <field name="name">stock.picking.details.move.tree</field>
+            <field name="model">stock.move</field>
+            <field eval="90" name="priority"/>
+            <field name="arch" type="xml">
+                <tree limit="500"
+                      create="0" delete="0"
+                      string="Stock Moves" editable="bottom"
+                      decoration-danger="not parent.immediate_transfer and state != 'done' and quantity_done > reserved_availability and show_reserved_availability"
+                      decoration-muted="scrapped == True or state == 'cancel' or (state == 'done' and is_locked == True)">
+                    <field name="name" invisible="1"/>
+                    <field name="date_expected" invisible="1"/>
+                    <field name="state" invisible="1" readonly="0"/>
+                    <field name="picking_type_id" invisible="1"/>
+                    <field name="location_id" invisible="1"/>
+                    <field name="location_dest_id" invisible="1"/>
+                    <field name="scrapped" invisible="1"/>
+                    <field name="picking_code" invisible="1"/>
+                    <field name="product_type" invisible="1"/>
+                    <field name="show_details_visible" invisible="1"/>
+                    <field name="show_reserved_availability" invisible="1"/>
+                    <field name="show_operations" invisible="1" readonly="1"/>
+                    <field name="additional" invisible="1"/>
+                    <field name="has_move_lines" invisible="1"/>
+                    <field name="is_locked" invisible="1"/>
+                    <field name="product_id" required="1" invisible="1"/>
+                    <field name="is_initial_demand_editable" invisible="1"/>
+                    <field name="is_quantity_done_editable" invisible="1"/>
+                    <field name="product_uom_qty" string="Initial Demand" attrs="{'column_invisible': ['&amp;',('parent.immediate_transfer', '=', True), ('parent.is_locked', '=', True)], 'readonly': [('is_initial_demand_editable', '=', False)]}"/>
+                    <field name="reserved_availability" string="Reserved" attrs="{'column_invisible': (['|','|', ('parent.state','=', 'done'), ('parent.picking_type_code', '=', 'incoming'),'&amp;',('parent.immediate_transfer', '=', True), ('parent.is_locked', '=', True)])}"/>
+                    <field name="quantity_done" string="Done" attrs="{'readonly': [('is_quantity_done_editable', '=', False)]}"/>
+                    <field name="product_uom" attrs="{'readonly': [('state', '!=', 'draft'), ('id', '!=', False)]}" options="{'no_open': True, 'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
+                    <button name="action_show_details" string="Register lots, packs, location" type="object" icon="fa-list"/>
+                </tree>
+            </field>
+        </record>
+
         <record id="view_move_kandan" model="ir.ui.view">
             <field name="name">stock.move.kanban</field>
             <field name="model">stock.move</field>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -282,7 +282,13 @@
                         <page string="Operations">
                             <field name="id" invisible="1"/>
                             <field name="immediate_transfer" invisible="1"/>
-                            <field name="move_ids_without_package" attrs="{'readonly': ['|', '&amp;', ('show_operations', '=', True), '|', ('is_locked', '=', True), ('state', '=', 'done'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" context="{'picking_type_code': picking_type_code, 'default_picking_id': id, 'form_view_ref':'stock.view_move_picking_form', 'address_in_id': partner_id, 'default_picking_type_id': picking_type_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id}">
+                            <field name="move_ids_without_package"
+                                   attrs="{'readonly': ['|', '&amp;', ('show_operations', '=', True), '|', ('is_locked', '=', True), ('state', '=', 'done'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}"
+                                   context="{'picking_type_code': picking_type_code, 'default_picking_id': id, 'address_in_id': partner_id, 'default_picking_type_id': picking_type_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id,
+                                             'form_view_ref':'stock.view_move_picking_form',
+                                             'tree_view_ref':'stock.view_picking_details_move_tree'}">
+                                <!-- View comentada e transferida para o arquivo 'stock_move.xml',
+                                     ela é referenciada no contexto 'tree_view_ref'
                                 <tree limit="500" decoration-danger="not parent.immediate_transfer and state != 'done' and quantity_done > reserved_availability and show_reserved_availability" decoration-muted="scrapped == True or state == 'cancel' or (state == 'done' and is_locked == True)" string="Stock Moves" editable="bottom">
                                     <field name="name" invisible="1"/>
                                     <field name="date_expected" invisible="1"/>
@@ -308,6 +314,7 @@
                                     <field name="product_uom" attrs="{'readonly': [('state', '!=', 'draft'), ('id', '!=', False)]}" options="{'no_open': True, 'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
                                     <button name="action_show_details" string="Register lots, packs, location" type="object" icon="fa-list" options='{"warn": true}'/>
                                 </tree>
+                                -->
                             </field>
                             <field name="package_level_ids" context="{'default_location_id': location_id, 'default_location_dest_id': location_dest_id}" attrs="{'readonly': [('state', '=', 'done')], 'invisible': ['|', ('picking_type_entire_packs', '=', False), ('show_operations', '=', True)]}" />
                             <button class="oe_highlight" name="put_in_pack" type="object" string="Put in Pack" attrs="{'invisible': [('state', 'in', ('draft', 'done', 'cancel'))]}" groups="stock.group_tracking_lot"/>

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1002,6 +1002,9 @@ actual arch.
             'parent',
             'id',
             'uid',
+            'user', # Adicionado pela Multidados:
+                    # Objetivo é poder usar o 'user' que adicionamos os
+                    # valores do usuário no contexto com a função 'session_info'
             'context',
             'context_today',
             'active_id',

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1177,6 +1177,11 @@ actual arch.
                         not self._context.get(action, True) and is_base_model):
                     node.set(action, 'false')
 
+        if node.tag in ('tree',):
+            if not node.get('list_dynamic') and \
+              (not self.env.context.get('list_dynamic', True) and is_base_model):
+                node.set('list_dynamic', 'false')
+
         if node.tag in ('kanban',):
             group_by_name = node.get('default_group_by')
             if group_by_name in Model._fields:

--- a/odoo/addons/base/rng/tree_view.rng
+++ b/odoo/addons/base/rng/tree_view.rng
@@ -13,6 +13,7 @@
             <rng:optional><rng:attribute name="create" /></rng:optional>
             <rng:optional><rng:attribute name="delete" /></rng:optional>
             <rng:optional><rng:attribute name="edit" /></rng:optional>
+            <rng:optional><rng:attribute name="list_dynamic" /></rng:optional>
             <rng:optional><rng:attribute name="string"/></rng:optional>
             <rng:optional><rng:attribute name="duplicate"/></rng:optional>
             <rng:optional><rng:attribute name="import"/></rng:optional>


### PR DESCRIPTION
# Descrição

- Adiciona 'user' nos símbolos de contexto no render da View
  - Quando alteramos o método 'session_info' para adicionar os campos do usuário no contexto, não era permitido utilizar em alguns locais, como no domain de tags filter.

# Informações adicionais

- [T7995](https://multi.multidados.tech/web?#id=8404&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1364)
- [private-addons](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/885)
- [muk](https://github.com/multidadosti-erp/muk-addons/pull/37)