### PR TITLE
T8295 - Adicionar na Agenda o Status: RESERVADA

### DIFF
--- a/addons/calendar/i18n/pt_BR.po
+++ b/addons/calendar/i18n/pt_BR.po
@@ -753,6 +753,12 @@ msgid "Duration in minutes"
 msgstr "Duração em Minutos"
 
 #. module: calendar
+#: code:addons/calendar/models/calendar.py:229
+#, python-format
+msgid "E-Mail sent to: %s (%s)"
+msgstr "E-Mail enviado para: %s (%s)"
+
+#. module: calendar
 #: selection:calendar.alarm,type:0
 #: model:ir.model.fields,field_description:calendar.field_calendar_attendee__email
 msgid "Email"


### PR DESCRIPTION
# Descrição

Adiciona Método para Facilitar a Herança módulo 'calendar'

- Adiciona método 'can_send_email' para poder herdar em outros módulos e tratar o envio do e-mail do evento.
- Adiciona LOG do e-mail enviado.
- Atualiza tradução pt_br do módulo.

# Informações adicionais

Dados da tarefa: [T8295](https://multi.multidados.tech/web?debug#id=8704&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [1418](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1418)
