### PR TITLE
T8801 - Implementar contratos de RH para colaboradores (Pgto)

### DIFF
--- a/addons/hr/i18n/pt_BR.po
+++ b/addons/hr/i18n/pt_BR.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-07 21:41+0000\n"
-"PO-Revision-Date: 2024-08-07 21:41+0000\n"
+"POT-Creation-Date: 2025-02-06 18:30+0000\n"
+"PO-Revision-Date: 2025-02-06 18:30+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,65 +19,22 @@ msgstr ""
 #: code:addons/hr/models/hr.py:76
 #, python-format
 msgid "%s (copy)"
-msgstr "%s (copy)"
+msgstr "%s (cópia)"
 
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.hr_job_view_kanban
 msgid "&amp;nbsp;"
-msgstr "&amp;nbsp;"
+msgstr ""
 
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.hr_department_view_kanban
 msgid "<i class=\"fa fa-ellipsis-v\" role=\"img\" aria-label=\"Manage\" title=\"Manage\"/>"
-msgstr "<i class=\"fa fa-ellipsis-v\" role=\"img\" aria-label=\"Manage\" title=\"Manage\"/>"
-
-#. module: hr
-#: model_terms:hr.job,website_description:hr.job_ceo
-#: model_terms:hr.job,website_description:hr.job_consultant
-#: model_terms:hr.job,website_description:hr.job_cto
-#: model_terms:hr.job,website_description:hr.job_developer
-#: model_terms:hr.job,website_description:hr.job_hrm
-#: model_terms:hr.job,website_description:hr.job_marketing
-#: model_terms:hr.job,website_description:hr.job_trainee
-msgid "<i>Work in a fun atmosphere</i>"
-msgstr "<i>Trabalhe em um ambiente alegre</i>"
-
-#. module: hr
-#: model_terms:hr.job,website_description:hr.job_ceo
-#: model_terms:hr.job,website_description:hr.job_consultant
-#: model_terms:hr.job,website_description:hr.job_cto
-#: model_terms:hr.job,website_description:hr.job_developer
-#: model_terms:hr.job,website_description:hr.job_hrm
-#: model_terms:hr.job,website_description:hr.job_marketing
-#: model_terms:hr.job,website_description:hr.job_trainee
-msgid "<i>You are passionate</i>"
-msgstr "<i>Você é apaixonado</i>"
-
-#. module: hr
-#: model_terms:hr.job,website_description:hr.job_cto
-#: model_terms:hr.job,website_description:hr.job_developer
-#: model_terms:hr.job,website_description:hr.job_trainee
-msgid "<i>You autonomously and quickly learn</i>"
-msgstr "<i>Você é autodidata e com rápido aprendizado</i>"
-
-#. module: hr
-#: model_terms:hr.job,website_description:hr.job_ceo
-#: model_terms:hr.job,website_description:hr.job_consultant
-#: model_terms:hr.job,website_description:hr.job_hrm
-#: model_terms:hr.job,website_description:hr.job_marketing
-msgid "<i>You easily manage them</i>"
-msgstr "<i>Você poderá gerencia-los facilmente</i>"
+msgstr "<i class=\"fa fa-ellipsis-v\" role=\"img\" aria-label=\"Gerenciar\" title=\"Gerenciar\"/>"
 
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.res_config_settings_view_form
-msgid ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" role=\"img\" aria-label=\"Values set here are company-"
-"specific.\" groups=\"base.group_multi_company\"/>"
-msgstr ""
-"<span class=“fa fa-lg fa-building-o” title=“Values set here are company-"
-"specific.” role=“img” aria-label=“Values set here are company-specific.” "
-"groups=“base.group_multi_company”/>"
+msgid "<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-specific.\" role=\"img\" aria-label=\"Values set here are company-specific.\" groups=\"base.group_multi_company\"/>"
+msgstr "<span class=\"fa fa-lg fa-building-o\" title=\"Os valores definidos aqui são específicos da empresa.\" role=\"img\" aria-label=\"Os valores definidos aqui são específicos da empresa.\" groups=\"base.group_multi_company\"/>"
 
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.hr_department_view_kanban
@@ -96,8 +53,7 @@ msgstr "<span>Para Fazer</span>"
 
 #. module: hr
 #: model:mail.template,body_html:hr.mail_template_data_unknown_employee_email_address
-msgid ""
-"<table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;\"><tr><td align=\"center\">\n"
+msgid "<table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;\"><tr><td align=\"center\">\n"
 "<table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" width=\"590\" style=\"padding: 16px; background-color: white; color: #454748; border-collapse:separate;\">\n"
 "<tbody>\n"
 "    <tr>\n"
@@ -124,8 +80,7 @@ msgid ""
 "</td></tr>\n"
 "</table>\n"
 "            "
-msgstr ""
-"<table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;\"><tr><td align=\"center\">\n"
+msgstr "<table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;\"><tr><td align=\"center\">\n"
 "<table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" width=\"590\" style=\"padding: 16px; background-color: white; color: #454748; border-collapse:separate;\">\n"
 "<tbody>\n"
 "    <tr>\n"
@@ -146,7 +101,7 @@ msgstr ""
 "<tr><td align=\"center\" style=\"min-width: 590px;\">\n"
 "    <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" width=\"590\" style=\"min-width: 590px; background-color: #F1F1F1; color: #454748; padding: 8px; border-collapse:separate;\">\n"
 "      <tr><td style=\"text-align: center; font-size: 13px;\">\n"
-"        Powered by <a target=\"_blank\" href=\"https://www.odoo.com?utm_source=db&amp;utm_medium=hr\" style=\"color: #875A7B;\">Odoo</a>\n"
+"        Powered by <a target=\"_blank\" href=\"https://www.example.com?utm_source=db&amp;utm_medium=hr\" style=\"color: #875A7B;\">MultiERP</a>\n"
 "      </td></tr>\n"
 "    </table>\n"
 "</td></tr>\n"
@@ -253,16 +208,6 @@ msgid "Certificate Level"
 msgstr "Grau de Instrução"
 
 #. module: hr
-#: model:hr.job,name:hr.job_ceo
-msgid "Chief Executive Officer"
-msgstr "Diretor Executivo de Empresa"
-
-#. module: hr
-#: model:hr.job,name:hr.job_cto
-msgid "Chief Technical Officer"
-msgstr "Diretor Técnico de Empresa"
-
-#. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_department__child_ids
 msgid "Child Departments"
 msgstr "Departamentos Filho (Subordinados)"
@@ -325,16 +270,6 @@ msgid "Configuration"
 msgstr "Configuração"
 
 #. module: hr
