### PR TITLE
T8957 - Data errada de aviso de Atividade

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -470,9 +470,23 @@ class MailActivity(models.Model):
             activity['mail_template_ids'] = [mail_template_dict[mail_template_id] for mail_template_id in activity['mail_template_ids']]
         return activities
 
+    @api.multi
+    def _get_activity_data_basic_domain(self, res_model):
+        """ Adicionado pela Multidados:
+        Adicionado função para obter o domain das atividades na
+        view do tipo Atividades para as models.
+
+        Args:
+            res_model (str): model a encontrar atividades
+
+        Returns:
+            list: domain para busca de atividades
+        """
+        return [('res_model', '=', res_model)]
+
     @api.model
     def get_activity_data(self, res_model, domain):
-        activity_domain = [('res_model', '=', res_model)]
+        activity_domain = self._get_activity_data_basic_domain(res_model)
         if domain:
             res = self.env[res_model].search(domain)
             activity_domain.append(('res_id', 'in', res.ids))


### PR DESCRIPTION
# Descrição

- Separação de código para herança em oca/social
  - A função de obtenção de atividades pela View do tipo 'activity', realiza um read_group, o qual ignora o método search de atividades ativas.
  - Adiciona uma função para obter o domain, aonde é herdada no módulo `oca/social/mail_activity_done` para utilização do active=True e done=False.

# Informações adicionais

- [T8957](https://multi.multidados.tech/web?#id=9366&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [oca/social](https://github.com/multidadosti-erp/social/pull/28)