### PR TITLE
T8805 - Ajustar estrutura de dados dos Colaboradores

### DIFF
--- a/addons/hr/views/hr_views.xml
+++ b/addons/hr/views/hr_views.xml
@@ -249,6 +249,7 @@
             <field name="view_mode">tree,form</field>
             <field name="view_id" ref="view_employee_tree"/>
             <field name="domain">[('parent_id','=',False)]</field>
+            <field name="context">{'create': False}</field>
             <field name="search_view_id" ref="view_employee_filter"/>
         </record>
 
@@ -258,6 +259,7 @@
             <field name="view_type">form</field>
             <field name="view_mode">form,tree</field>
             <field name="view_id" eval="False"/>
+            <field name="context">{'create': False}</field>
             <field name="search_view_id" ref="view_employee_filter"/>
         </record>
 
@@ -267,7 +269,7 @@
             <field name="view_type">form</field>
             <field name="view_mode">kanban,tree,form,activity</field>
             <field name="domain">[]</field>
-            <field name="context">{}</field>
+            <field name="context">{'create': False}</field>
             <field name="view_id" eval="False"/>
             <field name="search_view_id" ref="view_employee_filter"/>
             <field name="help" type="html">
@@ -313,6 +315,7 @@
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">hr.employee</field>
             <field name="domain">['|', ('id','in',active_ids), ('parent_id', 'in', active_ids)]</field>
+            <field name="context">{'create': False}</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree,form</field>
             <field name="view_id" ref="view_partner_tree2"/>
@@ -487,7 +490,8 @@
             <field name="search_view_id" ref="view_employee_filter"/>
             <field name="context">{
                 "search_default_department_id": [active_id],
-                "default_department_id": active_id}
+                "default_department_id": active_id,
+                "create": False}
             </field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">

--- a/addons/hr_contract/security/security.xml
+++ b/addons/hr_contract/security/security.xml
@@ -13,7 +13,22 @@
         recebiam o grupo `Contract: Manager`, foi trocado para o grupo
         `Contract: User`.
      -->
-    <data noupdate="1">
+    <function name="write" model="ir.model.data">
+        <function name="search" model="ir.model.data">
+            <value eval="[
+                ('model', 'in', ['res.groups', 'ir.rule']),
+                ('name', 'in', [
+                    'group_hr_contract_user',
+                    'group_hr_contract_manager',
+                    'hr_contract_user_rule',
+                    'hr_contract_manager_rule',
+                ])
+            ]"/>
+        </function>
+        <value eval="{'noupdate': False}" />
+    </function>
+
+    <data noupdate="0">
         <record id="hr_contract.group_hr_contract_user" model="res.groups">
             <field name="name">User</field>
             <field name="category_id" ref="base.module_category_hr_contract"/>

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -9,7 +9,8 @@
        <field name="context">{
            'search_default_is_absent_totay': 1,
            'search_default_department_id': [active_id],
-           'default_department_id': active_id}
+           'default_department_id': active_id,
+           'create': False}
        </field>
        <field name="search_view_id" ref="hr.view_employee_filter"/>
    </record>

--- a/addons/hr_recruitment/views/hr_recruitment_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_views.xml
@@ -874,7 +874,8 @@
         <field name="context">{
             'search_default_newly_hired_employee': 1,
             'search_default_department_id': [active_id],
-            'default_department_id': active_id}
+            'default_department_id': active_id,
+            'create': False}
         </field>
         <field name="search_view_id" ref="hr_employee_view_search"/>
     </record>

--- a/addons/sale_timesheet/tests/common.py
+++ b/addons/sale_timesheet/tests/common.py
@@ -8,14 +8,28 @@ class TestCommonSaleTimesheetNoChart(TestCommonSaleNoChart):
 
     @classmethod
     def setUpEmployees(cls):
+
+        cls.user_employee = cls.env["res.users"].create(
+            {"name": "Test User Employee",
+             "login": "test_employee_user",
+             "email": "testuseremployee@test.com",
+            })
+        cls.user_manager = cls.env["res.users"].create(
+            {"name": "Test User Manager",
+             "login": "test_manager_user",
+             "email": "testusermanager@test.com",
+            })
+
         # Create employees
         cls.employee_user = cls.env['hr.employee'].create({
             'name': 'Employee User',
             'timesheet_cost': 15,
+            'user_id': cls.user_employee.id
         })
         cls.employee_manager = cls.env['hr.employee'].create({
             'name': 'Employee Manager',
             'timesheet_cost': 45,
+            'user_id': cls.user_manager.id
         })
 
     @classmethod

--- a/addons/sale_timesheet/tests/test_project_billing.py
+++ b/addons/sale_timesheet/tests/test_project_billing.py
@@ -14,9 +14,16 @@ class TestProjectBilling(TestCommonSaleTimesheetNoChart):
         # set up
         cls.setUpServiceProducts()
         cls.setUpEmployees()
+
+        cls.user_tde = cls.env['res.users'].create({
+            'name': 'Test TDE',
+            'email': 'employeetesttde@test.com',
+            'login': 'employee_test_tde',
+        })
         cls.employee_tde = cls.env['hr.employee'].create({
             'name': 'Employee TDE',
             'timesheet_cost': 42,
+            'user_id': cls.user_tde.id,
         })
 
         cls.partner_2 = cls.env['res.partner'].create({

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -197,7 +197,10 @@
                             <h2><field name="login"/></h2>
                         </div>
 
-                        <field name="partner_id" nolabel="1" readonly="1" required="0" attrs="{'invisible': [('id', '=', False)]}"/>
+                        <label for="partner_id" class="oe_edit_only"/>
+                        <field name="partner_id" nolabel="1"
+                               required="0"
+                               attrs="{'readonly': [('id', '!=', False)]}"/>
 
                         <notebook>
                             <page name="access_rights" string="Access Rights">


### PR DESCRIPTION
# Descrição

- Bloqueio da criação de 'hr.employee' a partir das Actions da model
  - Os colaboradores, agora são criados somente pelo wizard adicionado no 'br_hr' (`partner.to.employee.wizard`)

- Corrige atualização de grupos de regras ref. à contratos de RH
  - As alterações feitas anteriormente para os grupos e regras de registro ref a contratos de RH (`hr_contract`) não estavam tendo efeito por conta do campo `noupdate=True`.
  - Adiciona function no XML para alterar os valores desse campo dos registros dos groups e regras de contrato de rh.

# Informações adicionais

- [T8805](https://multi.multidados.tech/web?#id=9214&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1614)
- [channel-addons](https://github.com/multidadosti-erp/multichannels-addons/pull/106)