-#: model:hr.job,name:hr.job_consultant
-msgid "Consultant"
-msgstr "Consultor"
-
-#. module: hr
-#: model:ir.model,name:hr.model_res_partner
-msgid "Contact"
-msgstr "Parceiro"
-
-#. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.view_employee_form
 msgid "Contact Information"
 msgstr "Informação de Contato"
@@ -383,6 +318,7 @@ msgstr "Definir a agenda do recurso"
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__department_id
 #: model:ir.model.fields,field_description:hr.field_hr_job__department_id
+#: model:ir.model.fields,field_description:hr.field_hr_job_mixin__department_id
 #: model_terms:ir.ui.view,arch_db:hr.view_department_filter
 #: model_terms:ir.ui.view,arch_db:hr.view_employee_filter
 #: model_terms:ir.ui.view,arch_db:hr.view_job_filter
@@ -393,6 +329,12 @@ msgstr "Departamento"
 #: model:ir.model.fields,field_description:hr.field_hr_department__name
 msgid "Department Name"
 msgstr "Nome do Departamento"
+
+#. module: hr
+#: model:ir.model.fields,help:hr.field_hr_employee__department_id
+#: model:ir.model.fields,help:hr.field_hr_job_mixin__department_id
+msgid "Department of the employee"
+msgstr "Departamento do colaborador"
 
 #. module: hr
 #: model:ir.actions.act_window,name:hr.open_module_tree_department
@@ -411,6 +353,7 @@ msgstr "Canal de Discussão"
 #: model:ir.model.fields,field_description:hr.field_hr_employee__display_name
 #: model:ir.model.fields,field_description:hr.field_hr_employee_category__display_name
 #: model:ir.model.fields,field_description:hr.field_hr_job__display_name
+#: model:ir.model.fields,field_description:hr.field_hr_job_mixin__display_name
 msgid "Display Name"
 msgstr "Nome exibido"
 
@@ -523,11 +466,6 @@ msgid "Expected number of employees for this job position after new recruitment.
 msgstr "Número de colaboradores para esta posição após o novo processo de contratação."
 
 #. module: hr
-#: model:hr.job,name:hr.job_developer
-msgid "Experienced Developer"
-msgstr "Desenvolvedor Experiente"
-
-#. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__google_drive_link
 msgid "External Drive Link"
 msgstr "Link Externo Drive"
@@ -615,17 +553,13 @@ msgid "Human Resources"
 msgstr "Recursos Humanos"
 
 #. module: hr
-#: model:hr.job,name:hr.job_hrm
-msgid "Human Resources Manager"
-msgstr "Gerente de Recursos Humanos"
-
-#. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_department__id
 #: model:ir.model.fields,field_description:hr.field_hr_employee__id
 #: model:ir.model.fields,field_description:hr.field_hr_employee_category__id
 #: model:ir.model.fields,field_description:hr.field_hr_job__id
+#: model:ir.model.fields,field_description:hr.field_hr_job_mixin__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__identification_id
@@ -659,7 +593,7 @@ msgid "If the active field is set to False, it will allow you to hide the resour
 msgstr "Se o campo ativo for definido como Falso, te permitirá esconder o registro do recurso sem removê-lo"
 
 #. module: hr
-#: code:addons/hr/models/hr.py:296
+#: code:addons/hr/models/hr.py:304
 #, python-format
 msgid "Import Template for Employees"
 msgstr "Template de Importação para Colaboradores"
@@ -698,6 +632,7 @@ msgstr "Descritivo da Função"
 #: model:ir.model,name:hr.model_hr_job
 #: model:ir.model.fields,field_description:hr.field_hr_employee__job_id
 #: model:ir.model.fields,field_description:hr.field_hr_job__name
+#: model:ir.model.fields,field_description:hr.field_hr_job_mixin__job_id
 msgid "Job Position"
 msgstr "Cargo"
 
@@ -709,14 +644,21 @@ msgstr "Cargos"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__job_title
+#: model:ir.model.fields,field_description:hr.field_hr_job_mixin__job_title
 msgid "Job Title"
 msgstr "Função"
+
+#. module: hr
+#: model:ir.model.fields,help:hr.field_hr_employee__job_id
+#: model:ir.model.fields,help:hr.field_hr_job_mixin__job_id
+msgid "Job position linked to the contract"
+msgstr "Cargo vinculado ao contrato"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_department__jobs_ids
 #: model_terms:ir.ui.view,arch_db:hr.view_job_filter
 msgid "Jobs"
-msgstr "Oportunidades de Emprego"
+msgstr "Cargos"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__km_home_work
@@ -728,6 +670,7 @@ msgstr "Distância casa-trabalho"
 #: model:ir.model.fields,field_description:hr.field_hr_employee____last_update
 #: model:ir.model.fields,field_description:hr.field_hr_employee_category____last_update
 #: model:ir.model.fields,field_description:hr.field_hr_job____last_update
+#: model:ir.model.fields,field_description:hr.field_hr_job_mixin____last_update
 msgid "Last Modified on"
 msgstr "Última modificação em"
 
@@ -788,11 +731,6 @@ msgid "Marital Status"
 msgstr "Estado Civil"
 
 #. module: hr
-#: model:hr.job,name:hr.job_marketing
-msgid "Marketing and Community Manager"
-msgstr "Marketing e Gerente de Comunidade"
-
-#. module: hr
 #: selection:hr.employee,marital:0
 msgid "Married"
 msgstr "Casado(a)"
@@ -832,6 +770,11 @@ msgid "Messages"
 msgstr "Mensagens"
 
 #. module: hr
+#: model:ir.model,name:hr.model_hr_job_mixin
+msgid "Mixin for HR Job-related fields"
+msgstr "Mixin para campos relacionados ao cargo de trabalho"
+
+#. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__name
 msgid "Name"
 msgstr "Nome"
@@ -869,7 +812,7 @@ msgstr "Anotação"
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__notes
 msgid "Notes"
-msgstr "Observações"
+msgstr "Anotações"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_department__message_needaction_counter
@@ -931,7 +874,7 @@ msgstr "Quantidade de mensagens não lidas."
 msgid "Odoo's department structure is used to manage all documents\n"
 "                related to employees by departments: expenses, timesheets,\n"
 "                leaves, recruitments, etc."
-msgstr "A estrutura de departamento do Odoo é usada para gerenciar todos documentos\n"
+msgstr "A estrutura de departamento do MultiERP é usada para gerenciar todos documentos\n"
 "       relacionados a colaboradores: despesas, quadros de horários,\n"
 "       afastamentos, recrutamentos, etc."
 
