### PR TITLE
T9041 - Criar Consultas e Testes pelo Cadastro do Cliente (Paciente)

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -158,7 +158,8 @@
                 <button name="toggle_active" position="before">
                     <button class="oe_stat_button" type="action" name="%(account.action_open_partner_analytic_accounts)d"
                         groups="account.group_account_invoice"
-                        icon="fa-book" title="Analytic Accounts">
+                        icon="fa-book" title="Analytic Accounts"
+                        attrs="{'invisible': [('contracts_count', '=', 0)]}">
                         <field string="Analytic Accounts" name="contracts_count" widget="statinfo"/>
                     </button>
                 </button>

--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -618,6 +618,7 @@ class Meeting(models.Model):
                                     self.env['mail.activity.type'].search([('category', '=', 'meeting')], limit=1).id
         }
         if vals['res_model_id'] and vals['res_id'] and vals['activity_type_id']:
+            vals['res_model'] = self.env['ir.model'].sudo().browse(vals['res_model_id']).model
             user_id = values.get('user_id', defaults.get('user_id'))
             if user_id:
                 vals['user_id'] = user_id
@@ -1954,7 +1955,7 @@ class Meeting(models.Model):
             activity_values['summary'] = values['name']
         if values.get('description'):
             activity_values['note'] = tools.plaintext2html(values['description'])
-        if values.get('start') or values.get('stop'):
+        if values.get('start'):
             # self.start is a datetime UTC *only when the event is not allday*
             # activty.date_deadline is a date (No TZ, but should represent the day in which the user's TZ is)
             # See 72254129dbaeae58d0a2055cba4e4a82cde495b7 for the same issue, but elsewhere

--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -42,10 +42,21 @@ class Partner(models.Model):
             operator = 'child_of' if partner.is_company else '='  # the opportunity count should counts the opportunities of this company and all its contacts
             partner.opportunity_count = self.env['crm.lead'].search_count([('partner_id', operator, partner.id), ('type', '=', 'opportunity')])
 
+    def _get_meetings(self):
+        """ Adicionado pela Multidados
+
+        Método retorna as reuniões do parceiro.
+        Foi adicionado para heranças em outros módulos.
+
+        Returns:
+            recordset: Os registros de reuniões associados ao parceiro.
+        """
+        return self.meeting_ids
+
     @api.multi
     def _compute_meeting_count(self):
         for partner in self:
-            partner.meeting_count = len(partner.meeting_ids)
+            partner.meeting_count = len(partner._get_meetings())
 
     @api.multi
     def schedule_meeting(self):

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -267,7 +267,7 @@
                         </group>
                     </group>
 
-                    <notebook colspan="4">
+                    <notebook colspan="4" name="main">
                         <page name="contacts_and_addresses" string="Contacts &amp; Addresses" autofocus="autofocus">
                             <field name="child_ids" mode="kanban" context="{'default_parent_id': active_id, 'default_street': street, 'default_street2': street2, 'default_city': city, 'default_state_id': state_id, 'default_zip': zip, 'default_country_id': country_id, 'default_supplier': supplier, 'default_customer': customer, 'default_lang': lang, 'default_user_id': user_id}">
                                 <kanban>


### PR DESCRIPTION
# Descrição

- Obter as reuniões do parceiro sem misturar com outros eventos
  - Foi adicionado uma função para obtenção das reuniões do parceiro, para quando adicionado a criação de `calendar.event` em outras models, não misturar com as Reuniões

- Correções na criação do calendar.event
  - O campo res_model_id sem valor, faz com que rotinas sejam chamadas desnecessáriamente.
  - If causava erro quando o evento tinha o valor do stop, atualizado, e o start não.

- Alterações no JavaScript da view de Calendários (filtros padrão)
  - **`calendar_view.js`**:
    - Inclui carregamento de registros utilizados como filtro padrão da view de calendários.
    - Cria estrutura do record para ser enviado para o CalendarModel.
  - **`calendar_model.js`**:
    - Leitura dos registros carregados pelas views e composição para a renderização.
    - Leitura do nome de registros relacionados pela função `(name_get)`

- Atributo name='main' no notebook, para evitar erro de herança

# Informações adicionais

- [T9041](https://multi.multidados.tech/web?#id=9450&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1694)
- [private-addons](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/1018)
- [public-addons](https://github.com/multidadosti-erp/multidadosti-addons/pull/625)
- [web-addons](https://github.com/multidadosti-erp/multidadosti-web-addons/pull/189)