### PR TITLE
T8870 - Tornar Obrigatório o preenchimento dos campos "midia e campanha" - Módulo de Oportunidades/Prospectos.

### DIFF
--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -236,6 +236,8 @@
             <field name="arch" type="xml">
                 <form string="Fields" duplicate="false">
                     <sheet>
+                        <div class="oe_button_box" name="button_box">
+                        </div>                    
                         <group>
                             <group>
                                 <field name="name"/>


### PR DESCRIPTION
# Descrição

Adiciona class="oe_button_box" Form Campos módulo 'base'
- Class adicionada para facilitar a adição de botões nos módulos que herdam essa view.

# Informações adicionais

Dados da tarefa: [T8870](https://multi.multidados.tech/web?debug=1#id=9279&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [1624](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1624)
