### PR TITLE
T8990 - Ao Criar uma Folga, espelhar no Calendário

### DIFF
--- a/addons/web/static/lib/fullcalendar/js/fullcalendar.js
+++ b/addons/web/static/lib/fullcalendar/js/fullcalendar.js
@@ -4919,6 +4919,10 @@ Grid.mixin({
 			seg.event = event;
 			seg.eventStartMS = +span.start; // TODO: not the best name after making spans unzoned
 			seg.eventDurationMS = span.end - span.start;
+
+            // Adicionado pela Multidados:
+            // mantém o evento readonly caso o campo 'is_calendar_fixed' = True
+            event.editable = !((event.record || {}).is_calendar_fixed );
 		}
 
 		return segs;


### PR DESCRIPTION
# Descrição

- Lib 'fullcalendar.js': readonly do campo 'is_calendar_fixed'
  - Adiciona verificação para deixar eventos do calendário como readonly quando o campo 'is_calendar_fixed' for = True.
  - A alteração foi feita de forma que se o campo não exista, ele não muda o comportamento atual. Isso porque o campo é adicionado no módulo `br_calendar`.

# Informações adicionais

- [T8990](https://multi.multidados.tech/web?#id=9399&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1667)