### PR TITLE
T8807 - Melhorias no core

### DIFF
--- a/addons/web/static/src/js/fields/relational_fields.js
+++ b/addons/web/static/src/js/fields/relational_fields.js
@@ -2471,8 +2471,12 @@ var FieldSelection = AbstractField.extend({
             this.values = this.record.specialData[this.name];
             this.formatType = 'many2one';
         } else {
+            // Adicionado pela Multidados:
+            //  - Adiciona obtenção de valores que não serão exibidos na hora
+            //   de selecionar um valor para o campo 'selection' (restrict_selection)
+            var restrict_selection = this.nodeOptions.restrict_selection || [];
             this.values = _.reject(this.field.selection, function (v) {
-                return v[0] === false && v[1] === '';
+                return (v[0] === false && v[1] === '') || restrict_selection.includes(v[0]);
             });
         }
         if (!this.attrs.modifiersValue || !this.attrs.modifiersValue.required) {

--- a/addons/web/static/src/js/views/form/form_controller.js
+++ b/addons/web/static/src/js/views/form/form_controller.js
@@ -504,6 +504,14 @@ var FormController = BasicController.extend({
             def = d.promise();
         } else if (attrs.special === 'cancel') {
             def = this._callButtonAction(attrs, event.data.record);
+
+        // Adicionado pela Multidados:
+        // - Adiciona tratamento para botões dropdown-toggle, não executa
+        //   nada, somente habilita os botões novamente.
+        } else if (attrs.type === 'dropdown') {
+            def = $.Deferred().promise();
+            this._enableButtons();
+
         } else if (!attrs.special || attrs.special === 'save') {
             // save the record but don't switch to readonly mode
             def = saveAndExecuteAction();

--- a/odoo/import_xml.rng
+++ b/odoo/import_xml.rng
@@ -19,6 +19,7 @@
     <rng:define name="value">
         <rng:element name="value">
             <rng:optional><rng:attribute name="model" /></rng:optional>
+            <rng:optional><rng:attribute name="name" /></rng:optional>
             <rng:choice>
                 <rng:attribute name="search" />
                 <rng:attribute name="eval" />

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -177,7 +177,7 @@ def _eval_xml(self, node, env):
                 return tuple(res)
             return res
     elif node.tag == "function":
-        args = []
+        args, kwargs = [], {}
         a_eval = node.get('eval')
         model_str = node.get('model')
         # FIXME: should probably be exclusive
@@ -187,11 +187,18 @@ def _eval_xml(self, node, env):
         for n in node:
             return_val = _eval_xml(self, n, env)
             if return_val is not None:
-                args.append(return_val)
+                # Alterado pela Multidados:
+                # - Permite que o atributo 'name' seja passado na tag
+                #   <value> do xml, para que o argumento seja passado
+                #   como 'kwargs' ao inves de 'args'
+                if n.tag == 'value' and n.get('name'):
+                    kwargs.update({n.get('name'): return_val})
+                else:
+                    args.append(return_val)
         model = env[model_str]
         method = node.get('name')
         # this one still depends on the old API
-        return odoo.api.call_kw(model, method, args, {})
+        return odoo.api.call_kw(model, method, args, kwargs)
     elif node.tag == "test":
         return node.text
 


### PR DESCRIPTION
# Descrição

- Implementa utilização de KWARGS em tags <function> no XML
  - Ao cirar uma função para ser executada na atualização do módulo, com a tag `<function>` no xml, somente era possível passar os argumentos nas tags `<value>` da forma sequencial de 'args'.
  - Adiciona atributo `name` no rng da tag value, para que o valor do argumento passado seja executado como kwarg, sendo o valor do name a chave do kwarg.
  - Definição de arg e kwarg:
    - *arg*: argumento passado para função posicionalmente.
    - *kwarg*: argumento passdo para a função nominalmente (key-arg)

- Permite a exclusão de itens na hora de selecionar valor Selection
  - Permite remover opções de seleção no campo Selection.
  - Adicionar na view a option no campo selection `restrict_selection`

- Adiciona JS para tratar cliques em botões dropdown no Statusbar
  - Adiciona comportamento para habilitar novamente os botões e retornar uma promisse vazia.

# Informações adicionais

- [T8807](https://multi.multidados.tech/web?#id=9216&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)