### PR TITLE
T8391 - Multiphono: Incluir a possibilidade de marcar consultas avulsas

### DIFF
--- a/addons/calendar/i18n/pt_BR.po
+++ b/addons/calendar/i18n/pt_BR.po
@@ -1600,6 +1600,12 @@ msgid "Update only this instance"
 msgstr "Atualizar somente esta instância"
 
 #. module: calendar
+#: code:addons/calendar/models/calendar.py:1072
+#, python-format
+msgid "User has no Timezone set. It's required to create calendar events."
+msgstr "O usuário não tem fuso-horário definido. O fuso é obrigatório para criar eventos de calendário."
+
+#. module: calendar
 #: model:ir.model,name:calendar.model_res_users
 msgid "Users"
 msgstr "Usuários"

--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -1068,6 +1068,9 @@ class Meeting(models.Model):
             # nome da timezone do usuario
             user_tz = meeting.user_id.tz
 
+            if not user_tz:
+                raise UserError(_("User has no Timezone set. It's required to create calendar events."))
+
             vtimezone = cal.add('vtimezone')
             vtimezone.add('tzid').value = user_tz
             vtimezone.add('x-lic-location').value = user_tz

--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -1737,10 +1737,10 @@ class Meeting(models.Model):
         if not 'duration' in values:
             values['duration'] = self._get_duration(values['start'], values['stop'])
 
+        defaults = self.default_get(['activity_ids', 'res_model_id', 'res_id', 'user_id'])
+
         # created from calendar: try to create an activity on the related record
         if not values.get('activity_ids'):
-            defaults = self.default_get(['activity_ids', 'res_model_id', 'res_id', 'user_id'])
-
             # Alterado pela Mutlidados:
             #  - Adiciona funções para a criação da atividade padrão.
             #  - Possibilita a herança (adicionado inicialmente para o multiphono)