@@ -960,6 +903,11 @@ msgstr "Vencido"
 #: model:ir.model.fields,field_description:hr.field_hr_department__parent_id
 msgid "Parent Department"
 msgstr "Departamento pai"
+
+#. module: hr
+#: model:ir.model,name:hr.model_res_partner
+msgid "Partner"
+msgstr "Parceiro"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__passport_id
@@ -1242,11 +1190,6 @@ msgid "Total Forecasted Employees"
 msgstr "Total de Colaboradores Previstos"
 
 #. module: hr
-#: model:hr.job,name:hr.job_trainee
-msgid "Trainee"
-msgstr "Estagiário"
-
-#. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_department__message_unread
 #: model:ir.model.fields,field_description:hr.field_hr_employee__message_unread
 #: model:ir.model.fields,field_description:hr.field_hr_job__message_unread
@@ -1313,24 +1256,6 @@ msgstr "Com apenas uma rápida olhada na tela de colaboradores do Sistema, você
 "dados de contato, cargo, disponibilidade, etc."
 
 #. module: hr
-#: model_terms:hr.job,website_description:hr.job_ceo
-#: model_terms:hr.job,website_description:hr.job_consultant
-#: model_terms:hr.job,website_description:hr.job_cto
-#: model_terms:hr.job,website_description:hr.job_developer
-#: model_terms:hr.job,website_description:hr.job_hrm
-#: model_terms:hr.job,website_description:hr.job_marketing
-#: model_terms:hr.job,website_description:hr.job_trainee
-msgid ""
-"With our product, which is a suite of 3000 business apps. It is fully open "
-"source, full featured and it’s online offer is 3 times cheaper than "
-"traditional competitors. We have 2.000.000 users, and we're growing fast."
-msgstr ""
-"Com o nosso produto, que é uma suíte de 3000 aplicativos de negócios. Ele é "
-"totalmente open source, cheia de recursos e a oferta on-line é 3 vezes mais "
-"barato que os concorrentes tradicionais. Nós temos 2.000.000 usuários, e "
-"estamos crescendo rapidamente."
-
-#. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__address_id
 msgid "Work Address"
 msgstr "Endereço Comercial"
@@ -1381,13 +1306,13 @@ msgid "Working Hours"
 msgstr "Jornada de Trabalho"
 
 #. module: hr
-#: code:addons/hr/models/hr.py:206
+#: code:addons/hr/models/hr.py:214
 #, python-format
 msgid "You cannot create a recursive hierarchy."
 msgstr "Você não pode criar uma hierarquia recursiva."
 
 #. module: hr
-#: code:addons/hr/models/hr.py:335
+#: code:addons/hr/models/hr.py:343
 #, python-format
 msgid "You cannot create recursive departments."
 msgstr "Você não pode criar um departamento recursivo."

--- a/addons/hr/models/__init__.py
+++ b/addons/hr/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import hr_job_mixin
 from . import hr
 from . import res_config_settings
 from . import mail_alias

--- a/addons/hr/models/hr.py
+++ b/addons/hr/models/hr.py
@@ -96,7 +96,8 @@ class Employee(models.Model):
     _name = "hr.employee"
     _description = "Employee"
     _order = 'name'
-    _inherit = ['mail.thread', 'mail.activity.mixin', 'resource.mixin']
+    _inherit = ['mail.thread', 'mail.activity.mixin', 'resource.mixin',
+                'hr.job.mixin']  # Features for hr.job  # Adicionado pela Multidados
 
     _mail_post_access = 'read'
 
@@ -162,7 +163,10 @@ class Employee(models.Model):
     emergency_phone = fields.Char("Emergency Phone", groups="hr.group_hr_user")
     km_home_work = fields.Integer(string="Km home-work", groups="hr.group_hr_user")
     google_drive_link = fields.Char(string="Employee Documents", groups="hr.group_hr_user")
