### PR TITLE
T8227 - Sistema permite retornar números de série diferente no retorno do estoque/locação

### DIFF
--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -209,6 +209,7 @@
                     <field name="picking_id" invisible="1"/>
                     <field name="is_locked" invisible="1"/>
                     <field name="picking_type_entire_packs" invisible="1"/>
+                    <field name="origin_returned_move_id" invisible="1"/>
                     <group>
                         <group name='group_product'>
                             <field name="product_id" readonly="1"/>
@@ -226,7 +227,8 @@
                             </div>
                         </group>
                     </group>
-                    <field name="move_line_ids" attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" context="{'tree_view_ref': 'stock.view_stock_move_line_operation_tree', 'default_product_uom_id': product_uom, 'default_picking_id': picking_id, 'default_move_id': id, 'default_product_id': product_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id}"/>
+                    <field name="move_line_ids" attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}"
+                           context="{'tree_view_ref': 'stock.view_stock_move_line_operation_tree', 'default_product_uom_id': product_uom, 'default_picking_id': picking_id, 'default_move_id': id, 'default_product_id': product_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_origin_returned_move_id': origin_returned_move_id}"/>
                     <footer class="oe_edit_only">
                         <button string="Confirm" special="save" class="oe_highlight"/>
                         <button string="Discard" special="cancel"/>
@@ -243,7 +245,8 @@
             <field name="inherit_id" ref="stock.view_stock_move_operations"/>
             <field name="arch" type="xml">
                 <field name="move_line_ids" position="replace">
-                    <field name="move_line_nosuggest_ids" attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" context="{'tree_view_ref': 'stock.view_stock_move_line_operation_tree','default_picking_id': picking_id, 'default_move_id': id, 'default_product_id': product_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id}"/>
+                    <field name="move_line_nosuggest_ids" attrs="{'readonly': ['|', ('state', '=', 'cancel'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}"
+                           context="{'tree_view_ref': 'stock.view_stock_move_line_operation_tree','default_picking_id': picking_id, 'default_move_id': id, 'default_product_id': product_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_origin_returned_move_id': origin_returned_move_id}"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
# Descrição

Adiciona 'origin_returned_move_id' Contexto módulo 'stock'

- Adiciona o campo 'origin_returned_move_id' no contexto da inclusão do stock_move_lines.

# Informações adicionais

Dados da tarefa: [T8227](https://multi.multidados.tech/web#id=8636&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [1410](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1410)
