### PR TITLE
T8874 - Erro ao Editar o Orçamento

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -345,6 +345,11 @@ class SaleOrder(models.Model):
         - Invoice address
         - Delivery address
         """
+        # Multidados: Adicionado para não regravar os campos caso não tenha mudado o
+        # partner_id.
+        if hasattr(self, '_origin') and self._origin.partner_id == self.partner_id:
+            return
+
         if not self.partner_id:
             self.update({
                 'partner_invoice_id': False,


### PR DESCRIPTION
# Descrição

Ajusta método 'onchange_partner_id' módulo 'sale'
- Adiciona verificação para não regravar campos caso não tenha mudado o partner_id do pedido.

# Informações adicionais

Dados da tarefa: [T8874](https://multi.multidados.tech/web?debug=1#id=9283&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [1625](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1625)
