### PR TITLE
T9002 - Permitir cancelar separação de orçamento de locação sem contrato vinculado 

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -216,7 +216,7 @@ class AccountChartTemplate(models.Model):
                 accounting_props.sudo().unlink()
 
             # delete account, journal, tax, fiscal position and reconciliation model
-            models_to_delete = ['account.reconcile.model', 'account.fiscal.position', 'account.tax', 'account.move', 'account.journal']
+            models_to_delete = ['account.reconcile.model', 'account.tax', 'account.move', 'account.journal']
             for model in models_to_delete:
                 res = self.env[model].search([('company_id', '=', company.id)])
                 if len(res):


### PR DESCRIPTION
# Descrição

Remove exclusao de pos. fiscal que estava causando conflito nos testes

Modulo não e usado em producao

# Informações adicionais

- [T9002](https://multi.multidados.tech/web?debug=1#id=9411&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

