### PR TITLE
T8463 - Produtos não estão atualizando o preço no POS de acordo com a lista de preços

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -324,6 +324,7 @@ exports.PosModel = Backbone.Model.extend({
         },
     },{
         model:  'product.pricelist.item',
+        order:  _.map(['date_start, product_tmpl_id, product_id, categ_id'], function (name) { return {name: name}; }),
         domain: function(self) { return [['pricelist_id', 'in', _.pluck(self.pricelists, 'id')]]; },
         loaded: function(self, pricelist_items){
             var pricelist_by_id = {};

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -324,7 +324,7 @@ exports.PosModel = Backbone.Model.extend({
         },
     },{
         model:  'product.pricelist.item',
-        order:  _.map(['date_start, product_tmpl_id, product_id, categ_id'], function (name) { return {name: name}; }),
+        order:  _.map(['applied_on, product_id, product_tmpl_id, date_start, min_quantity desc, categ_id desc, id desc, pricelist_id'], function (name) { return {name: name}; }),
         domain: function(self) { return [['pricelist_id', 'in', _.pluck(self.pricelists, 'id')]]; },
         loaded: function(self, pricelist_items){
             var pricelist_by_id = {};

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -161,7 +161,7 @@ class Pricelist(models.Model):
                 list_ids = (list_ids,)
             items = self.env["product.pricelist.item"].search(
                 [("id", "in", list_ids)],
-                order="date_start, product_tmpl_id, product_id, categ_id",
+                order="applied_on, product_id, product_tmpl_id, date_start, min_quantity desc, categ_id desc, id desc",
             )
         else:
             items = self.env['product.pricelist.item']
@@ -390,13 +390,13 @@ class PricelistItem(models.Model):
     # inconstencies and undeterministic issues.
 
     product_tmpl_id = fields.Many2one(
-        'product.template', 'Product Template', ondelete='cascade',
+        'product.template', 'Product Template', ondelete='cascade', index=True,
         help="Specify a template if this rule only applies to one product template. Keep empty otherwise.")
     product_id = fields.Many2one(
-        'product.product', 'Product', ondelete='cascade',
+        'product.product', 'Product', ondelete='cascade', index=True,
         help="Specify a product if this rule only applies to one product. Keep empty otherwise.")
     categ_id = fields.Many2one(
-        'product.category', 'Product Category', ondelete='cascade',
+        'product.category', 'Product Category', ondelete='cascade', index=True,
         help="Specify a product category if this rule only applies to products belonging to this category or its children categories. Keep empty otherwise.")
     min_quantity = fields.Integer(
         'Min. Quantity', default=0,
@@ -442,8 +442,8 @@ class PricelistItem(models.Model):
     currency_id = fields.Many2one(
         'res.currency', 'Currency',
         readonly=True, related='pricelist_id.currency_id', store=True)
-    date_start = fields.Date('Start Date', help="Starting date for the pricelist item validation")
-    date_end = fields.Date('End Date', help="Ending valid for the pricelist item validation")
+    date_start = fields.Date('Start Date', help="Starting date for the pricelist item validation", index=True)
+    date_end = fields.Date('End Date', help="Ending valid for the pricelist item validation", index=True)
     compute_price = fields.Selection([
         ('fixed', 'Fix Price'),
         ('percentage', 'Percentage (discount)'),


### PR DESCRIPTION
# Descrição

[Ajusta Order Pesquisa Tabela Preço módulo 'point_of_sale'](https://github.com/multidadosti-erp/odoo/commit/4e4658991483576d7833a8a4c04f4cc6037620c8) 
- Odoo Não priorizava os produtos, gerando erro em tabelas de preço
  com linhas globais.

[Ajusta Order Pesquisa Tabela Preço módulo 'product'](https://github.com/multidadosti-erp/odoo/commit/fd6f463a33693e362a89e0553a918754ddcbb789) 

- Odoo Não priorizava os produtos, gerando erro em tabelas de preço
  com linhas globais.

# Informações adicionais

Dados da tarefa: [T8463](https://multi.multidados.tech/web?&debug=#id=8872&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [1470](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1470)
