### PR TITLE
T8339 - Desenvolvimento da postagem de despesas para o Conta Corrente

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -610,7 +610,8 @@
                                 <field name="date" readonly="1"/>
                                 <field name="name" readonly="1"/>
                                 <field name="state" invisible="1"/>
-                                <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
+                                <field name="analytic_account_id" readonly="1"
+                                       groups="analytic.group_analytic_accounting"/>
                                 <field name="analytic_tag_ids" widget="many2many_tags" groups="analytic.group_analytic_tags"/>
                                 <field name="message_unread" invisible="1"/>
                                 <field name="attachment_number" string=" "/>
@@ -631,7 +632,7 @@
                                 <field name="total_amount" nolabel="1" class="oe_subtotal_footer_separator"/>
                             </group>
                         </page>
-                        <page string="Other Info">
+                        <page name="other_info" string="Other Info">
                             <group>
                                 <group>
                                     <field name="journal_id" domain="[('type', '=', 'purchase')]" options="{'no_open': True, 'no_create': True}" attrs="{'invisible': [('payment_mode', '!=', 'own_account')]}"/>

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -56,7 +56,6 @@
             <field name="inherit_id" ref="account.product_template_form_view"/>
             <field name="arch" type="xml">
                 <field name="property_account_expense_id" position="attributes">
-                    <attribute name="domain">[('deprecated','=',False)]</attribute>
                     <attribute name="attrs">{'readonly': [('purchase_ok', '=', 0)]}</attribute>
                 </field>
                 <field name='supplier_taxes_id' position="replace" >

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5783,12 +5783,13 @@ class Model(AbstractModel):
         else:
             return self[field_name]
 
-    def effect_notify(self, title='', message='', **kwargs):
+    def effect_notify(self, title='', message='', kind='notify', **kwargs):
         """ Utilizado para obter o retorno de efeito JS para
         notificar usuários a partir do WebClient.
 
         OBS: Alteração JS feita para permitir a notificação é
         encontrada no arquivo 'web/static/src/js/chrome/abstract_web_client.js'
+        na função '_onShowEffect'.
 
         Args:
             title (str): Título da notificação.
@@ -5797,14 +5798,38 @@ class Model(AbstractModel):
         Returns:
             dict: valores para efeito de notificação
         """
-        title = title or _('Notification')
+        # Ícones tipados
+        kind_icons = {
+            'warn': 'fa-exclamation-triangle',
+            'error': 'fa-skull-crossbones',
+        }
+        # Títulos tipados
+        kind_titles = {
+            'notify': _('Notification'),
+            'warn': _('Warning'),
+            'error': _('Error'),
+        }
 
-        return { 'effect': {
-                    'type': 'notification',
-                    'title': title,
-                    'message': message,
-                    **kwargs
-                }}
+        # Obtenção do título pelo tipo: args com preferência
+        title = title or kind_titles.get(kind)
+
+        # Obtenção do ícone pelo tipo: args com preferência
+        icon = kwargs.get('icon') or kind_icons.get(kind)
+        if icon:
+            kwargs['icon'] = icon
+
+        # Deixa notificação fixa em caso de erro ou aviso
+        if kind in ['error', 'warn']:
+            kwargs['sticky'] = True
+
+        # Retorno do efeito tratado no arquivo JS
+        return {'effect': {
+            'type': 'notification',
+            'title': title or kind_titles['notify'],
+            'message': message,
+            'kind': kind,
+            **kwargs
+        }}
 
 
 class TransientModel(Model):


### PR DESCRIPTION
# Descrição

- Adiciona atributos nas views do Core
    - Facilita necessidade de herança.

- Adiciona parâmetro 'kind' na função do efeito de notificar (effect_notify)
    - Adiciona o parâmetro para facilitar a chamada da função, passando somente o param 'kind' e o ícone e título são automaticamente selecionados.

# Informações adicionais

- [T8339](https://multi.multidados.tech/web?#id=8748&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:

- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1431)
- [private-addons](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/913)
- [financial-addons](https://github.com/multidadosti-erp/multidadosti-financial-addons/pull/510)
- [channel-addons](https://github.com/multidadosti-erp/multichannels-addons/pull/85)