### PR TITLE
T9005 - Remover campo "Não associe a um cliente", ao realizar a conversão de prospecto para oportunidade.

### DIFF
--- a/addons/crm/wizard/crm_partner_binding.py
+++ b/addons/crm/wizard/crm_partner_binding.py
@@ -31,7 +31,6 @@ class PartnerBinding(models.TransientModel):
     action = fields.Selection([
         ('exist', 'Link to an existing customer'),
         ('create', 'Create a new customer'),
-        ('nothing', 'Do not link to a customer')
     ], 'Related Customer', required=True)
     partner_id = fields.Many2one('res.partner', 'Customer')
 


### PR DESCRIPTION
# Descrição

* Remove opção de criar oportunidade sem parceiro

Remover a opção 'Não associe a um cliente' ao criar Oportunidade a partir do Prospecto

# Informações adicionais

Dados da tarefa: [T9005](https://multi.multidados.tech/web#id=9414&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