-    job_title = fields.Char("Job Title")
+
+    # Alterado pela Multidados:
+    # - Transfere campos para o mixin 'hr.job.mixin'
+    #job_title = fields.Char("Job Title")
 
     # image: all image fields are base64 encoded and PIL-supported
     image = fields.Binary(
@@ -185,9 +189,13 @@ class Employee(models.Model):
     mobile_phone = fields.Char('Work Mobile')
     work_email = fields.Char('Work Email')
     work_location = fields.Char('Work Location')
+
     # employee in company
-    job_id = fields.Many2one('hr.job', 'Job Position')
-    department_id = fields.Many2one('hr.department', 'Department')
+    # Alterado pela Multidados:
+    # - Transfere campos para o mixin 'hr.job.mixin'
+    #job_id = fields.Many2one('hr.job', 'Job Position')
+    #department_id = fields.Many2one('hr.department', 'Department')
+
     parent_id = fields.Many2one('hr.employee', 'Manager')
     child_ids = fields.One2many('hr.employee', 'parent_id', string='Subordinates')
     coach_id = fields.Many2one('hr.employee', 'Coach')

--- a/addons/hr/models/hr_job_mixin.py
+++ b/addons/hr/models/hr_job_mixin.py
@@ -1,0 +1,19 @@
+from odoo import models, fields
+
+
+class HrJobMixin(models.AbstractModel):
+    _name = "hr.job.mixin"
+    _description = "Mixin for HR Job-related fields"
+
+
+    department_id = fields.Many2one(
+        "hr.department",
+        string="Department",
+        help="Department of the employee")
+
+    job_id = fields.Many2one(
+        "hr.job",
+        string="Job Position",
+        help="Job position linked to the contract")
+
+    job_title = fields.Char("Job Title")

--- a/addons/hr_contract/i18n/pt_BR.po
+++ b/addons/hr_contract/i18n/pt_BR.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-07 22:03+0000\n"
-"PO-Revision-Date: 2024-08-07 22:03+0000\n"
+"POT-Creation-Date: 2025-02-06 18:44+0000\n"
+"PO-Revision-Date: 2025-02-06 18:44+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,11 +19,6 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_form
 msgid "<span class=\"text-muted\">(If fixed-term contract)</span>"
 msgstr "<span class=\"text-muted\">(se contrato de termo fixo)</span>"
-
-#. module: hr_contract
-#: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_form
-msgid "<span>/ month</span>"
-msgstr "<span>/ mês</span>"
 
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__message_needaction
@@ -72,6 +67,7 @@ msgstr "Cancelado"
 
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__company_id
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__company_id
 msgid "Company"
 msgstr "Empresa"
 
@@ -92,6 +88,11 @@ msgstr "Contagem de contratos"
 
 #. module: hr_contract
 #: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_form
+msgid "Contract Dates"
+msgstr "Datas do Contrato"
+
+#. module: hr_contract
+#: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_form
 msgid "Contract Details"
 msgstr "Detalhes do Contrato"
 
@@ -100,11 +101,6 @@ msgstr "Detalhes do Contrato"
 #: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_form
 msgid "Contract Reference"
 msgstr "Contrato Referência"
-
-#. module: hr_contract
-#: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_form
-msgid "Contract Terms"
-msgstr "Termos do Contrato"
 
 #. module: hr_contract
 #: model:ir.model,name:hr_contract.model_hr_contract_type
@@ -134,7 +130,7 @@ msgid "Contract expired"
 msgstr "Contrato expirado"
 
 #. module: hr_contract
-#: code:addons/hr_contract/models/hr_contract.py:99
+#: code:addons/hr_contract/models/hr_contract.py:119
 #, python-format
 msgid "Contract start date must be earlier than contract end date."
 msgstr "A data de início do contrato deve ser anterior à data de término do contrato."
@@ -147,7 +143,6 @@ msgstr "Contrato a Renovar"
 #. module: hr_contract
 #: model:ir.actions.act_window,name:hr_contract.act_hr_employee_2_hr_contract
 #: model:ir.actions.act_window,name:hr_contract.action_hr_contract
-#: model:ir.ui.menu,name:hr_contract.hr_menu_contract
 #: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_search
 #: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_tree
 #: model_terms:ir.ui.view,arch_db:hr_contract.hr_hr_employee_view_form2
@@ -173,6 +168,7 @@ msgstr "Criado em"
 
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__currency_id
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__currency_id
 msgid "Currency"
 msgstr "Moeda"
 
@@ -189,17 +185,31 @@ msgid "Current Employee"
 msgstr "Colaborador Atual"
 
 #. module: hr_contract
+#: model:ir.model.fields,help:hr_contract.field_hr_contract__schedule_pay
+#: model:ir.model.fields,help:hr_contract.field_hr_contract_mixin__schedule_pay
+msgid "Defines the frequency of the wage payment."
+msgstr "Define a frequência de pagamento do salário."
+
+#. module: hr_contract
 #: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_kanban
 msgid "Delete"
 msgstr "Excluir"
 
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__department_id
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__department_id
 msgid "Department"
 msgstr "Departamento"
 
 #. module: hr_contract
+#: model:ir.model.fields,help:hr_contract.field_hr_contract__department_id
+#: model:ir.model.fields,help:hr_contract.field_hr_contract_mixin__department_id
+msgid "Department of the employee"
+msgstr "Departamento do colaborador"
+
+#. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__display_name
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__display_name
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract_type__display_name
 msgid "Display Name"
 msgstr "Nome exibido"
@@ -218,12 +228,14 @@ msgstr "Editar Contrato"
 #: model:hr.contract.type,name:hr_contract.hr_contract_type_emp
 #: model:ir.model,name:hr_contract.model_hr_employee
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__employee_id
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__employee_id
 #: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_search
 msgid "Employee"
 msgstr "Colaborador"
 
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__type_id
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__type_id
 msgid "Employee Category"
 msgstr "Categoria de Colaboradores"
 
@@ -233,17 +245,26 @@ msgid "Employee Contracts"
 msgstr "Contratos de Colaboradores"
 
 #. module: hr_contract
+#: model:ir.model.fields,help:hr_contract.field_hr_contract__employee_id
+#: model:ir.model.fields,help:hr_contract.field_hr_contract_mixin__employee_id
+msgid "Employee linked to the contract"
+msgstr "Colaborador ligado ao contrato"
+
+#. module: hr_contract
 #: model:ir.model.fields,help:hr_contract.field_hr_contract__wage
+#: model:ir.model.fields,help:hr_contract.field_hr_contract_mixin__wage
 msgid "Employee's monthly gross wage."
 msgstr "Salário bruto mensal do colaborador."
 
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__date_end
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__date_end
 msgid "End Date"
 msgstr "Data Final"
 
 #. module: hr_contract
 #: model:ir.model.fields,help:hr_contract.field_hr_contract__date_end
+#: model:ir.model.fields,help:hr_contract.field_hr_contract_mixin__date_end
 msgid "End date of the contract (if it's a fixed-term contract)."
 msgstr "Data de término do contrato (se for um contrato a termo)."
 
@@ -304,6 +325,12 @@ msgid "Green this button when the contract information has been transfered to th
 msgstr "Deixe verde este botão quando as informações foram transferidas para a secretaria social."
 
 #. module: hr_contract
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract__wage
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__wage
+msgid "Gross Wage"
+msgstr "Salário Bruto"
+
+#. module: hr_contract
 #: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_search
 msgid "Group By"
 msgstr "Agrupar Por"
@@ -316,7 +343,13 @@ msgid "HR Contract: update state"
 msgstr "Contrato de RH: estado de atualização"
 
 #. module: hr_contract
+#: model:ir.ui.menu,name:hr_contract.hr_menu_contract
+msgid "HR Contracts"
+msgstr "Contratos de RH"
+
+#. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__id
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__id
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract_type__id
 msgid "ID"
 msgstr ""
@@ -358,11 +391,25 @@ msgstr "Trabalho"
 
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__job_id
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__job_id
 msgid "Job Position"
 msgstr "Cargo"
 
 #. module: hr_contract
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract__job_title
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__job_title
+msgid "Job Title"
+msgstr "Função"
+
+#. module: hr_contract
+#: model:ir.model.fields,help:hr_contract.field_hr_contract__job_id
+#: model:ir.model.fields,help:hr_contract.field_hr_contract_mixin__job_id
+msgid "Job position linked to the contract"
+msgstr "Cargo relacionado ao contrato"
+
+#. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract____last_update
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin____last_update
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract_type____last_update
 msgid "Last Modified on"
 msgstr "Última modificação em"
@@ -420,9 +467,15 @@ msgid "Messages"
 msgstr "Mensagens"
 
 #. module: hr_contract
-#: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_form
-msgid "Monthly Advantages in Cash"
-msgstr "Benefícios Mensais em Dinheiro"
+#: model:ir.model,name:hr_contract.model_hr_contract_mixin
+msgid "Mixin for HR Contract fields for wizards and logs tables"
+msgstr "Mixin para os campos de Contrato de RH para wizards e tabelas de logs"
+
+#. module: hr_contract
+#: selection:hr.contract,schedule_pay:0
+#: selection:hr.contract.mixin,schedule_pay:0
+msgid "Monthly"
+msgstr "Mensal"
 
 #. module: hr_contract
 #: selection:hr.contract,state:0
@@ -446,9 +499,10 @@ msgstr "Tipo da Próxima Atividade"
 
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__notes
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__notes
 #: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_form
 msgid "Notes"
-msgstr "Observações"
+msgstr "Anotações"
 
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__message_needaction_counter
@@ -486,6 +540,12 @@ msgid "Planned"
 msgstr "Planejado"
 
 #. module: hr_contract
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract__recurrency_label
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__recurrency_label
+msgid "Recurrency Label"
+msgstr "Rótulo da recorrência"
+
+#. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__activity_user_id
 msgid "Responsible User"
 msgstr "Usuário Responsável"
@@ -499,6 +559,17 @@ msgstr "Em Uso"
 #: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_form
 msgid "Salary Information"
 msgstr "Informação de Salário"
+
+#. module: hr_contract
+#: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_form
+msgid "Sallary"
+msgstr "Salário"
+
+#. module: hr_contract
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract__schedule_pay
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__schedule_pay
+msgid "Scheduled Pay"
+msgstr "Frequência de Pagamento"
 
 #. module: hr_contract
 #: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_search
@@ -528,11 +599,13 @@ msgstr "Secretaría Social"
 
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__date_start
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract_mixin__date_start
 msgid "Start Date"
 msgstr "Data de Início"
 
 #. module: hr_contract
 #: model:ir.model.fields,help:hr_contract.field_hr_contract__date_start
+#: model:ir.model.fields,help:hr_contract.field_hr_contract_mixin__date_start
 msgid "Start date of the contract."
 msgstr "Data inicial do contrato."
 
@@ -590,6 +663,12 @@ msgid "Today Activities"
 msgstr "Atividades de Hoje"
 
 #. module: hr_contract
+#: model:ir.model.fields,help:hr_contract.field_hr_contract__type_id
+#: model:ir.model.fields,help:hr_contract.field_hr_contract_mixin__type_id
+msgid "Type of the contract"
+msgstr "Tipo do contrato"
+
+#. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__message_unread
 msgid "Unread Messages"
 msgstr "Mensagens não lidas"
@@ -615,9 +694,14 @@ msgid "Visa No"
 msgstr "Núm. do Visto"
 
 #. module: hr_contract
-#: model:ir.model.fields,field_description:hr_contract.field_hr_contract__wage
-msgid "Wage"
-msgstr "Salário"
+#: model:ir.model.fields,field_description:hr_contract.field_hr_contract__website_message_ids
+msgid "Website Messages"
+msgstr "Mensagens do Site"
+
+#. module: hr_contract
+#: model:ir.model.fields,help:hr_contract.field_hr_contract__website_message_ids
+msgid "Website communication history"
+msgstr "Histórico de Comunicação do Site"
 
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__permit_no
@@ -627,10 +711,28 @@ msgstr "Permissão de Trabalho Num."
 #. module: hr_contract
 #: model:hr.contract.type,name:hr_contract.hr_contract_type_wrkr
 msgid "Worker"
-msgstr ""
+msgstr "Contratado"
 
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__resource_calendar_id
 msgid "Working Schedule"
 msgstr "Horário de Trabalho"
+
+#. module: hr_contract
+#: selection:hr.contract,schedule_pay:0
+#: selection:hr.contract.mixin,schedule_pay:0
+msgid "Yearly"
+msgstr "Anualmente"
+
+#. module: hr_contract
+#: code:addons/hr_contract/models/hr_contract_mixin.py:81
+#, python-format
+msgid "month"
+msgstr "mês"
+
+#. module: hr_contract
+#: code:addons/hr_contract/models/hr_contract_mixin.py:82
+#, python-format
+msgid "year"
+msgstr "ano"
 

--- a/addons/hr_contract/models/__init__.py
+++ b/addons/hr_contract/models/__init__.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+# Adicionado pela Multidados:
+from . import hr_contract_mixin
+
 from . import hr_contract

--- a/addons/hr_contract/models/hr_contract_mixin.py
+++ b/addons/hr_contract/models/hr_contract_mixin.py
@@ -1,0 +1,92 @@
+# Parte do conteúdo da model 'hr.contract' dos módulos
+# 'hr_contract' e 'hr_payroll' foi transferida para este
+# mixin, a fim de facilitar a reutilização dos campos nas
+# models de Logs de contrato e Wizard de atualização
+# (hr.employee.update) e (update.employee.contract.wizard)
+
+from odoo import models, fields, api, _
+
+
+class HrContractMixin(models.AbstractModel):
+    _name = 'hr.contract.mixin'
+    _inherit = ['hr.job.mixin']
+    _description = 'Mixin for HR Contract fields for wizards and logs tables'
+
+
+    # Campos do módulo hr_contract
+    employee_id = fields.Many2one(
+        'hr.employee',
+        string='Employee',
+        required=False,
+        help="Employee linked to the contract")
+
+    type_id = fields.Many2one(
+        "hr.contract.type",
+        string="Employee Category",
+        required=True,
+        default=lambda self: self.env['hr.contract.type'].search([], limit=1),
+        help="Type of the contract")
+
+    date_start = fields.Date(
+        string="Start Date",
+        required=True,
+        default=fields.Date.today,
+        help="Start date of the contract.")
+
+    date_end = fields.Date(
+        string="End Date",
+        help="End date of the contract (if it's a fixed-term contract).")
+
+    # Campos do módulo hr_payroll
+    schedule_pay = fields.Selection([  # importado parcialmente de 'hr_payroll'
+          ('monthly', 'Monthly'),
+          ('yearly', 'Yearly'),
+        ],
+        string="Scheduled Pay",
+        required=True,
+        default="monthly",
+        help="Defines the frequency of the wage payment.")
+
+    wage = fields.Monetary(
+        'Wage',
+        digits=(16, 2),
+        required=True,
+        track_visibility="onchange",
+        help="Employee's monthly gross wage.")
+
+    notes = fields.Text('Notes')
+
+    recurrency_label = fields.Char(
+        string='Recurrency Label',
+        compute='_compute_recurrency_label',
+        store=False)
+
+    company_id = fields.Many2one('res.company')
+
+    currency_id = fields.Many2one(
+        string="Currency",
+        related='company_id.currency_id',
+        readonly=True)
+
+
+    # Adicionado pela Multidados:
+    def _recurrency_label_mappings(self):
+        """ Adicionado pela Multidados:
+        Utilizada para obter a string a mostrar no form de contrato,
+        gravada no campo computado "recurrency_label".
+
+        Returns:
+            dict: Mapeamento do campo 'schedule_pay' com 'recurrency_label'
+        """
+        return {'monthly': _("month"),
+                'yearly': _("year")}
+
+    # Adicionado pela Multidados:
+    @api.depends('schedule_pay')
+    def _compute_recurrency_label(self):
+        """ Adicionado pela Multidados:
+        Valor a renderizar na tela informando a recorrência do salário.
+        """
+        _map = self._recurrency_label_mappings()
+        for rec in self:
+            rec.recurrency_label = _map.get(rec.schedule_pay, "<???>")

--- a/addons/hr_contract/models/hr_contract_mixin.py
+++ b/addons/hr_contract/models/hr_contract_mixin.py
@@ -8,83 +8,85 @@ from odoo import models, fields, api, _
 
 
 class HrContractMixin(models.AbstractModel):
-    _name = 'hr.contract.mixin'
-    _inherit = ['hr.job.mixin']
-    _description = 'Mixin for HR Contract fields for wizards and logs tables'
-
+    _name = "hr.contract.mixin"
+    _inherit = ["hr.job.mixin"]
+    _description = "Mixin for HR Contract fields for wizards and logs tables"
 
     # Campos do módulo hr_contract
     employee_id = fields.Many2one(
-        'hr.employee',
-        string='Employee',
+        "hr.employee",
+        string="Employee",
         required=False,
-        help="Employee linked to the contract")
+        help="Employee linked to the contract",
+    )
 
     type_id = fields.Many2one(
         "hr.contract.type",
         string="Employee Category",
         required=True,
-        default=lambda self: self.env['hr.contract.type'].search([], limit=1),
-        help="Type of the contract")
+        default=lambda self: self.env["hr.contract.type"].search([], limit=1),
+        help="Type of the contract",
+    )
 
     date_start = fields.Date(
         string="Start Date",
         required=True,
         default=fields.Date.today,
-        help="Start date of the contract.")
+        help="Start date of the contract.",
+    )
 
     date_end = fields.Date(
         string="End Date",
-        help="End date of the contract (if it's a fixed-term contract).")
+        help="End date of the contract (if it's a fixed-term contract).",
+    )
 
     # Campos do módulo hr_payroll
