### PR TITLE
T8950 - Ajustar menu Pedido nos Orçamentos e Traduções

### DIFF
--- a/addons/mrp/i18n/pt_BR.po
+++ b/addons/mrp/i18n/pt_BR.po
@@ -1787,7 +1787,7 @@ msgstr "Local onde o sistema estocará os produtos acabados."
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_production_form_view
 msgid "Lock"
-msgstr "Trancar"
+msgstr "Concluir"
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_workcenter_productivity__loss_id

--- a/addons/purchase/i18n/pt_BR.po
+++ b/addons/purchase/i18n/pt_BR.po
@@ -883,20 +883,20 @@ msgstr "Carregar a fatura de fornecedor baseada na ordem de compra selecionada. 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_form
 msgid "Lock"
-msgstr "Trancar"
+msgstr "Concluir"
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_contact_config_settings__lock_confirmed_po
 #: model:ir.model.fields,field_description:purchase.field_res_config_settings__lock_confirmed_po
 msgid "Lock Confirmed Orders"
-msgstr "Trancar Pedidos Confirmados"
+msgstr "Concluir Pedidos Confirmados"
 
 #. module: purchase
 #: code:addons/purchase/controllers/portal.py:65
 #: selection:purchase.order,state:0
 #, python-format
 msgid "Locked"
-msgstr "Trancado"
+msgstr "Concluído"
 
 #. module: purchase
 #: model:ir.model.fields,field_description:purchase.field_purchase_order__message_main_attachment_id

--- a/addons/sale/i18n/pt_BR.po
+++ b/addons/sale/i18n/pt_BR.po
@@ -1780,7 +1780,7 @@ msgstr "É verdadeiro se o linha pedido de venda vem de uma despesa ou contas de
 #, python-format
 msgid "It is forbidden to modify the following fields in a locked order:\n"
 "%s"
-msgstr "É proibido a modificação dos seguintes campos em um pedido trancado:\n"
+msgstr "É proibido a modificação dos seguintes campos em um pedido Concluído:\n"
 "%s"
 
 #. module: sale
@@ -1854,18 +1854,18 @@ msgstr "Vamos criar uma novo orçamento.<br><i>Observe que botões coloridos ger
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.view_order_form
 msgid "Lock"
-msgstr "Trancar"
+msgstr "Concluir"
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_contact_config_settings__auto_done_setting
 #: model:ir.model.fields,field_description:sale.field_res_config_settings__auto_done_setting
 msgid "Lock Confirmed Sales"
-msgstr "Trancar Vendas Confirmadas"
+msgstr "Concluir Vendas Confirmadas"
 
 #. module: sale
 #: selection:sale.order,state:0
 msgid "Locked"
-msgstr "Trancado"
+msgstr "Concluído"
 
 #. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.onboarding_quotation_layout_step
@@ -2294,6 +2294,11 @@ msgstr "Quantidades solicitadas"
 #: model:ir.ui.menu,name:sale.sale_order_menu
 msgid "Orders"
 msgstr "Pedidos"
+
+#. module: sale
+#: model:ir.ui.menu,name:sale.menu_sale_order_done
+msgid "Orders Done"
+msgstr "Pedidos Concluídos"
 
 #. module: sale
 #: model:ir.actions.act_window,name:sale.action_orders_to_invoice
@@ -2815,6 +2820,11 @@ msgid "Reference of the document that generated this sales order request."
 msgstr "Referência para o documento que gerou esta solicitação de pedido de venda."
 
 #. module: sale
+#: model:ir.ui.menu,name:sale.sale_order_menu_reg
+msgid "Registrations"
+msgstr "Cadastros"
+
+#. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
 msgid "Reject This Quotation"
 msgstr "Rejeite este Orçamento"
@@ -3031,7 +3041,12 @@ msgstr "Pedido(s) de Venda"
 #: model_terms:ir.ui.view,arch_db:sale.view_sale_order_pivot
 #, python-format
 msgid "Sales Orders"
-msgstr "Ordens de Vendas"
+msgstr "Pedidos"
+
+#. module: sale
+#: model:ir.actions.act_window,name:sale.action_orders_done
+msgid "Sales Orders Done"
+msgstr "Pedidos Concuídos"
 
 #. module: sale
 #: model:ir.model.fields,field_description:sale.field_account_invoice__team_id

--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -2220,6 +2220,11 @@ msgid "Orders"
 msgstr ""
 
 #. module: sale
+#: model:ir.ui.menu,name:sale.menu_sale_order_done
+msgid "Orders Done"
+msgstr ""
+
+#. module: sale
 #: model:ir.actions.act_window,name:sale.action_orders_to_invoice
 #: model:ir.ui.menu,name:sale.menu_sale_order_invoice
 #: model_terms:ir.ui.view,arch_db:sale.crm_team_salesteams_view_kanban
@@ -2741,6 +2746,11 @@ msgstr ""
 #. module: sale
 #: model:ir.model.fields,help:sale.field_sale_order__origin
 msgid "Reference of the document that generated this sales order request."
+msgstr ""
+
+#. module: sale
+#: model:ir.ui.menu,name:sale.sale_order_menu_reg
+msgid "Registrations"
 msgstr ""
 
 #. module: sale

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -13,17 +13,23 @@
             parent="sale_menu_root"
             sequence="2"/>
 
+        <menuitem id="sale_order_menu_reg"
+            name="Registrations"
+            parent="sale_order_menu"
+            sequence="4"/>
+
         <menuitem id="report_sales_team"
             name="Sales Teams"
-            parent="sale_order_menu"
+            parent="sale_order_menu_reg"
             groups="sales_team.group_sale_manager"
             action="sales_team.crm_team_salesteams_act"
