### PR TITLE
T8341 - Verificar a geração do arquivo .ics ao enviar os invites atraves do sistema

### DIFF
--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -1017,13 +1017,13 @@ class Meeting(models.Model):
         """
         result = {}
 
-        def ics_datetime(idate, allday=False):
+        def ics_datetime(idate, allday=False, tz_name='UTC'):
 
             if idate:
                 if allday:
                     return idate
                 else:
-                    return idate.replace(tzinfo=pytz.timezone('UTC'))
+                    return idate.replace(tzinfo=pytz.utc).astimezone(pytz.timezone(tz_name))
             return False
 
         try:
@@ -1061,10 +1061,10 @@ class Meeting(models.Model):
             if not meeting.start or not meeting.stop:
                 raise UserError(_("First you have to specify the date of the invitation."))
 
-            event.add('dtstart').value = ics_datetime(meeting.start, allday=meeting.allday)
+            event.add('dtstart').value = ics_datetime(meeting.start, allday=meeting.allday, tz_name=user_tz)
             event.dtstart.tzid_param = user_tz
 
-            event.add('dtend').value = ics_datetime(meeting.stop, allday=meeting.allday)
+            event.add('dtend').value = ics_datetime(meeting.stop, allday=meeting.allday, tz_name=user_tz)
             event.dtend.tzid_param = user_tz
 
             event.add('dtstamp').value = ics_datetime(fields.Datetime.now())


### PR DESCRIPTION
# Descrição

* Corrige timezone da horas de inicio/fim dos .ics

Invites enviados via .ics estavam com a timezone UTC

# Informações adicionais

Dados da tarefa: [T8341](https://multi.multidados.tech/web?debug#id=8750&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)


