### PR TITLE
T8722 - Retirar a opção de criar item ao vincular um fornecedor

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -133,6 +133,9 @@ var FieldMany2One = AbstractField.extend({
         } else if (this.nodeOptions.no_create != undefined) {
             // Caso o valor da opção seja 'bool' ou 'number'
             can_create = can_create && !this.nodeOptions.no_create;
+        } else if (this.nodeOptions.no_create_edit != undefined) {
+            // Caso o valor da opção seja 'bool' ou 'number'
+            can_create = can_create && !this.nodeOptions.no_create_edit;
         }
         this.can_create = can_create;
 


### PR DESCRIPTION
# Descrição

- Corrige a falta de efeito da opção 'no_create_edit' em campos M2O
  - A option 'no_create_edit' não estava fazendo efeito em campos many2one nas views.

# Informações adicionais

- [T8722](https://multi.multidados.tech/web?#id=9131&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)