### PR TITLE
T8670 - Verificar pedidos da kanxa que não estão integrando

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -2147,15 +2147,10 @@ class AccountPaymentTerm(models.Model):
         dist = currency.round(value - amount)
         dist_without_taxes = currency.round(value_without_taxes - amount_without_taxes)
 
-        if dist:
+        if dist or dist_without_taxes:
             last_date = result and result[-1][0] or fields.Date.today()
             days = result and result[-1][2] or 0
-            result.append((last_date, dist, days))
-
-        if dist_without_taxes:
-            last_date = result and result[-1][0] or fields.Date.today()
-            days = result and result[-1][2] or 0
-            result.append((last_date, dist_without_taxes, days))
+            result.append((last_date, dist, days, dist_without_taxes))
 
         return result
 


### PR DESCRIPTION
# Descrição

Ajusta Geração Parcelas Pgto módulo 'account'
- Estava duplicando as datas refente a valor sem taxa de impostos.

# Informações adicionais

Dados da tarefa: [T8670](https://multi.multidados.tech/web#id=9079&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

