### PR TITLE
T8827 - Ajustes Contrato Tipo Hora

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -127,6 +127,34 @@ class Currency(models.Model):
                         )
         return amount_words
 
+    def get_locale_value(self, original_value, company=False):
+        """ Adicionado pela Multidados:
+
+        - Sobrescreve função básica da classe 'models.Model' para que
+          quando chamada a partir de uma moeda (res.currency), utiliza
+          ela para formatar o valor, e não somente a moeda definida no
+          local, pela lib 'locale' em 'currency'.
+
+        - Utiliza a formatação pela linguagem definida no contexto.
+
+        Arguments:
+            original_value {float} -- Valor a ser formatado de acordo.
+
+        Returns:
+            str -- Valor formatado para moeda do usuário.
+        """
+        lang = self.env['res.lang']._lang_get(self._context.get('lang') or 'pt_BR')
+
+        fmt = "%.{0}f".format(self.decimal_places)
+        fmt = lang.format(fmt, self.round(original_value), grouping=True, monetary=True)
+
+        if self.position == 'before':
+            fmt = '{symbol} {value}'.format(symbol=self.symbol or '', value=fmt)
+        else:
+            fmt = '{value} {symbol}'.format(symbol=self.symbol or '', value=fmt)
+        return fmt
+
+
     @api.multi
     def round(self, amount):
         """Return ``amount`` rounded  according to ``self``'s rounding rules.

--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -182,7 +182,7 @@ class Lang(models.Model):
 
     @tools.ormcache('code')
     def _lang_get_id(self, code):
-        return (self.search([('code', '=', code)]) or
+        return (self.search([('code', '=', code), ('active', 'in', [True, False])]) or
                 self.search([('code', '=', 'en_US')]) or
                 self.search([], limit=1)).id
 


### PR DESCRIPTION
# Descrição

- Formatação de moeda específica quando chamada a partir de uma moeda
  - A função `get_locale_value` é adicionada nas models padrão, para obter um valor no formato monetário para a localização atual, com base na linguagem do usuário ativo.
    - A função foi sobrescrita para ser executada diferente quando chamada a partir de uma moeda (res.currency)

  - Na obtenção da linguagem, adiciona obtenção de linguagens inativas quando especificadas o campo `code` da linguagem.

# Informações adicionais

- [T8827](https://multi.multidados.tech/web?debug#id=9236&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [private-addons (anterior)](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/972)
- [private-addons (novo)](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/973)