### PR TITLE
T8839 - Corrigir Visão do Calendario com base na permissão do usuario

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_model.js
+++ b/addons/web/static/src/js/views/calendar/calendar_model.js
@@ -589,12 +589,15 @@ return AbstractModel.extend({
                     }
                     records.unshift(me);
                 }
+                // MultidadosTI: link exibia todos os calendarios
+                // Codigo comentado devido ao fato de não ser interessante
+                // que um usuario possa ver eventos de calendario de outros usuarios
                 // add all selection
-                records.push({
-                    'value': 'all',
-                    'label': field.relation === 'res.partner' || field.relation === 'res.users' ? _t("Everybody's calendars") : _t("Everything"),
-                    'active': filter.all,
-                });
+                // records.push({
+                //     'value': 'all',
+                //     'label': field.relation === 'res.partner' || field.relation === 'res.users' ? _t("Everybody's calendars") : _t("Everything"),
+                //     'active': filter.all,
+                // });
 
                 filter.filters = records;
             });


### PR DESCRIPTION
# Descrição

* Remove opção de visualizar todos os calendarios

Objetivo é melhorar a privacidade do usuario, permitindo que somente ele veja seu eventos de calendario.

# Informações adicionais

Dados da tarefa: [T8839](https://multi.multidados.tech/web#id=9248&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)