-    schedule_pay = fields.Selection([  # importado parcialmente de 'hr_payroll'
-          ('monthly', 'Monthly'),
-          ('yearly', 'Yearly'),
+    schedule_pay = fields.Selection(
+        [  # importado parcialmente de 'hr_payroll'
+            ("monthly", "Monthly"),
+            ("yearly", "Yearly"),
         ],
         string="Scheduled Pay",
         required=True,
         default="monthly",
-        help="Defines the frequency of the wage payment.")
+        help="Defines the frequency of the wage payment.",
+    )
 
     wage = fields.Monetary(
-        'Wage',
+        "Wage",
         digits=(16, 2),
         required=True,
         track_visibility="onchange",
-        help="Employee's monthly gross wage.")
+        help="Employee's monthly gross wage.",
+    )
 
-    notes = fields.Text('Notes')
+    notes = fields.Text("Notes")
 
     recurrency_label = fields.Char(
-        string='Recurrency Label',
-        compute='_compute_recurrency_label',
-        store=False)
+        string="Recurrency Label", compute="_compute_recurrency_label", store=False
+    )
 
-    company_id = fields.Many2one('res.company')
+    company_id = fields.Many2one("res.company")
 
     currency_id = fields.Many2one(
-        string="Currency",
-        related='company_id.currency_id',
-        readonly=True)
-
+        string="Currency", related="company_id.currency_id", readonly=True
+    )
 
     # Adicionado pela Multidados:
     def _recurrency_label_mappings(self):
