### PR TITLE
T8410 - Integrar novo sistema de cadastro de certificados na consulta do SEFAZ

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -284,6 +284,8 @@ class configmanager(object):
                          help="Use the unaccent function provided by the database when available.")
         group.add_option("--geoip-db", dest="geoip_database", my_default='/usr/share/GeoIP/GeoLite2-City.mmdb',
                          help="Absolute path to the GeoIP database file.")
+        group.add_option("--encryption-key", dest="encryption_key", my_default='5ZsZ-p2iU_2mP6s7qIUSc4nrr2DhrG07_MEBYLvL8rI=',
+                         help="Encryption Key used do criptografy values (default '123zYz').")
         parser.add_option_group(group)
 
         if os.name == 'posix':


### PR DESCRIPTION
# Descrição

* Adiciona chave de criptografia

Chave utilizada apenas em testes, ja que ambientes de produção possuem sua propria key

# Informações adicionais

Dados da tarefa: [T8410](https://multi.multidados.tech/web#id=8819&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)
