### PR TITLE
T8719 - Adicionar no Kanban dos Orçamentos as Categorias dos Produtosseta

### DIFF
--- a/addons/web/static/src/js/views/kanban/kanban_column.js
+++ b/addons/web/static/src/js/views/kanban/kanban_column.js
@@ -56,6 +56,7 @@ var KanbanColumn = Widget.extend({
         this.deletable = options.deletable;
         this.archivable = options.archivable;
         this.draggable = options.draggable;
+        this.group_readonly = options.group_readonly || [];
         this.KanbanRecord = options.KanbanRecord || KanbanRecord; // the KanbanRecord class to use
         this.records_editable = options.records_editable;
         this.records_deletable = options.records_deletable;
@@ -71,6 +72,7 @@ var KanbanColumn = Widget.extend({
         }
 
         this.record_options = _.clone(recordOptions);
+        this.record_options.groupReadonlyAttr = this.group_readonly;
 
         if (options.grouped_by_m2o) {
             // For many2one, a false value means that the field is not set.
@@ -117,7 +119,7 @@ var KanbanColumn = Widget.extend({
                 containment: this.draggable ? false : 'parent',
                 revert: 0,
                 delay: 0,
-                items: '> .o_kanban_record:not(.o_updating)',
+                items: '> .o_kanban_record:not(.o_updating).draggable',
                 cursor: 'move',
                 over: function () {
                     self.$el.addClass('o_kanban_hover');

--- a/addons/web/static/src/js/views/kanban/kanban_record.js
+++ b/addons/web/static/src/js/views/kanban/kanban_record.js
@@ -53,6 +53,7 @@ var KanbanRecord = Widget.extend({
         this.read_only_mode = options.read_only_mode;
         this.qweb = options.qweb;
         this.subWidgets = {};
+        this.group_readonly = new Domain(options.groupReadonlyAttr, state.data).compute(state.data);
 
         this._setState(state);
         // avoid quick multiple clicks
@@ -344,6 +345,7 @@ var KanbanRecord = Widget.extend({
         this.defs = [];
         this._replaceElement(this.qweb.render('kanban-box', this.qweb_context));
         this.$el.addClass('o_kanban_record').attr("tabindex",0);
+
         this.$el.attr('role', 'article');
         this.$el.data('record', this);
         if (this.$el.hasClass('oe_kanban_global_click') ||

--- a/addons/web/static/src/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/js/views/kanban/kanban_renderer.js
@@ -457,8 +457,16 @@ var KanbanRenderer = BasicRenderer.extend({
                 draggable = !(groupByFieldAttrs.readonly);
             }
         }
+        var drag_attr_readonly = [];
         if (groupByFieldInfo) {
-            if (draggable && groupByFieldInfo.readonly !== undefined) {
+            var dragging_options = groupByFieldInfo.options.dragging;
+            if (dragging_options){
+                force_draggable = !!(dragging_options.drag) || force_draggable;
+            }
+            // o domínio readonly nos attrs prevalecem do que o próprio atributo.
+            if (draggable && (groupByFieldInfo.modifiers || {}).readonly) {
+                drag_attr_readonly = groupByFieldInfo.modifiers.readonly;
+            } else if (draggable && groupByFieldInfo.readonly !== undefined) {
                 draggable = !(groupByFieldInfo.readonly);
             }
         }
@@ -467,6 +475,7 @@ var KanbanRenderer = BasicRenderer.extend({
         var groupByTooltip = groupByFieldInfo && groupByFieldInfo.options.group_by_tooltip;
         this.columnOptions = _.extend(this.columnOptions, {
             draggable: force_draggable && draggable,
+            group_readonly: drag_attr_readonly,
             group_by_tooltip: groupByTooltip,
             groupedBy: groupByField,
             grouped_by_m2o: this.groupedByM2O,


### PR DESCRIPTION
# Descrição

- Adiciona funcionamento de atributos de campos readonly no kanban
  - Corrige no agrupamento de registros, o bloqueio caso o campo tenha nos attrs declarados, uma regra para o readonly.

  - Quando carregamos um campo no kanban, verifica o atributo `attrs` dos campos para determinar se pode ser arrastado o registro para outras colunas do kanban, alterando o valor do campo de agrupamento.

  - Adiciona verificação da tag 'dragging' nas options dos campos no kanban, para forçar que um registro possa ter o valor alterado quando agrupado, apesar de estar bloqueado na tag `kanban`.

# Informações adicionais

- [T8719](https://multi.multidados.tech/web?#id=9128&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [oca-web](https://github.com/multidadosti-erp/web/pull/14)
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1585)