-        """ Adicionado pela Multidados:
+        """Adicionado pela Multidados:
         Utilizada para obter a string a mostrar no form de contrato,
         gravada no campo computado "recurrency_label".
 
         Returns:
             dict: Mapeamento do campo 'schedule_pay' com 'recurrency_label'
         """
-        return {'monthly': _("month"),
-                'yearly': _("year")}
+        return {"monthly": _("month"), "yearly": _("year")}
 
     # Adicionado pela Multidados:
-    @api.depends('schedule_pay')
+    @api.depends("schedule_pay")
     def _compute_recurrency_label(self):
-        """ Adicionado pela Multidados:
+        """Adicionado pela Multidados:
         Valor a renderizar na tela informando a recorrência do salário.
         """
         _map = self._recurrency_label_mappings()

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -103,46 +103,58 @@
                             <field name="name" placeholder="Contract Reference"/>
                         </h1>
                     </div>
-                    <group>
+                    <group name="main">
                         <group>
-                            <field name="employee_id"/>
-                            <field name="department_id"/>
-                            <field name="job_id"/>
-                        </group>
-                        <group>
-                            <field name="type_id"/>
+                            <field name="employee_id"
+                                   options="{'no_create_edit': True, 'no_open': True}"/>
+                            <field name="type_id"
+                                   options="{'no_create_edit': True}"/>
                             <field name="reported_to_secretariat" widget="toggle_button" options='{"active": "Reported to the social secretariat", "inactive": "To report to the social secretariat"}'/>
                         </group>
+                        <group>
+                            <field name="department_id"
+                                   options="{'no_create_edit': True, 'no_open': True}"/>
+                            <field name="job_id"
+                                   domain="[('department_id', '=', department_id), ('department_id', '=', False)]"
+                                   options="{'no_create_edit': True, 'no_open': True}"/>
+                            <field name="resource_calendar_id"
+                                   options="{'no_create_edit': True, 'no_open': True}"/>
+                        </group>
                     </group>
-                    <notebook>
+                    <notebook name="main">
                         <page string="Contract Details" name="other">
                             <group>
-                                <group name="duration_group" string="Contract Terms">
+                                <group name="duration_group" string="Contract Dates">
                                     <field name="date_start"/>
                                     <label for="date_end"/>
-                                    <div class="o_row">
+                                    <div class="o_row" name="date_end">
                                         <field name="date_end" nolabel="1"/>
                                         <span class="text-muted">(If fixed-term contract)</span>
                                     </div>
                                     <field name="trial_date_end"/>
-                                    <field name="resource_calendar_id"/>
                                 </group>
                             </group>
-                            <group string="Notes">
+                            <group string="Notes" name="notes">
                                 <field name="notes" nolabel="1"/>
                             </group>
                         </page>
                         <page string="Salary Information" name="information">
