### PR TITLE
T8959 - Erro ao trocar nome de produto ja cadastrado, o sistema está apresentando restrição de acesso.

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3571,7 +3571,11 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                     self.env['ir.translation']._sync_terms_translations(field, self)
                 elif has_translation and field.translate:
                     # The translated value of a field has been modified.
-                    src_trans = self.read([name])[0][name]
+                    
+                    # Multidados: Adicionado o Sudo para resolver os casos de campos related 
+                    # com tabelas sem acesso pelo usuário.
+                    src_trans = self.sudo().read([name])[0][name]
+
                     if not src_trans:
                         # Insert value to DB
                         src_trans = vals[name]


### PR DESCRIPTION
# Descrição

Adiciona sudo() translation read 'models.py' do core.
- Adicionado sudo para evitar erros de permissão do Odoo para atualizar campos Related tem tabelas que o usuário não tem acesso.

# Informações adicionais

Dados da tarefa: [T8959](https://multi.multidados.tech/web?debug#id=9368&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)
