### PR TITLE
T8515 - Alterar a busca (pesquisa) do sistema para que possibilite a busca por cadastros ignorando a acentuação utilizada no cadastro

### DIFF
--- a/odoo/modules/db.py
+++ b/odoo/modules/db.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+import psycopg2
 import odoo.modules
 import logging
 
@@ -122,3 +122,16 @@ def has_unaccent(cr):
     """
     cr.execute("SELECT proname FROM pg_proc WHERE proname='unaccent'")
     return len(cr.fetchall()) > 0
+
+def create_unaccent(cr):
+    """ Create in the database has an unaccent function.
+
+    The unaccent is supposed to be provided by the PostgreSQL unaccent contrib
+    module but any similar function will be picked by OpenERP.
+    """
+    try:
+        with cr.savepoint():
+            cr.execute("CREATE EXTENSION unaccent")
+        cr.commit()
+    except psycopg2.Error:
+        pass

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -146,8 +146,18 @@ class Registry(Mapping):
 
         with closing(self.cursor()) as cr:
             has_unaccent = odoo.modules.db.has_unaccent(cr)
+
             if odoo.tools.config['unaccent'] and not has_unaccent:
                 _logger.warning("The option --unaccent was given but no unaccent() function was found in database.")
+
+                # Cria a extenção unaccent
+                odoo.modules.db.create_unaccent(cr)
+
+                # Verifica novamente a criação do unaccent
+                has_unaccent = odoo.modules.db.has_unaccent(cr)
+                if has_unaccent:
+                    _logger.info("Create Sucess unaccent in database.")
+
             self.has_unaccent = odoo.tools.config['unaccent'] and has_unaccent
 
     @classmethod


### PR DESCRIPTION
# Descrição

[Adiciona método 'create_unaccent' módulo 'modules'](https://github.com/multidadosti-erp/odoo/commit/8a650b6b8a0fb33d2a024f140e55b037200a253e) 

- Método para criar automaticamente a exstensão do postgree 'unaccent'

# Informações adicionais

Dados da tarefa: [T8515](https://multi.multidados.tech/web?debug#id=8924&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