-            sequence="3"/>
+            sequence="2"/>
 
         <menuitem id="res_partner_menu"
-            parent="sale_order_menu"
+            parent="sale_order_menu_reg"
             action="base.action_partner_form"
-            sequence="4" groups="sales_team.group_sale_salesman"/>
+            sequence="1" 
+            groups="sales_team.group_sale_salesman"/>
 
         <menuitem id="menu_sale_report"
             name="Reporting"
@@ -725,7 +731,7 @@
             <field name="view_mode">tree,kanban,form,calendar,pivot,graph,activity</field>
             <field name="search_view_id" ref="sale_order_view_search_inherit_sale"/>
             <field name="context">{}</field>
-            <field name="domain">[('state', 'not in', ('draft', 'sent', 'cancel'))]</field>
+            <field name="domain">[('state', '=', 'sale')]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     Create a new quotation, the first step of a new sale!
@@ -781,7 +787,75 @@
             name="Orders"
             action="action_orders"
             parent="sale_order_menu"
-            sequence="2" groups="sales_team.group_sale_salesman"/>
+            sequence="2" 
+            groups="sales_team.group_sale_salesman"/>
+
+       <record id="action_orders_done" model="ir.actions.act_window">
+            <field name="name">Sales Orders Done</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">sale.order</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,kanban,form,calendar,pivot,graph,activity</field>
+            <field name="search_view_id" ref="sale_order_view_search_inherit_sale"/>
+            <field name="context">{}</field>
+            <field name="domain">[('state', '=', 'done')]</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    Create a new quotation, the first step of a new sale!
+                </p><p>
+                    Once the quotation is done, it becomes a sales order.<br/> You will be able to create an invoice and collect the payment.
+                </p>
+            </field>
+        </record>
+
+        <record id="sale_order_done_action_view_order_tree" model="ir.actions.act_window.view">
+            <field name="sequence" eval="1"/>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="sale.view_order_tree"/>
+            <field name="act_window_id" ref="action_orders_done"/>
+        </record>
+
+        <record id="sale_order_done_action_view_order_kanban" model="ir.actions.act_window.view">
+            <field name="sequence" eval="2"/>
+            <field name="view_mode">kanban</field>
+            <field name="view_id" ref="sale.view_sale_order_kanban"/>
+            <field name="act_window_id" ref="action_orders_done"/>
+        </record>
+
+        <record id="sale_order_done_action_view_order_form" model="ir.actions.act_window.view">
+            <field name="sequence" eval="3"/>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="sale.view_order_form"/>
+            <field name="act_window_id" ref="action_orders_done"/>
+        </record>
+
+        <record id="sale_order_done_action_view_order_calendar" model="ir.actions.act_window.view">
+            <field name="sequence" eval="4"/>
+            <field name="view_mode">calendar</field>
+            <field name="view_id" ref="sale.view_sale_order_calendar"/>
+            <field name="act_window_id" ref="action_orders_done"/>
+        </record>
+
+        <record id="sale_order_done_action_view_order_pivot" model="ir.actions.act_window.view">
+            <field name="sequence" eval="5"/>
+            <field name="view_mode">pivot</field>
+            <field name="view_id" ref="sale.view_sale_order_pivot"/>
+            <field name="act_window_id" ref="action_orders_done"/>
+        </record>
+
+        <record id="sale_order_done_action_view_order_graph" model="ir.actions.act_window.view">
+            <field name="sequence" eval="6"/>
+            <field name="view_mode">graph</field>
+            <field name="view_id" ref="sale.view_sale_order_graph"/>
+            <field name="act_window_id" ref="action_orders_done"/>
+        </record>
+
+        <menuitem id="menu_sale_order_done"
+            name="Orders Done"
+            action="action_orders_done"
+            parent="sale_order_menu"
+            sequence="3" 
+            groups="sales_team.group_sale_salesman"/>
 
         <record id="action_orders_to_invoice" model="ir.actions.act_window">
             <field name="name">Orders to Invoice</field>
@@ -805,7 +879,8 @@
         <menuitem id="menu_sale_invoicing"
             name="To Invoice"
             parent="sale_menu_root"
-            sequence="3" groups="sales_team.group_sale_salesman"/>
+            sequence="4" 
+            groups="sales_team.group_sale_salesman"/>
 
         <menuitem id="menu_sale_order_invoice"
             action="action_orders_to_invoice"
@@ -834,10 +909,10 @@
               </p>
             </field>
         </record>
+
         <menuitem action="action_orders_upselling"
             id="menu_sale_order_upselling" parent="sale.menu_sale_invoicing"
             sequence="5" active="False"/>
-
 
         <record id="action_quotations_with_onboarding" model="ir.actions.act_window">
             <field name="name">Quotations</field>

--- a/addons/stock/i18n/pt_BR.po
+++ b/addons/stock/i18n/pt_BR.po
@@ -2824,7 +2824,7 @@ msgstr "Locais"
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
 msgid "Lock"
-msgstr "Trancar"
+msgstr "Concluír"
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.product_category_form_view_inherit


### PR DESCRIPTION
# Descrição

[Ajusta Tradução pt_br do módulo 'stock'](https://github.com/multidadosti-erp/odoo/commit/69f91dc9e54790c3e5fa8f3da366467f78aedf43)

[Ajusta Menu Pedidos e Traduções no Core do Odoo](https://github.com/multidadosti-erp/odoo/commit/ff55d7499379a3a3f387d63ed4be746ca812d336) 

- Tradução pt_br para os módulos: 'mrp', 'purchase' e 'sale'
- Ajuste do Menu no módulo 'sale'

# Informações adicionais

Dados da tarefa: [T8950](link)


