### PR TITLE
T8911 - Erros de tradução

### DIFF
--- a/addons/crm/i18n/pt_BR.po
+++ b/addons/crm/i18n/pt_BR.po
@@ -1340,7 +1340,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_case_leads_filter
 #: model_terms:ir.ui.view,arch_db:crm.view_crm_case_opportunities_filter
 msgid "Medium"
-msgstr "Mídia"
+msgstr "Média"
 
 #. module: crm
 #: code:addons/crm/models/crm_lead.py:985

--- a/addons/link_tracker/i18n/pt_BR.po
+++ b/addons/link_tracker/i18n/pt_BR.po
@@ -158,7 +158,7 @@ msgstr "Código de Rastreamento de Link"
 #. module: link_tracker
 #: model:ir.model.fields,field_description:link_tracker.field_link_tracker__medium_id
 msgid "Medium"
-msgstr "Mídia"
+msgstr "Média"
 
 #. module: link_tracker
 #: model:ir.model.fields,field_description:link_tracker.field_link_tracker__count

--- a/addons/utm/i18n/pt_BR.po
+++ b/addons/utm/i18n/pt_BR.po
@@ -161,7 +161,7 @@ msgstr "Rastreador de Link"
 #: model_terms:ir.ui.view,arch_db:utm.utm_medium_view_tree
 #: model_terms:ir.ui.view,arch_db:utm.utm_source_view_tree
 msgid "Medium"
-msgstr "Mídia"
+msgstr "Média"
 
 #. module: utm
 #: model:utm.campaign,name:utm.utm_campaign_email_campaign_products
@@ -233,7 +233,7 @@ msgstr "Campanha UTM"
 #. module: utm
 #: model:ir.model,name:utm.model_utm_medium
 msgid "UTM Medium"
-msgstr "Mídia UTM"
+msgstr "Média UTM"
 
 #. module: utm
 #: model:ir.model,name:utm.model_utm_mixin

--- a/addons/website_sale_link_tracker/i18n/pt_BR.po
+++ b/addons/website_sale_link_tracker/i18n/pt_BR.po
@@ -48,7 +48,7 @@ msgstr "Marketing"
 #: model:ir.model.fields,field_description:website_sale_link_tracker.field_sale_report__medium_id
 #, python-format
 msgid "Medium"
-msgstr "Mídia"
+msgstr "Média"
 
 #. module: website_sale_link_tracker
 #. openerp-web


### PR DESCRIPTION
# Descrição

Corrige tradução de "Medium" para "Média" nos módulos 'crm', 'link_tracker', 'utm' e 'website_sale_link_tracker'

# Informações adicionais

Dados da tarefa: [T8911](https://multi.multidados.tech/web#id=9320&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver):

* https://github.com/multidadosti-erp/multichannels-addons/pull/108
* https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1641