--- a/addons/web/static/src/js/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/js/views/calendar/calendar_controller.js
@@ -216,17 +216,10 @@ var CalendarController = AbstractController.extend({
         event.stopPropagation();
         this._move('next');
     },
-    /**
-     * @private
-     * @param {OdooEvent} event
-     */
-    _onOpenCreate: function (event) {
-        var self = this;
-        if (this.model.get().scale === "month") {
-            event.data.allDay = true;
-        }
-        var data = this.model.calendarEventToRecord(event.data);
-
+    // Multidados:
+    //  Adiciona obtenção de contexto por função
+    //  - facilita herança.
+    _contextDefaults: function(event, data) {
         var context = _.extend({}, this.context, event.options && event.options.context);
         context.default_name = data.name || null;
         context['default_' + this.mapping.date_start] = data[this.mapping.date_start] || null;
@@ -239,6 +232,23 @@ var CalendarController = AbstractController.extend({
         if (this.mapping.all_day) {
             context['default_' + this.mapping.all_day] = data[this.mapping.all_day] || null;
         }
+        return context
+    },
+    /**
+     * @private
+     * @param {OdooEvent} event
+     */
+    _onOpenCreate: function (event) {
+        var self = this;
+        if (this.model.get().scale === "month") {
+            event.data.allDay = true;
+        }
+        var data = this.model.calendarEventToRecord(event.data);
+
+        // Multidados:
+        //  Adiciona obtenção de contexto por função
+        //  - facilita herança.
+        var context = this._contextDefaults(event, data);
 
         for (var k in context) {
             if (context[k] && context[k]._isAMomentObject) {

--- a/addons/web/static/src/js/views/calendar/calendar_quick_create.js
+++ b/addons/web/static/src/js/views/calendar/calendar_quick_create.js
@@ -48,10 +48,7 @@ var QuickCreate = Dialog.extend({
                     }
                 }},
                 {text: _t("Edit"), click: function () {
-                    dataCalendar.disableQuickCreate = true;
-                    dataCalendar.title = self.$('input').val().trim();
-                    dataCalendar.on_save = self.destroy.bind(self);
-                    self.trigger_up('openCreate', dataCalendar);
+                    self._quickEdit(dataCalendar);
                 }},
                 {text: _t("Cancel"), close: true},
             ] : [],
@@ -79,6 +76,23 @@ var QuickCreate = Dialog.extend({
         var val = this.$('input').val().trim();
         dataCalendar.title = val;
         return (val)? this.trigger_up('quickCreate', {data: dataCalendar, options: this.options}) : false;
+    },
+
+    /**
+     * Adicionado pela Multidados:
+     * - Foi somente transferido para uma função do objeto
+     *   para possibilitar herança.
+     *
+     * Gathers data from the quick create dialog a launch quick_create(data) method
+     * to edit form.
+     */
+    _quickEdit: function (dataCalendar) {
+        $.extend(dataCalendar, {
+            disableQuickCreate: true,
+            title: this.$('input').val().trim(),
+            on_save: this.destroy.bind(this),
+        })
+        this.trigger_up('openCreate', dataCalendar);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/src/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/js/views/calendar/calendar_renderer.js
@@ -391,6 +391,7 @@ return AbstractRenderer.extend({
                 if (self.state.context.default_name) {
                     data.title = self.state.context.default_name;
                 }
+                data.context = self.state.context;
                 self.trigger_up('openCreate', data);
                 self.$calendar.fullCalendar('unselect');
             },

--- a/addons/web/static/src/scss/navbar.scss
+++ b/addons/web/static/src/scss/navbar.scss
@@ -18,6 +18,9 @@ body.o_is_superuser .o_menu_systray {
         background-color: fade_out($o-navbar-inverse-link-hover-bg, 0.5);
     }
 }
+body > header {
+    background-color: $o-brand-odoo;
+}
 .o_main_navbar {
     position: relative;
     height: $o-navbar-height;

--- a/odoo/addons/base/i18n/af.po
+++ b/odoo/addons/base/i18n/af.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Martin Trigaux <mat@odoo.com>, 2017
 # Andre de Kock <adekock11@gmail.com>, 2017
@@ -9170,7 +9170,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/ir/ir_ui_view.py:918
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/am.po
+++ b/odoo/addons/base/i18n/am.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Martin Trigaux <mat@odoo.com>, 2017
 msgid ""
@@ -9169,7 +9169,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/ir/ir_ui_view.py:918
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/ar.po
+++ b/odoo/addons/base/i18n/ar.po
@@ -12922,7 +12922,7 @@ msgstr "نوع الحقل"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "الحقل `%(field_name)s` غير موجود"
 
 #. module: base

--- a/odoo/addons/base/i18n/az.po
+++ b/odoo/addons/base/i18n/az.po
@@ -1,10 +1,10 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Jumshud Sultanov <cumshud@gmail.com>, 2019
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11266,7 +11266,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -10842,7 +10842,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/bg.po
+++ b/odoo/addons/base/i18n/bg.po
@@ -13958,8 +13958,8 @@ msgstr "Вид поле"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
-msgstr "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
+msgstr "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 
 #. module: base
 #: code:addons/base/models/ir_model.py:410

--- a/odoo/addons/base/i18n/bn.po
+++ b/odoo/addons/base/i18n/bn.po
@@ -1,12 +1,12 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Martin Trigaux, 2019
 # Abu Zafar <azmikbal@gmail.com>, 2021
 # Khanstore <dmashraf@gmail.com>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11548,7 +11548,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/bs.po
+++ b/odoo/addons/base/i18n/bs.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Malik K, 2018
 # Nemanja Dragovic <nemanjadragovic94@gmail.com>, 2018
@@ -10,7 +10,7 @@
 # Igor Krizanovic <krizanovic.igor@gmail.com>, 2019
 # Martin Trigaux, 2019
 # Ervin Cerović, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11400,7 +11400,7 @@ msgstr "Tip polja"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Polje `%(field_name)s` ne postoji"
 
 #. module: base

--- a/odoo/addons/base/i18n/ca.po
+++ b/odoo/addons/base/i18n/ca.po
@@ -12129,7 +12129,7 @@ msgstr "Camp de Tipus"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "El camp `%(field_name)s` no existeix"
 
 #. module: base

--- a/odoo/addons/base/i18n/cs.po
+++ b/odoo/addons/base/i18n/cs.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Ladislav Tomm <tomm@helemik.cz>, 2018
 # Jan Horzinka <jan.horzinka@centrum.cz>, 2018
@@ -12,7 +12,7 @@
 # Rastislav Brencic <rastislav.brencic@azet.sk>, 2021
 # karolína schusterová <karolina.schusterova@vdp.sk>, 2021
 # trendspotter, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -14056,7 +14056,7 @@ msgstr "Typ pole"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Pole  `%(field_name)s` neexistuje"
 
 #. module: base

--- a/odoo/addons/base/i18n/da.po
+++ b/odoo/addons/base/i18n/da.po
@@ -14982,7 +14982,7 @@ msgstr "Felttype"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Felt '%(field_name)s' findes ikke"
 
 #. module: base

--- a/odoo/addons/base/i18n/de.po
+++ b/odoo/addons/base/i18n/de.po
@@ -14853,7 +14853,7 @@ msgstr "Typfeld-Text"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Das Feld `%(field_name)s` existiert nicht"
 
 #. module: base

--- a/odoo/addons/base/i18n/el.po
+++ b/odoo/addons/base/i18n/el.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # 437c9d6e19936ed69f57bed9e0fe4716, 2018
 # Giota Dandidou <giotadandidou@gmail.com>, 2018
@@ -14,7 +14,7 @@
 # Vangelis Skarmoutsos <skarmoutsosv@gmail.com>, 2019
 # Alexandros Kapetanios <alexandros@gnugr.org>, 2021
 # Methodoos Greece <info@methodoos.com>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11858,7 +11858,7 @@ msgstr "Τύπος Πεδίου"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Το πεδίο `%(field_name)s` δεν υπάρχει"
 
 #. module: base

--- a/odoo/addons/base/i18n/en_GB.po
+++ b/odoo/addons/base/i18n/en_GB.po
@@ -11228,7 +11228,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/es.po
+++ b/odoo/addons/base/i18n/es.po
@@ -14344,7 +14344,7 @@ msgstr "Tipo de campo"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "El campo `%(field_name)s` no existe"
 
 #. module: base

--- a/odoo/addons/base/i18n/es_BO.po
+++ b/odoo/addons/base/i18n/es_BO.po
@@ -11228,7 +11228,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/es_CL.po
+++ b/odoo/addons/base/i18n/es_CL.po
@@ -11229,7 +11229,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/es_CO.po
+++ b/odoo/addons/base/i18n/es_CO.po
@@ -11228,7 +11228,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/es_CR.po
+++ b/odoo/addons/base/i18n/es_CR.po
@@ -11228,7 +11228,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/es_DO.po
+++ b/odoo/addons/base/i18n/es_DO.po
@@ -11228,7 +11228,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/es_EC.po
+++ b/odoo/addons/base/i18n/es_EC.po
@@ -11228,7 +11228,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/es_PE.po
+++ b/odoo/addons/base/i18n/es_PE.po
@@ -11228,7 +11228,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/es_PY.po
+++ b/odoo/addons/base/i18n/es_PY.po
@@ -11228,7 +11228,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/es_VE.po
+++ b/odoo/addons/base/i18n/es_VE.po
@@ -11228,7 +11228,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/et.po
+++ b/odoo/addons/base/i18n/et.po
@@ -12661,7 +12661,7 @@ msgstr "Välja tüüp"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/eu.po
+++ b/odoo/addons/base/i18n/eu.po
@@ -11374,7 +11374,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/fa.po
+++ b/odoo/addons/base/i18n/fa.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # mehdi samadi <mehsamadi@gmail.com>, 2018
 # arya sadeghi <aryasadeghy@gmail.com>, 2018
@@ -18,7 +18,7 @@
 # Mohsen Mohammadi <iammohsen.123@gmail.com>, 2021
 # Far Har <fhari1234@gmail.com>, 2021
 # M.Hossein S.Farvashani <Farvashani@gmail.com>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11576,7 +11576,7 @@ msgstr "نوع فیلد"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/fi.po
+++ b/odoo/addons/base/i18n/fi.po
@@ -12020,7 +12020,7 @@ msgstr "Kentän tyyppi"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Kenttää '%(field_name)s' ei ole olemassa"
 
 #. module: base

--- a/odoo/addons/base/i18n/fil.po
+++ b/odoo/addons/base/i18n/fil.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11262,7 +11262,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/fo.po
+++ b/odoo/addons/base/i18n/fo.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Martin Trigaux <mat@odoo.com>, 2017
 msgid ""
@@ -9169,7 +9169,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/ir/ir_ui_view.py:918
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/fr.po
+++ b/odoo/addons/base/i18n/fr.po
@@ -14659,7 +14659,7 @@ msgstr "Type de Champ"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Le champ `%(field_name)s` n'existe pas"
 
 #. module: base

--- a/odoo/addons/base/i18n/fr_CA.po
+++ b/odoo/addons/base/i18n/fr_CA.po
@@ -11228,7 +11228,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/gl.po
+++ b/odoo/addons/base/i18n/gl.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Martin Trigaux <mat@odoo.com>, 2017
 msgid ""
@@ -9169,7 +9169,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/ir/ir_ui_view.py:918
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/gu.po
+++ b/odoo/addons/base/i18n/gu.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Jay Vora <jay.vora@serpentcs.com>, 2018
 # Divya Pandya <dia@odoo.com>, 2018
@@ -11,7 +11,7 @@
 # Ranjit Pillai <rpi@odoo.com>, 2018
 # Spellbound Soft Solutions <jeel.spellbound@gmail.com>, 2018
 # Martin Trigaux, 2019
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11275,7 +11275,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/he.po
+++ b/odoo/addons/base/i18n/he.po
@@ -12400,7 +12400,7 @@ msgstr "סוג שדה"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "שדה `%(field_name)s` לא קיים"
 
 #. module: base

--- a/odoo/addons/base/i18n/hr.po
+++ b/odoo/addons/base/i18n/hr.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # KRISTINA PALAŠ <kristina.palas@storm.hr>, 2019
 # Stjepan Lovasić <stjepan.lovasic@gmail.com>, 2019
@@ -24,7 +24,7 @@
 # Hrvoje Sić <hrvoje.sic@gmail.com>, 2021
 # 0ba0ac30481a756f36528ba6f9a4317e_6443a87 <52eefe24349934c364624ef40611b7a3_1010754>, 2021
 # Bole <bole@dajmi5.com>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11741,7 +11741,7 @@ msgstr "Vrsta polja"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Polje `%(field_name)s` ne postoji"
 
 #. module: base

--- a/odoo/addons/base/i18n/hu.po
+++ b/odoo/addons/base/i18n/hu.po
@@ -12939,7 +12939,7 @@ msgstr "Típus mező"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "`%(field_name)s` mező nem létezik"
 
 #. module: base

--- a/odoo/addons/base/i18n/id.po
+++ b/odoo/addons/base/i18n/id.po
@@ -11594,7 +11594,7 @@ msgstr "Tipe Kolom"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/is.po
+++ b/odoo/addons/base/i18n/is.po
@@ -1,12 +1,12 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Martin Trigaux, 2018
 # Birgir Steinarsson <biggboss83@gmail.com>, 2019
 # Björn Ingvarsson <boi@exigo.is>, 2019
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -12745,8 +12745,8 @@ msgstr "Field Type"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
-msgstr "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
+msgstr "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 
 #. module: base
 #: code:addons/base/models/ir_model.py:410

--- a/odoo/addons/base/i18n/it.po
+++ b/odoo/addons/base/i18n/it.po
@@ -14096,7 +14096,7 @@ msgstr "Tipo campo"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Il campo `%(field_name)s` non esiste"
 
 #. module: base

--- a/odoo/addons/base/i18n/ja.po
+++ b/odoo/addons/base/i18n/ja.po
@@ -13452,7 +13452,7 @@ msgstr "項目タイプ"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "フィールド `%(field_name)s` がありません。"
 
 #. module: base

--- a/odoo/addons/base/i18n/ka.po
+++ b/odoo/addons/base/i18n/ka.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Davit Matchakhelidze <david.machakhelidze@gmail.com>, 2019
 # Giorgi Melitauri <gmelitauri@live.com>, 2019
@@ -11,7 +11,7 @@
 # Martin Trigaux, 2019
 # Gizo Kobakhidze <040168@gmail.com>, 2019
 # Mari Khomeriki <mari.khomeriki@maxinai.com>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11306,7 +11306,7 @@ msgstr "ველის ტიპი"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/kab.po
+++ b/odoo/addons/base/i18n/kab.po
@@ -1,11 +1,11 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Muḥend Belqasem <belkacem77@gmail.com>, 2019
 # Martin Trigaux, 2019
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11346,7 +11346,7 @@ msgstr "Tawsit n Wurti"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Urti `%(field_name)s` Ulac-it"
 
 #. module: base

--- a/odoo/addons/base/i18n/km.po
+++ b/odoo/addons/base/i18n/km.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Sitthykun LY <ly.sitthykun@gmail.com>, 2018
 # AN Souphorn <ansouphorn@gmail.com>, 2018
@@ -9,7 +9,7 @@
 # Samkhann Seang <seangsamkhann@gmail.com>, 2018
 # Sengtha Chay <sengtha@gmail.com>, 2019
 # Lux Sok <sok.lux@gmail.com>, 2019
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11942,7 +11942,7 @@ msgstr "ប្រភេទឯកសារ"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/ko.po
+++ b/odoo/addons/base/i18n/ko.po
@@ -14920,7 +14920,7 @@ msgstr "필드 유형"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "`%(field_name)s` 필드가 없습니다"
 
 #. module: base

--- a/odoo/addons/base/i18n/lo.po
+++ b/odoo/addons/base/i18n/lo.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Martin Trigaux <mat@odoo.com>, 2017
 msgid ""
@@ -9169,7 +9169,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/ir/ir_ui_view.py:918
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/lt.po
+++ b/odoo/addons/base/i18n/lt.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Edgaras Kriukonis <edgaras@focusate.eu>, 2018
 # Zygimantus <zygimantus@gmail.com>, 2018
@@ -25,7 +25,7 @@
 # grupoda2 <dmitrijus.ivanovas@gmail.com>, 2021
 # Cécile Collart <cco@odoo.com>, 2021
 # Arunas V. <arunas@devoro.com>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11780,7 +11780,7 @@ msgstr "Lauko tipas"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Laukas `%(field_name)s` neegzistuoja"
 
 #. module: base

--- a/odoo/addons/base/i18n/lv.po
+++ b/odoo/addons/base/i18n/lv.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # JanisJanis <jbojars@gmail.com>, 2019
 # InfernalLV <karlisdreizis@gmail.com>, 2019
@@ -10,7 +10,7 @@
 # Martin Trigaux, 2019
 # ievaputnina <ievai.putninai@gmail.com>, 2019
 # Arnis Putniņš <arnis@allegro.lv>, 2019
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -13190,8 +13190,8 @@ msgstr "Lauka Tips"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
-msgstr "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
+msgstr "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 
 #. module: base
 #: code:addons/base/models/ir_model.py:410

--- a/odoo/addons/base/i18n/mk.po
+++ b/odoo/addons/base/i18n/mk.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Martin Trigaux <mat@odoo.com>, 2017
 msgid ""
@@ -9169,7 +9169,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/ir/ir_ui_view.py:918
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/mn.po
+++ b/odoo/addons/base/i18n/mn.po
@@ -12933,7 +12933,7 @@ msgstr "Талбарын төрөл"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "`%(field_name)s` талбар байхгүй байна"
 
 #. module: base

--- a/odoo/addons/base/i18n/nb.po
+++ b/odoo/addons/base/i18n/nb.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Torvald Baade Bringsvor <bringsvor@bringsvor.com>, 2018
 # Jan Pedro Tumusok <jpt@eyenetworks.no>, 2018
@@ -11,7 +11,7 @@
 # Aleksander, 2019
 # Martin Trigaux, 2019
 # Marius Stedjan <marius@stedjan.com>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11557,7 +11557,7 @@ msgstr "Felttype"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Feltet '%(field_name)s' eksisterer ikke"
 
 #. module: base

--- a/odoo/addons/base/i18n/nl.po
+++ b/odoo/addons/base/i18n/nl.po
@@ -15,7 +15,7 @@
 # Yenthe Van Ginneken <yenthespam@gmail.com>, 2019
 # Martin Trigaux, 2019
 # Erwin van der Ploeg <erwin@odooexperts.nl>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -15035,7 +15035,7 @@ msgstr "Soort veld"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Veld '%(field_name)s' bestaat niet"
 
 #. module: base

--- a/odoo/addons/base/i18n/nl_BE.po
+++ b/odoo/addons/base/i18n/nl_BE.po
@@ -11228,7 +11228,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/pl.po
+++ b/odoo/addons/base/i18n/pl.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Grażyna Grzelak <grazyna.grzelak@openglobe.pl>, 2018
 # Michał <michal.gorecki@esnc.pl>, 2018
@@ -37,7 +37,7 @@
 # Piotr Strębski <strebski@gmail.com>, 2021
 # Rafał Kozak <rafal.kozak@openglobe.pl>, 2021
 # Wojciech Warczakowski <w.warczakowski@gmail.com>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -13727,7 +13727,7 @@ msgstr "Typ pola"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Pole `%(field_name)s` nie istnieje"
 
 #. module: base

--- a/odoo/addons/base/i18n/pt.po
+++ b/odoo/addons/base/i18n/pt.po
@@ -11930,7 +11930,7 @@ msgstr "Tipo de Campo"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "O campo `%(field_name)s` não existe"
 
 #. module: base

--- a/odoo/addons/base/i18n/pt_BR.po
+++ b/odoo/addons/base/i18n/pt_BR.po
@@ -15106,8 +15106,8 @@ msgstr "Tipo do Campo"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
-msgstr "O campo `%(field_name)s` não existe"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
+msgstr "O campo `%(field_name)s` não existe para a model `%(model_name)s`"
 
 #. module: base
 #: code:addons/base/models/ir_model.py:410

--- a/odoo/addons/base/i18n/ro.po
+++ b/odoo/addons/base/i18n/ro.po
@@ -12336,7 +12336,7 @@ msgstr "Tip Câmp"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Câmpul `%(field_name)s` nu există"
 
 #. module: base

--- a/odoo/addons/base/i18n/ru.po
+++ b/odoo/addons/base/i18n/ru.po
@@ -14293,7 +14293,7 @@ msgstr "Тип поля"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Поле `%(field_name)s` не существует"
 
 #. module: base

--- a/odoo/addons/base/i18n/sk.po
+++ b/odoo/addons/base/i18n/sk.po
@@ -12879,7 +12879,7 @@ msgstr "Typ Poľa"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Pole `%(field_name)s` neexistuje"
 
 #. module: base

--- a/odoo/addons/base/i18n/sl.po
+++ b/odoo/addons/base/i18n/sl.po
@@ -11947,7 +11947,7 @@ msgstr "Tip polja"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Polje `%(field_name)s` ne obstaja"
 
 #. module: base

--- a/odoo/addons/base/i18n/so.po
+++ b/odoo/addons/base/i18n/so.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11262,7 +11262,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/sq.po
+++ b/odoo/addons/base/i18n/sq.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Martin Trigaux <mat@odoo.com>, 2017
 msgid ""
@@ -9169,7 +9169,7 @@ msgstr ""
 #. module: base
 #: code:addons/base/ir/ir_ui_view.py:918
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/sr.po
+++ b/odoo/addons/base/i18n/sr.po
@@ -1,12 +1,12 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Slobodan Simić <slsimic@gmail.com>, 2019
 # Martin Trigaux, 2019
 # Uros Kalajdzic <ukalajdzic@gmail.com>, 2020
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11274,7 +11274,7 @@ msgstr "Tip polja"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/sr@latin.po
+++ b/odoo/addons/base/i18n/sr@latin.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Martin Trigaux <mat@odoo.com>, 2017
 # Nemanja Dragovic <nemanjadragovic94@gmail.com>, 2017
@@ -9270,7 +9270,7 @@ msgstr "Tip polja"
 #. module: base
 #: code:addons/base/ir/ir_ui_view.py:918
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/sv.po
+++ b/odoo/addons/base/i18n/sv.po
@@ -11449,7 +11449,7 @@ msgstr "Fälttyp"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/ta.po
+++ b/odoo/addons/base/i18n/ta.po
@@ -1,14 +1,14 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Martin Trigaux, 2019
 # Abul Hassan M I <miabulhassan@gmail.com>, 2019
 # Bagavathikumar Ramakrishnan <bagavathikumar@gmail.com>, 2019
 # Prassanna <prasaugus@gmail.com>, 2019
 # Alagappan Karthikeyan <me@karthik.sg>, 2019
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -11278,7 +11278,7 @@ msgstr "புலம் வகை"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/th.po
+++ b/odoo/addons/base/i18n/th.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Prawit Boonthue <prawit.boonthue@gmail.com>, 2018
 # LAO <sumonchai@gmail.com>, 2018
@@ -18,7 +18,7 @@
 # Odoo Thaidev <odoothaidev@gmail.com>, 2020
 # Amin Cheloh <nineamin@hotmail.com>, 2021
 # Wichanon Jamwutthipreecha, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -12183,8 +12183,8 @@ msgstr "ประเภทฟิลด์"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
-msgstr "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
+msgstr "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 
 #. module: base
 #: code:addons/base/models/ir_model.py:410

--- a/odoo/addons/base/i18n/tr.po
+++ b/odoo/addons/base/i18n/tr.po
@@ -31,7 +31,7 @@
 # Nadir Gazioglu <nadirgazioglu@gmail.com>, 2021
 # Ozlem Cikrikci <ozlemc@eskayazilim.com.tr>, 2021
 # abc Def <hdogan1974@gmail.com>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -13686,7 +13686,7 @@ msgstr "Alan Türü"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "`%(field_name)s` alanı mevcut değil"
 
 #. module: base

--- a/odoo/addons/base/i18n/uk.po
+++ b/odoo/addons/base/i18n/uk.po
@@ -15209,7 +15209,7 @@ msgstr "Тип поля"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Поле `%(field_name)s` не існує"
 
 #. module: base

--- a/odoo/addons/base/i18n/vi.po
+++ b/odoo/addons/base/i18n/vi.po
@@ -14967,7 +14967,7 @@ msgstr "Loại trường"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "Trường `%(field_name)s` không tồn tại"
 
 #. module: base

--- a/odoo/addons/base/i18n/zh_CN.po
+++ b/odoo/addons/base/i18n/zh_CN.po
@@ -14589,7 +14589,7 @@ msgstr "字段类型"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "字段`%(field_name)s`不存在"
 
 #. module: base

--- a/odoo/addons/base/i18n/zh_TW.po
+++ b/odoo/addons/base/i18n/zh_TW.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * base
-# 
+#
 # Translators:
 # Bill Hsu <hcm86@icloud.com>, 2018
 # amos lin <seeing@edirect168.com>, 2018
@@ -13,7 +13,7 @@
 # Benson <Benson.Dr@Gmail.com>, 2021
 # Tom Liang <tom.liang@omniwaresoft.com.tw>, 2021
 # 敬雲 林 <chingyun@yuanchih-consult.com>, 2021
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
@@ -14446,7 +14446,7 @@ msgstr "字段類型"
 #. module: base
 #: code:addons/base/models/ir_ui_view.py:1084
 #, python-format
-msgid "Field `%(field_name)s` does not exist"
+msgid "Field `%(field_name)s` does not exist for model `%(model_name)s`"
 msgstr "字段`%(field_name)s`不存在"
 
 #. module: base

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1137,7 +1137,7 @@ actual arch.
             if field in fields:
                 fields[field].update(fields_def[field])
             else:
-                message = _("Field `%(field_name)s` does not exist") % dict(field_name=field)
+                message = _("Field `%(field_name)s` does not exist for model `%(model_name)s`") % dict(field_name=field, model_name=model)
                 self.raise_view_error(message, view_id)
 
         missing = [item for item in attrs_fields if item[0] not in fields]


### PR DESCRIPTION
# Descrição

- Validação para que o usuário tenha um fuso horário definido
  - Ao criar ICAL, fuso horário do usuário deve ser obrigatório.
  - Atualiza tradução para mensagem de erro.

- Transfere código do Calendar Quick Create para função    
    - Código inserido em função para possibilitar herança.

- Melhorias na criação padrão de atividade relacionada ao 'calendar.event'  
    - Uma atividade sempre é criada caso a reunião esteja relacionada a algum registro, mas era criada de forma pobre e incorreta.
    - Foi adicionado funções para essa criação das atividades padrão, e possibilitar a mudança em outros módulos, como no multiphoono.

- Adiciona colorização para quando o header quebra de linha

- Melhorias no JS da View de Calendário (Contexto)
    - Adiciona contexto para o quick add do calendário, para facilitar heranças no 'br_calendar' para inclusão do campo de tipo de atividade na ciração rápida do 'calendar.event'.

- Melhora mensagem de erro na atualização do banco
    - Agora é informada a tabela do campo inexistente, para identificar quando está dentro de trees mais facilmente.
    - Atualiza arquivos de tradução

# Informações adicionais

- [T8391](https://multi.multidados.tech/web?#id=8800&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1457)
- [private-addons](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/920)
- [oca-social](https://github.com/multidadosti-erp/social/pull/18)