-                            <group name="main_info">
-                                <group name="salary_and_advantages" string="Monthly Advantages in Cash">
-                                    <label for="wage"/>
-                                    <div class="o_row" name="wage">
-                                        <field name="wage" nolabel="1"/>
-                                        <span>/ month</span>
-                                    </div>
-                                    <field name="advantages" nolabel="1" placeholder="Advantages..." colspan="2" invisible="1"/>
-                                </group>
-                            </group>
+                            <notebook name="in_sallary">
+                                <page string="Sallary" name="sallary">
+                                    <group name="main_info">
+                                        <group name="salary_and_advantages" string="Sallary">
+                                            <field name="currency_id"/>
+                                            <field name="schedule_pay"/>
+                                            <label for="wage"/>
+                                            <div class="o_row" name="wage">
+                                                <field name="wage" nolabel="1"/>
+                                                <span>/ <field name="recurrency_label"/></span>
+                                            </div>
+                                            <field name="advantages" nolabel="1" placeholder="Advantages..." colspan="2" invisible="1"/>
+                                        </group>
+                                    </group>
+                                </page>
+                            </notebook>
                         </page>
                     </notebook>
                     </sheet>
@@ -217,7 +229,7 @@
             <field name="view_type">form</field>
             <field name="view_mode">kanban,tree,form,activity</field>
             <field name="domain">[('employee_id', '!=', False)]</field>
-            <field name="context">{'search_default_current':1, 'search_default_group_by_state': 1}</field>
+            <field name="context">{'search_default_current':1, 'search_default_contract_type': 1}</field>
             <field name="search_view_id" ref="hr_contract_view_search"/>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">

--- a/addons/hr_expense/i18n/pt_BR.po
+++ b/addons/hr_expense/i18n/pt_BR.po
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * hr_expense
+#	* hr_expense
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-27 17:54+0000\n"
-"PO-Revision-Date: 2024-03-27 17:54+0000\n"
+"POT-Creation-Date: 2025-02-06 19:02+0000\n"
+"PO-Revision-Date: 2025-02-06 19:02+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -90,7 +90,7 @@ msgstr "<strong>Pagamento por:</strong>"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.report_expense_sheet
 msgid "<strong>Total</strong>"
-msgstr "Total"
+msgstr ""
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.report_expense_sheet
@@ -201,7 +201,7 @@ msgstr "Reembolso Aprovado"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_filter
 msgid "Approved refunding expense sheets, not the refused ones"
-msgstr "Relatórios de Reembolso de despesas aprovados, sem os recusados"
+msgstr "Relatórios de Reembolso de despesas aprovados, nenhum recusado"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_view_form
@@ -293,12 +293,12 @@ msgstr "Despesas Confirmadas"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_filter
 msgid "Confirmed Expenses to refund"
-msgstr "Despesas Confirmadas para Reembolsar"
+msgstr "Despesas confirmadas para o Reembolso"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_view_form
-msgid "Create Refund Report"
-msgstr "Criar Relatório de Reembolso"
+msgid "Create Expense Report(s)"
+msgstr "Criar Relatório(s) de Despesas"
 
 #. module: hr_expense
 #: model_terms:ir.actions.act_window,help:hr_expense.action_request_approve_expense_sheet
@@ -357,7 +357,6 @@ msgid "Date"
 msgstr "Data"
 
 #. module: hr_expense
-#: model:ir.model.fields,field_description:hr_expense.field_contact_config_settings__expense_alias_prefix
 #: model:ir.model.fields,field_description:hr_expense.field_res_config_settings__expense_alias_prefix
 msgid "Default Alias Name for Expenses"
 msgstr "Apelido Padrão para Despesas"
@@ -379,7 +378,7 @@ msgstr "Descrição"
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet__display_name
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet_register_payment_wizard__display_name
 msgid "Display Name"
-msgstr "Nome a Apresentar"
+msgstr "Nome exibido"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_view_form
@@ -626,7 +625,7 @@ msgstr "Despesas de Seu Membro de Equipe"
 #. module: hr_expense
 #: model:ir.model.fields,help:hr_expense.field_hr_expense_sheet__expense_line_ids
 msgid "Expenses related to the sheet. Changes on this field are managed on 'create' and 'write' methods to keep, expenses with right values for sheet fields on expenses."
-msgstr "Despesas relacionadas ao Relatório. As alterações neste campo são gerenciadas pelos métodos 'create' e 'write', para manter as despesas relacionadas corretamente aos relatórios."
+msgstr "Despesas relacionadas ao relatório. As mudanças nesse campo são gerenciadas pelos métodos 'create' e 'write', para manter as despesas relacionadas corretamente com os relatórios."
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_filter
@@ -804,7 +803,6 @@ msgid "Late Activities"
 msgstr "Últimas Atividades"
 
 #. module: hr_expense
-#: model:ir.model.fields,field_description:hr_expense.field_contact_config_settings__use_mailgateway
 #: model:ir.model.fields,field_description:hr_expense.field_res_config_settings__use_mailgateway
 #: model_terms:ir.ui.view,arch_db:hr_expense.res_config_settings_view_form
 msgid "Let your employees record expenses by email"
@@ -1009,14 +1007,14 @@ msgid "Once your <b>Expense report</b> is ready, you can submit it to your manag
 msgstr "Assim que o seu <b>Relatório de Despesas</b> estiver pronto, você poderá enviá-lo ao seu gerente e aguardar por sua aprovação."
 
 #. module: hr_expense
-#: code:addons/hr_expense/models/hr_expense.py:865
+#: code:addons/hr_expense/models/hr_expense.py:864
 #, python-format
 msgid "Only HR Officers or the concerned employee can reset to draft."
 msgstr "Apenas a equipe do RH ou o colaborador que reportou a despesa podem redefiní-la como provisória."
 
 #. module: hr_expense
-#: code:addons/hr_expense/models/hr_expense.py:826
-#: code:addons/hr_expense/models/hr_expense.py:847
+#: code:addons/hr_expense/models/hr_expense.py:825
+#: code:addons/hr_expense/models/hr_expense.py:846
 #, python-format
 msgid "Only Managers and HR Officers can approve expenses"
 msgstr "Apenas Gerentes e Equipe do RH podem aprovar despesas"
@@ -1073,7 +1071,7 @@ msgstr "Modo de Pagamento"
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet_register_payment_wizard__payment_method_id
 msgid "Payment Type"
-msgstr "Tipo de pagamento"
+msgstr "Tipo de Pagamento"
 
 #. module: hr_expense
 #: selection:hr.expense,activity_state:0
@@ -1507,7 +1505,7 @@ msgid "Website communication history"
 msgstr "Histórico de Comunicação do Site"
 
 #. module: hr_expense
