### PR TITLE
T8595 - Correção no kanban de vendas

### DIFF
--- a/addons/sale/i18n/pt_BR.po
+++ b/addons/sale/i18n/pt_BR.po
@@ -351,7 +351,7 @@ msgstr "<strong>Vendedor:</strong>"
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_sale_order_kanban
 msgid "<strong>Salesteam:</strong>"
-msgstr "<strong>Vendedor:</strong>"
+msgstr "<strong>Equipe de Vendas:</strong>"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.report_invoice_document_inherit_sale
@@ -1653,6 +1653,11 @@ msgstr "Linhas faturáveis"
 #: selection:sale.advance.payment.inv,advance_payment_method:0
 msgid "Invoiceable lines (deduct down payments)"
 msgstr "Linhas faturáveis (deduzir pagamentos baixados)"
+
+#. module: sale
+#: selection:sale.report,state:0
+msgid "Invoiced"
+msgstr "Faturado"
 
 #. module: sale
 #: code:addons/sale/models/sale.py:1147

--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -303,6 +303,11 @@ msgid "<strong>Fiscal Position Remark:</strong>"
 msgstr ""
 
 #. module: sale
+#: model_terms:ir.ui.view,arch_db:sale.view_sale_order_kanban
+msgid "<strong>Partner:</strong>"
+msgstr ""
+
+#. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.report_saleorder_document
 msgid "<strong>Payment Terms:</strong>"
 msgstr ""
@@ -314,7 +319,13 @@ msgstr ""
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.report_saleorder_document
+#: model_terms:ir.ui.view,arch_db:sale.view_sale_order_kanban
 msgid "<strong>Salesperson:</strong>"
+msgstr ""
+
+#. module: sale
+#: model_terms:ir.ui.view,arch_db:sale.view_sale_order_kanban
+msgid "<strong>Salesteam:</strong>"
 msgstr ""
 
 #. module: sale


### PR DESCRIPTION
# Descrição

- Corrige tradução do módulo de Vendas
  - Adiciona termos no arquivo .pot para funcionar corretamente.

# Informações adicionais

- [T8595](https://multi.multidados.tech/web?#id=9004&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1504)