-#: code:addons/hr_expense/models/hr_expense.py:834
+#: code:addons/hr_expense/models/hr_expense.py:833
 #, python-format
 msgid "You can only approve your department expenses"
 msgstr "Você só pode aprovar despesas do seu departamento"
@@ -1519,7 +1517,7 @@ msgid "You can only generate accounting entry for approved expense(s)."
 msgstr "Você só pode gerar entrada contábil de despesa(s) aprovada(s)."
 
 #. module: hr_expense
-#: code:addons/hr_expense/models/hr_expense.py:855
+#: code:addons/hr_expense/models/hr_expense.py:854
 #, python-format
 msgid "You can only refuse your department expenses"
 msgstr "Você só pode recusar despesas do seu departamento"
@@ -1536,7 +1534,7 @@ msgid "You cannot add expenses of another employee."
 msgstr "Você não pode adicionar despesas de outro colaborador."
 
 #. module: hr_expense
-#: code:addons/hr_expense/models/hr_expense.py:831
+#: code:addons/hr_expense/models/hr_expense.py:830
 #, python-format
 msgid "You cannot approve your own expenses"
 msgstr "Você não pode aprovar suas próprias despesas"
@@ -1554,7 +1552,7 @@ msgid "You cannot delete a posted or paid expense."
 msgstr "Você não pode remover uma despesa lançada ou paga."
 
 #. module: hr_expense
-#: code:addons/hr_expense/models/hr_expense.py:852
+#: code:addons/hr_expense/models/hr_expense.py:851
 #, python-format
 msgid "You cannot refuse your own expenses"
 msgstr "Você não pode recusar suas próprias despesas"

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -336,6 +336,7 @@
             <field name="view_mode">tree,kanban,form,activity</field>
             <field name="search_view_id" ref="view_hr_expense_filter"/>
             <field name="context">{'default_payment_mode': 'own_account',
+                                   'search_default_employee': 1,
                                    'search_default_no_report': 1,
                                    'search_default_no_report_invoice': 1}
             </field>

--- a/addons/hr_payroll/models/hr_contract.py
+++ b/addons/hr_payroll/models/hr_contract.py
@@ -1,7 +1,7 @@
 # -*- coding:utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 
 
 class HrContract(models.Model):
@@ -10,20 +10,38 @@ class HrContract(models.Model):
     allows to configure different Salary structure
     """
     _inherit = 'hr.contract'
-    _description = 'Employee Contract'
 
     struct_id = fields.Many2one('hr.payroll.structure', string='Salary Structure')
-    schedule_pay = fields.Selection([
-        ('monthly', 'Monthly'),
+
+    # Alterado pela Multidados:
+    # transfere criação do campo para o módulo 'hr_contract'
+    schedule_pay = fields.Selection(selection_add=[
+        # ('monthly', 'Monthly'), # transferido para o módulo 'hr_contract'
         ('quarterly', 'Quarterly'),
         ('semi-annually', 'Semi-annually'),
-        ('annually', 'Annually'),
+        # ('annually', 'Annually'), # transferido para o módulo 'hr_contract'
         ('weekly', 'Weekly'),
         ('bi-weekly', 'Bi-weekly'),
         ('bi-monthly', 'Bi-monthly'),
-    ], string='Scheduled Pay', index=True, default='monthly',
-    help="Defines the frequency of the wage payment.")
+    ])
     resource_calendar_id = fields.Many2one(required=True, help="Employee's working schedule.")
+
+
+    def _recurrency_label_mappings(self):
+        """ Adiciona Labels para os novos valores do campo
+        Selection 'schedule_pay'.
+
+        Returns:
+            dict: Mapeamento do campo 'schedule_pay' com 'recurrency_label'
+        """
+        return {
+            **super(HrContract, self)._recurrency_label_mappings(),
+            'quarterly': _("quarter"),
+            'semi-annually': _("semester"),
+            'weekly': _("week"),
+            'bi-weekly': _("fortnight"),
+            'bi-monthly': _("two months"),
+        }
 
     @api.multi
     def get_all_structures(self):

--- a/addons/hr_payroll/views/hr_contract_views.xml
+++ b/addons/hr_payroll/views/hr_contract_views.xml
@@ -12,15 +12,8 @@
         <field name="model">hr.contract</field>
         <field name="inherit_id" ref="hr_contract.hr_contract_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='type_id']" position="after">
+            <xpath expr="//field[@name='currency_id']" position="before">
                 <field name="struct_id" required="1"/>
-            </xpath>
-            <xpath expr="//field[@name='type_id']" position="before">
-                <field name="company_id" groups="base.group_multi_company"/>
-                <field name="currency_id" invisible="1"/>
-            </xpath>
-             <xpath expr="//field[@name='resource_calendar_id']" position="after">
-                <field name="schedule_pay"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -607,8 +607,8 @@ class WebsiteSale(ProductConfiguratorController):
                     _logger.debug("website_sale postprocess: %s value has been dropped (empty or not writable)" % k)
 
         new_values['customer'] = True
-        new_values['team_id'] = request.website.salesteam_id and request.website.salesteam_id.id
-        new_values['user_id'] = request.website.salesperson_id and request.website.salesperson_id.id
+        new_values['team_id'] = request.website.salesteam_id.id
+        new_values['user_id'] = request.website.salesperson_id.id
 
         if request.website.specific_user_account:
             new_values['website_id'] = request.website.id


### PR DESCRIPTION
# Descrição

- Altera estrutura inicial do form da model 'hr_contract'
  - Ajusta estrutura básica para não ter que alterar totalmente ela via Xpaths.

- "hr.contract.mixin" para campos básicos relacionado ao contrato HR
  - Para evitar a criação do mesmo campo em algumas tabelas, foi adicionado o mixin para garantir que mantenha os campos sempre herdados.
  - Importa alguns campos que eram exclusivos do 'hr.payroll' para o 'hr_contract'
  - Herdado também no módulo "br_hr_contract"

- "hr.job.mixin" para campos básicos relacionado ao emprego
  - Para evitar a criação do mesmo campo em algumas tabelas, foi adicionado o mixin para garantir que mantenha os campos sempre herdados.
  - Utilizado nos commits seguintes no mixin 'hr.contract'.

# Informações adicionais

- [T8801](https://multi.multidados.tech/web?#id=9210&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [oca-multi-company](https://github.com/multidadosti-erp/multi-company/pull/14)
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1633)
- [private-addons](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/981)
- [channel-addons](https://github.com/multidadosti-erp/multichannels-addons/pull/110)