### PR TITLE
T9064 - Adicionar no Botões de Exportar XLS as Ações do módulo br_base_export_xls

### DIFF
--- a/addons/web/i18n/pt_BR.po
+++ b/addons/web/i18n/pt_BR.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-23 16:59+0000\n"
-"PO-Revision-Date: 2023-10-23 16:59+0000\n"
+"POT-Creation-Date: 2025-03-25 15:55+0000\n"
+"PO-Revision-Date: 2025-03-25 15:55+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,7 +17,7 @@ msgstr ""
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/calendar/calendar_model.js:579
+#: code:addons/web/static/src/js/views/calendar/calendar_model.js:586
 #, python-format
 msgid " [Me]"
 msgstr " [Eu]"
@@ -40,14 +40,14 @@ msgstr " ou "
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/fields/field_utils.js:296
-#: code:addons/web/static/src/js/views/kanban/kanban_column.js:169
+#: code:addons/web/static/src/js/views/kanban/kanban_column.js:171
 #, python-format
 msgid " records"
 msgstr " registros"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:657
+#: code:addons/web/static/src/xml/base.xml:667
 #, python-format
 msgid "# Code editor"
 msgstr "# Editor de código"
@@ -146,7 +146,7 @@ msgstr "'%s' não é um float correto"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/field_utils.js:629
+#: code:addons/web/static/src/js/fields/field_utils.js:634
 #, python-format
 msgid "'%s' is not a correct integer"
 msgstr "'%s' não é um integer correto"
@@ -174,8 +174,8 @@ msgstr "(mudança)"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:510
-#: code:addons/web/static/src/xml/base.xml:539
+#: code:addons/web/static/src/xml/base.xml:520
+#: code:addons/web/static/src/xml/base.xml:549
 #, python-format
 msgid "(count)"
 msgstr "(contagem)"
@@ -193,6 +193,13 @@ msgstr "(sem string)"
 #, python-format
 msgid "(nolabel)"
 msgstr "(sem rótulo)"
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/js/widgets/float_full_time_widget.js:275
+#, python-format
+msgid ", can not be more than 23:59:59,999 sec and less than 0 sec! Please check it!"
+msgstr ", não pode ser mais que 23:59:59,999 seg e menos que 0 seg! Por favor, verifique!"
 
 #. module: web
 #. openerp-web
@@ -237,14 +244,14 @@ msgstr "Uma janela pop-up com seu relatório foi bloqueada. Pode ser necessário
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:634
+#: code:addons/web/static/src/xml/base.xml:644
 #, python-format
 msgid "ALL"
 msgstr "TODOS"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:635
+#: code:addons/web/static/src/xml/base.xml:645
 #, python-format
 msgid "ANY"
 msgstr "QUALQUER"
@@ -265,7 +272,7 @@ msgstr "Erro de Acesso"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1574
+#: code:addons/web/static/src/xml/base.xml:1585
 #, python-format
 msgid "Access to all Enterprise Apps"
 msgstr "Acesso a todos os aplicativos corporativos"
@@ -309,8 +316,8 @@ msgstr "Ativo"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/relational_fields.js:857
-#: code:addons/web/static/src/xml/base.xml:1417
+#: code:addons/web/static/src/js/fields/relational_fields.js:870
+#: code:addons/web/static/src/xml/base.xml:1428
 #: code:addons/web/static/src/xml/kanban.xml:56
 #: code:addons/web/static/src/xml/kanban.xml:73
 #, python-format
@@ -326,14 +333,14 @@ msgstr "Adicionar %s"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1131
+#: code:addons/web/static/src/xml/base.xml:1142
 #, python-format
 msgid "Add Custom Filter"
 msgstr "Adicionar Filtro Personalizado"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1116
+#: code:addons/web/static/src/xml/base.xml:1127
 #, python-format
 msgid "Add Custom Group"
 msgstr "Adicionar Grupo Personalizado"
@@ -347,7 +354,7 @@ msgstr "Adicionar Coluna"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1135
+#: code:addons/web/static/src/xml/base.xml:1146
 #, python-format
 msgid "Add a condition"
 msgstr "Adicionar condição"
@@ -361,7 +368,7 @@ msgstr "Adicionar linha"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:618
+#: code:addons/web/static/src/xml/base.xml:628
 #, python-format
 msgid "Add branch"
 msgstr "Adicionar ramo"
@@ -375,28 +382,28 @@ msgstr "Adicionar coluna"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:642
+#: code:addons/web/static/src/xml/base.xml:652
 #, python-format
 msgid "Add filter"
 msgstr "Adicionar filtro"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:702
+#: code:addons/web/static/src/xml/base.xml:712
 #, python-format
 msgid "Add new value"
 msgstr "Adicionar novo valor"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:617
+#: code:addons/web/static/src/xml/base.xml:627
 #, python-format
 msgid "Add node"
 msgstr "Adicionar nó"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:703
+#: code:addons/web/static/src/xml/base.xml:713
 #, python-format
 msgid "Add tag"
 msgstr "Adicionar tag"
@@ -417,14 +424,14 @@ msgstr "Adicionar..."
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/relational_fields.js:1636
+#: code:addons/web/static/src/js/fields/relational_fields.js:1649
 #, python-format
 msgid "Add: "
 msgstr "Adicionar: "
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1215
+#: code:addons/web/static/src/xml/base.xml:1226
 #, python-format
 msgid "Advanced Search..."
 msgstr "Busca Avançada..."
@@ -438,23 +445,23 @@ msgstr "Alerta"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:624
-#: code:addons/web/static/src/xml/base.xml:629
+#: code:addons/web/static/src/xml/base.xml:634
+#: code:addons/web/static/src/xml/base.xml:639
 #, python-format
 msgid "All"
 msgstr "Tudo"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/calendar/calendar_model.js:460
-#: code:addons/web/static/src/js/views/calendar/calendar_renderer.js:404
+#: code:addons/web/static/src/js/views/calendar/calendar_model.js:467
+#: code:addons/web/static/src/js/views/calendar/calendar_renderer.js:410
 #, python-format
 msgid "All day"
 msgstr "Dia inteiro"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:496
+#: code:addons/web/static/src/xml/base.xml:506
 #, python-format
 msgid "All users"
 msgstr "Todos os usuários"
@@ -497,24 +504,24 @@ msgstr "Ocorreu um erro desconhecido do CORS. O erro provavelmente se origina de
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1579
+#: code:addons/web/static/src/xml/base.xml:1590
 #, python-format
 msgid "And more"
 msgstr "E mais"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:625
-#: code:addons/web/static/src/xml/base.xml:630
+#: code:addons/web/static/src/xml/base.xml:635
+#: code:addons/web/static/src/xml/base.xml:640
 #, python-format
 msgid "Any"
 msgstr "Alguma"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1125
-#: code:addons/web/static/src/xml/base.xml:1133
-#: code:addons/web/static/src/xml/base.xml:1208
+#: code:addons/web/static/src/xml/base.xml:1136
+#: code:addons/web/static/src/xml/base.xml:1144
+#: code:addons/web/static/src/xml/base.xml:1219
 #, python-format
 msgid "Apply"
 msgstr "Aplicar"
@@ -543,7 +550,7 @@ msgstr "Arquivado"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/kanban/kanban_column.js:386
+#: code:addons/web/static/src/js/views/kanban/kanban_column.js:388
 #, python-format
 msgid "Are you sure that you want to archive all the records from this column?"
 msgstr "Tem certeza de que deseja arquivar todos os registros desta coluna ?"
@@ -557,7 +564,7 @@ msgstr "Tem certeza de que deseja arquivar todos os registros selecionados ?"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/kanban/kanban_column.js:324
+#: code:addons/web/static/src/js/views/kanban/kanban_column.js:326
 #, python-format
 msgid "Are you sure that you want to remove this column ?"
 msgstr "Você tem certeza que quer remover esta coluna ?"
@@ -572,14 +579,14 @@ msgstr "Você tem certeza que quer remover este filtro?"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/basic/basic_controller.js:322
-#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:352
+#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:365
 #, python-format
 msgid "Are you sure you want to delete this record ?"
 msgstr "Você tem certeza que quer excluir este registro?"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1033
+#: code:addons/web/static/src/xml/base.xml:1044
 #, python-format
 msgid "Attach"
 msgstr "Anexar"
@@ -593,7 +600,7 @@ msgstr "Anexo:"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1413
+#: code:addons/web/static/src/xml/base.xml:1424
 #, python-format
 msgid "Available fields"
 msgstr "Campos Disponíveis"
@@ -609,7 +616,7 @@ msgstr ""
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:517
+#: code:addons/web/static/src/xml/base.xml:527
 #, python-format
 msgid "Bar Chart"
 msgstr "Gráfico de Barras"
@@ -621,7 +628,7 @@ msgstr ""
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1148
+#: code:addons/web/static/src/xml/base.xml:1159
 #, python-format
 msgid "Based On"
 msgstr "Baseado em"
@@ -641,7 +648,7 @@ msgstr "Os campos binários não podem ser exportados para o Excel, a menos que 
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:957
+#: code:addons/web/static/src/xml/base.xml:968
 #, python-format
 msgid "Binary file"
 msgstr "Arquivo binário"
@@ -655,7 +662,7 @@ msgstr "Azul"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1578
+#: code:addons/web/static/src/xml/base.xml:1589
 #, python-format
 msgid "Bugfixes guarantee"
 msgstr "Garantia de correções"
@@ -683,7 +690,7 @@ msgstr ""
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1227
+#: code:addons/web/static/src/xml/base.xml:1238
 #, python-format
 msgid "CLEAR"
 msgstr "LIMPAR"
@@ -716,8 +723,8 @@ msgstr "A visão de calendário não definiu o atributo 'date_start'"
 #: code:addons/web/static/src/js/fields/relational_fields.js:66
 #: code:addons/web/static/src/js/fields/upgrade_fields.js:75
 #: code:addons/web/static/src/js/services/crash_manager.js:229
-#: code:addons/web/static/src/js/views/calendar/calendar_quick_create.js:56
-#: code:addons/web/static/src/js/views/kanban/kanban_column.js:318
+#: code:addons/web/static/src/js/views/calendar/calendar_quick_create.js:53
+#: code:addons/web/static/src/js/views/kanban/kanban_column.js:320
 #: code:addons/web/static/src/js/views/view_dialogs.js:405
 #: code:addons/web/static/src/xml/base.xml:181
 #, python-format
@@ -733,7 +740,7 @@ msgstr "Não é possível renderizar gráfico com o modo : "
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/kanban/kanban_record.js:428
+#: code:addons/web/static/src/js/views/kanban/kanban_record.js:436
 #, python-format
 msgid "Card color: %s"
 msgstr "Cor do cartão: %s"
@@ -758,7 +765,7 @@ msgstr "Alterar padrão:"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:516
+#: code:addons/web/static/src/xml/base.xml:526
 #, python-format
 msgid "Change graph"
 msgstr "Alterar gráfico"
@@ -772,9 +779,9 @@ msgstr "Escolher"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:941
-#: code:addons/web/static/src/xml/base.xml:981
-#: code:addons/web/static/src/xml/base.xml:1012
+#: code:addons/web/static/src/xml/base.xml:952
+#: code:addons/web/static/src/xml/base.xml:992
+#: code:addons/web/static/src/xml/base.xml:1023
 #, python-format
 msgid "Clear"
 msgstr "Limpar"
@@ -790,12 +797,12 @@ msgstr "Limpar Eventos"
 #. openerp-web
 #: code:addons/web/static/src/js/fields/basic_fields.js:2197
 #: code:addons/web/static/src/js/tools/debug_manager.js:496
-#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:363
+#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:376
 #: code:addons/web/static/src/js/views/view_dialogs.js:123
 #: code:addons/web/static/src/js/widgets/data_export.js:212
 #: code:addons/web/static/src/js/widgets/domain_selector_dialog.js:24
-#: code:addons/web/static/src/xml/base.xml:745
-#: code:addons/web/static/src/xml/base.xml:1524
+#: code:addons/web/static/src/xml/base.xml:755
+#: code:addons/web/static/src/xml/base.xml:1535
 #: code:addons/web/static/src/xml/dialog.xml:11
 #, python-format
 msgid "Close"
@@ -817,14 +824,14 @@ msgstr "Título da coluna"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1190
+#: code:addons/web/static/src/xml/base.xml:1201
 #, python-format
 msgid "Compare To"
 msgstr "Comparado a"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:470
+#: code:addons/web/static/src/xml/base.xml:480
 #, python-format
 msgid "Condition:"
 msgstr "Condição:"
@@ -898,8 +905,8 @@ msgstr "Copiado !"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:961
-#: code:addons/web/static/src/xml/base.xml:966
+#: code:addons/web/static/src/xml/base.xml:972
+#: code:addons/web/static/src/xml/base.xml:977
 #, python-format
 msgid "Copy Text"
 msgstr "Copiar Texto"
@@ -938,8 +945,8 @@ msgstr "Não foi possível serializar o XML"
 #: code:addons/web/static/src/js/views/graph/graph_view.js:52
 #: code:addons/web/static/src/js/views/pivot/pivot_view.js:48
 #: code:addons/web/static/src/js/views/pivot/pivot_view.js:60
-#: code:addons/web/static/src/xml/base.xml:513
-#: code:addons/web/static/src/xml/base.xml:542
+#: code:addons/web/static/src/xml/base.xml:523
+#: code:addons/web/static/src/xml/base.xml:552
 #, python-format
 msgid "Count"
 msgstr "Contar"
@@ -947,26 +954,26 @@ msgstr "Contar"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/fields/relational_fields.js:45
-#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:268
+#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:278
 #: code:addons/web/static/src/js/views/calendar/calendar_quick_create.js:45
 #: code:addons/web/static/src/js/views/kanban/kanban_controller.js:415
 #: code:addons/web/static/src/js/views/view_dialogs.js:411
 #: code:addons/web/static/src/xml/base.xml:388
-#: code:addons/web/static/src/xml/base.xml:408
+#: code:addons/web/static/src/xml/base.xml:418
 #, python-format
 msgid "Create"
 msgstr "Criar"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/form/form_controller.js:644
+#: code:addons/web/static/src/js/views/form/form_controller.js:665
 #, python-format
 msgid "Create "
 msgstr "Criar "
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/relational_fields.js:544
+#: code:addons/web/static/src/js/fields/relational_fields.js:557
 #, python-format
 msgid "Create \"<strong>%s</strong>\""
 msgstr "Criar \"<strong>%s</strong>\""
@@ -987,7 +994,7 @@ msgstr "Crie um novo registro"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/relational_fields.js:558
+#: code:addons/web/static/src/js/fields/relational_fields.js:571
 #, python-format
 msgid "Create and Edit..."
 msgstr "Criar e Editar..."
@@ -1001,14 +1008,14 @@ msgstr "Criar e editar"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/relational_fields.js:587
+#: code:addons/web/static/src/js/fields/relational_fields.js:600
 #, python-format
 msgid "Create: "
 msgstr "Criar: "
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:251
+#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:261
 #, python-format
 msgid "Create: %s"
 msgstr "Criar: %s"
@@ -1046,7 +1053,7 @@ msgstr "Usuário de criação:"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:922
+#: code:addons/web/static/src/xml/base.xml:933
 #, python-format
 msgid "Current state"
 msgstr "Estado atual"
@@ -1061,7 +1068,7 @@ msgstr "Filtro Personalizado"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/kanban/kanban_record.js:28
-#: code:addons/web/static/src/xml/base.xml:869
+#: code:addons/web/static/src/xml/base.xml:879
 #: code:addons/web/static/src/xml/kanban.xml:88
 #, python-format
 msgid "Dark blue"
@@ -1070,7 +1077,7 @@ msgstr "Azul escuro"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/kanban/kanban_record.js:25
-#: code:addons/web/static/src/xml/base.xml:866
+#: code:addons/web/static/src/xml/base.xml:876
 #: code:addons/web/static/src/xml/kanban.xml:85
 #, python-format
 msgid "Dark purple"
@@ -1084,7 +1091,7 @@ msgstr "Banco de Dados"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/search/groupby_menu.js:52
-#: code:addons/web/static/src/xml/base.xml:560
+#: code:addons/web/static/src/xml/base.xml:570
 #: code:addons/web/static/src/xml/web_calendar.xml:81
 #, python-format
 msgid "Day"
@@ -1099,19 +1106,19 @@ msgstr "Desativar"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:453
+#: code:addons/web/static/src/xml/base.xml:463
 #, python-format
 msgid "Default:"
 msgstr "Padrão:"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:350
-#: code:addons/web/static/src/js/views/form/form_controller.js:187
+#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:363
+#: code:addons/web/static/src/js/views/form/form_controller.js:186
 #: code:addons/web/static/src/js/views/list/list_controller.js:176
-#: code:addons/web/static/src/xml/base.xml:855
-#: code:addons/web/static/src/xml/base.xml:1335
-#: code:addons/web/static/src/xml/base.xml:1459
+#: code:addons/web/static/src/xml/base.xml:865
+#: code:addons/web/static/src/xml/base.xml:1346
+#: code:addons/web/static/src/xml/base.xml:1470
 #: code:addons/web/static/src/xml/kanban.xml:24
 #, python-format
 msgid "Delete"
@@ -1119,7 +1126,7 @@ msgstr "Excluir"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:616
+#: code:addons/web/static/src/xml/base.xml:626
 #, python-format
 msgid "Delete node"
 msgstr "Excluir nó"
@@ -1140,7 +1147,7 @@ msgstr "Excluir este anexo"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1054
+#: code:addons/web/static/src/xml/base.xml:1065
 #, python-format
 msgid "Delete this file"
 msgstr "Excluir este arquivo"
@@ -1158,7 +1165,7 @@ msgstr "Descrição"
 #: code:addons/web/static/src/js/widgets/colorpicker.js:36
 #: code:addons/web/static/src/js/widgets/domain_selector_dialog.js:31
 #: code:addons/web/static/src/xml/base.xml:395
-#: code:addons/web/static/src/xml/base.xml:418
+#: code:addons/web/static/src/xml/base.xml:428
 #: code:addons/web/static/src/xml/kanban.xml:75
 #: code:addons/web/static/src/xml/report.xml:18
 #, python-format
@@ -1198,7 +1205,7 @@ msgstr "Template de Documento"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1552
+#: code:addons/web/static/src/xml/base.xml:1563
 #, python-format
 msgid "Documentation"
 msgstr "Documentação"
@@ -1206,7 +1213,7 @@ msgstr "Documentação"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/widgets/domain_selector_dialog.js:36
-#: code:addons/web/static/src/xml/base.xml:603
+#: code:addons/web/static/src/xml/base.xml:613
 #, python-format
 msgid "Domain"
 msgstr "Domínio"
@@ -1220,7 +1227,7 @@ msgstr "Erro de domínio"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:615
+#: code:addons/web/static/src/xml/base.xml:625
 #, python-format
 msgid "Domain node"
 msgstr "Nó de domínio"
@@ -1241,15 +1248,15 @@ msgstr "Não saia dai, <br /> que ainda está carregando ..."
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:548
+#: code:addons/web/static/src/xml/base.xml:558
 #, python-format
 msgid "Download xls"
 msgstr "Baixar xls"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:589
-#: code:addons/web/static/src/xml/base.xml:1562
+#: code:addons/web/static/src/xml/base.xml:599
+#: code:addons/web/static/src/xml/base.xml:1573
 #, python-format
 msgid "Dropdown menu"
 msgstr "Menu Dropdown"
@@ -1263,10 +1270,10 @@ msgstr "Duplicar"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:344
+#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:357
 #: code:addons/web/static/src/js/views/calendar/calendar_quick_create.js:50
-#: code:addons/web/static/src/xml/base.xml:404
-#: code:addons/web/static/src/xml/base.xml:940
+#: code:addons/web/static/src/xml/base.xml:414
+#: code:addons/web/static/src/xml/base.xml:951
 #: code:addons/web/static/src/xml/kanban.xml:74
 #: code:addons/web/static/src/xml/report.xml:14
 #, python-format
@@ -1282,14 +1289,14 @@ msgstr "Editar Ação"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/kanban/kanban_column.js:337
+#: code:addons/web/static/src/js/views/kanban/kanban_column.js:339
 #, python-format
 msgid "Edit Column"
 msgstr "Editar Coluna"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:610
+#: code:addons/web/static/src/xml/base.xml:620
 #, python-format
 msgid "Edit Domain"
 msgstr "Editar Domain"
@@ -1356,14 +1363,14 @@ msgstr "Esc para descartar"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/calendar/calendar_model.js:588
+#: code:addons/web/static/src/js/views/calendar/calendar_model.js:602
 #, python-format
 msgid "Everybody's calendars"
 msgstr "Calendário de Todos"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/calendar/calendar_model.js:588
+#: code:addons/web/static/src/js/views/calendar/calendar_model.js:602
 #, python-format
 msgid "Everything"
 msgstr "Tudo"
@@ -1377,14 +1384,14 @@ msgstr "Exemplos"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:547
+#: code:addons/web/static/src/xml/base.xml:557
 #, python-format
 msgid "Expand all"
 msgstr "Expandir todos"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1439
+#: code:addons/web/static/src/xml/base.xml:1450
 #, python-format
 msgid "Expand parents"
 msgstr "Expandir parentes"
@@ -1392,6 +1399,7 @@ msgstr "Expandir parentes"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/list/list_controller.js:157
+#: code:addons/web/static/src/xml/base.xml:401
 #, python-format
 msgid "Export"
 msgstr "Exportar"
@@ -1405,7 +1413,7 @@ msgstr "Exportar Dados"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1406
+#: code:addons/web/static/src/xml/base.xml:1417
 #, python-format
 msgid "Export Format:"
 msgstr "Formato de Exportação:"
@@ -1428,14 +1436,14 @@ msgstr "Id. Externo"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:828
+#: code:addons/web/static/src/xml/base.xml:838
 #, python-format
 msgid "External link"
 msgstr "Link externo"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1225
+#: code:addons/web/static/src/xml/base.xml:1236
 #, python-format
 msgid "FILTER"
 msgstr "FILTRO"
@@ -1457,8 +1465,8 @@ msgstr "Falso"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1357
-#: code:addons/web/static/src/xml/base.xml:1358
+#: code:addons/web/static/src/xml/base.xml:1368
+#: code:addons/web/static/src/xml/base.xml:1369
 #, python-format
 msgid "Favorites"
 msgstr "Favoritos"
@@ -1480,7 +1488,7 @@ msgstr "Obter vista dos campos"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1425
+#: code:addons/web/static/src/xml/base.xml:1436
 #, python-format
 msgid "Fields to export"
 msgstr "Campos para exportar"
@@ -1536,7 +1544,7 @@ msgstr "Filtros"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:546
+#: code:addons/web/static/src/xml/base.xml:556
 #, python-format
 msgid "Flip axis"
 msgstr "Virar eixo"
@@ -1550,7 +1558,7 @@ msgstr "Dobrar"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:758
+#: code:addons/web/static/src/xml/base.xml:768
 #, python-format
 msgid "Followed by"
 msgstr "Seguido por"
@@ -1583,7 +1591,7 @@ msgstr "De %s Para %s"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/kanban/kanban_record.js:29
-#: code:addons/web/static/src/xml/base.xml:870
+#: code:addons/web/static/src/xml/base.xml:880
 #: code:addons/web/static/src/xml/kanban.xml:89
 #, python-format
 msgid "Fushia"
@@ -1591,7 +1599,7 @@ msgstr ""
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1571
+#: code:addons/web/static/src/xml/base.xml:1582
 #, python-format
 msgid "Get this feature and much more with Odoo Enterprise!"
 msgstr "Obtenha este recurso e muito mais com MultiERP Enterprise!"
@@ -1620,7 +1628,7 @@ msgstr "Gráfico"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/kanban/kanban_record.js:30
-#: code:addons/web/static/src/xml/base.xml:871
+#: code:addons/web/static/src/xml/base.xml:881
 #: code:addons/web/static/src/xml/colorpicker.xml:31
 #: code:addons/web/static/src/xml/kanban.xml:90
 #, python-format
@@ -1656,42 +1664,42 @@ msgstr "Roteamento HTTP"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:879
+#: code:addons/web/static/src/xml/base.xml:889
 #, python-format
 msgid "Hide in Kanban"
 msgstr "Ocultar em Kanban"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:434
+#: code:addons/web/static/src/xml/base.xml:444
 #, python-format
 msgid "Hit DOWN to navigate to the list below"
 msgstr "Pressione DOWN para navegar para a lista abaixo"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:441
+#: code:addons/web/static/src/xml/base.xml:451
 #, python-format
 msgid "Hit ENTER to"
 msgstr "Pressione ENTER para"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:433
+#: code:addons/web/static/src/xml/base.xml:443
 #, python-format
 msgid "Hit ENTER to CREATE"
 msgstr "Pressione ENTER para CRIAR"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:425
+#: code:addons/web/static/src/xml/base.xml:435
 #, python-format
 msgid "Hit ENTER to SAVE"
 msgstr "Pressione ENTER para SALVAR"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:426
+#: code:addons/web/static/src/xml/base.xml:436
 #, python-format
 msgid "Hit ESCAPE to DISCARD"
 msgstr "Pressione ESCAPE para DESCARTAR"
@@ -1713,7 +1721,7 @@ msgstr "Eu tenho certeza disso."
 #. module: web
 #: model:ir.model.fields,field_description:web.field_report_layout__id
 msgid "ID"
-msgstr "Id."
+msgstr ""
 
 #. module: web
 #. openerp-web
@@ -1754,7 +1762,7 @@ msgstr "Nome de base de dados inválido. Apenas caracteres alfanuméricos, subtr
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:608
+#: code:addons/web/static/src/xml/base.xml:618
 #, python-format
 msgid "Invalid domain"
 msgstr "Domínio inválido"
@@ -1762,7 +1770,7 @@ msgstr "Domínio inválido"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/widgets/model_field_selector.js:409
-#: code:addons/web/static/src/xml/base.xml:739
+#: code:addons/web/static/src/xml/base.xml:749
 #, python-format
 msgid "Invalid field chain"
 msgstr "Cadeia de campo inválida"
@@ -1797,7 +1805,7 @@ msgstr ""
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/chrome/user_menu.js:125
+#: code:addons/web/static/src/js/chrome/user_menu.js:126
 #, python-format
 msgid "Keyboard Shortcuts"
 msgstr "Atalhos do Teclado"
@@ -1851,7 +1859,7 @@ msgstr "Último Trimestre"
 #. module: web
 #: model:ir.model.fields,field_description:web.field_report_layout__write_uid
 msgid "Last Updated by"
-msgstr "Última atualização por"
+msgstr "Última Atualização por"
 
 #. module: web
 #: model:ir.model.fields,field_description:web.field_report_layout__write_date
@@ -1896,7 +1904,7 @@ msgstr "Deixar as Ferramentas de Desenvolvimento"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/kanban/kanban_record.js:24
-#: code:addons/web/static/src/xml/base.xml:865
+#: code:addons/web/static/src/xml/base.xml:875
 #: code:addons/web/static/src/xml/kanban.xml:84
 #, python-format
 msgid "Light blue"
@@ -1911,7 +1919,7 @@ msgstr "Leveza %"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:518
+#: code:addons/web/static/src/xml/base.xml:528
 #, python-format
 msgid "Line Chart"
 msgstr "Gráfico de linha"
@@ -1946,8 +1954,8 @@ msgstr "Carregando (%d)"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1067
-#: code:addons/web/static/src/xml/base.xml:1472
+#: code:addons/web/static/src/xml/base.xml:1078
+#: code:addons/web/static/src/xml/base.xml:1483
 #, python-format
 msgid "Loading, please wait..."
 msgstr "Carregando, por favor espere..."
@@ -1955,9 +1963,9 @@ msgstr "Carregando, por favor espere..."
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/core/misc.js:13
-#: code:addons/web/static/src/js/fields/relational_fields.js:158
-#: code:addons/web/static/src/js/fields/relational_fields.js:244
-#: code:addons/web/static/src/xml/base.xml:1465
+#: code:addons/web/static/src/js/fields/relational_fields.js:171
+#: code:addons/web/static/src/js/fields/relational_fields.js:257
+#: code:addons/web/static/src/xml/base.xml:1476
 #, python-format
 msgid "Loading..."
 msgstr "Carregando..."
@@ -1974,7 +1982,7 @@ msgstr "Entrar como superusuário"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1557
+#: code:addons/web/static/src/xml/base.xml:1568
 #, python-format
 msgid "Log out"
 msgstr "Sair"
@@ -2010,10 +2018,10 @@ msgstr "Enviar:"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/xml/base.xml:386
-#: code:addons/web/static/src/xml/base.xml:402
 #: code:addons/web/static/src/xml/base.xml:412
-#: code:addons/web/static/src/xml/base.xml:504
-#: code:addons/web/static/src/xml/base.xml:533
+#: code:addons/web/static/src/xml/base.xml:422
+#: code:addons/web/static/src/xml/base.xml:514
+#: code:addons/web/static/src/xml/base.xml:543
 #, python-format
 msgid "Main actions"
 msgstr "Principais ações"
@@ -2041,21 +2049,21 @@ msgstr "Gerenciar Filtros"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:641
+#: code:addons/web/static/src/xml/base.xml:651
 #, python-format
 msgid "Match"
 msgstr "Combinar"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:648
+#: code:addons/web/static/src/xml/base.xml:658
 #, python-format
 msgid "Match records with"
 msgstr "Corresponder registros com"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:646
+#: code:addons/web/static/src/xml/base.xml:656
 #, python-format
 msgid "Match records with the following rule:"
 msgstr "Combine registros com a seguinte regra:"
@@ -2069,8 +2077,8 @@ msgstr "Tente recarregar a aplicação pressionado F5 ..."
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:505
-#: code:addons/web/static/src/xml/base.xml:534
+#: code:addons/web/static/src/xml/base.xml:515
+#: code:addons/web/static/src/xml/base.xml:544
 #, python-format
 msgid "Measures"
 msgstr "Medidas"
@@ -2078,7 +2086,7 @@ msgstr "Medidas"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/kanban/kanban_record.js:27
-#: code:addons/web/static/src/xml/base.xml:868
+#: code:addons/web/static/src/xml/base.xml:878
 #: code:addons/web/static/src/xml/kanban.xml:87
 #, python-format
 msgid "Medium blue"
@@ -2107,7 +2115,7 @@ msgstr "Registro Ausente"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1576
+#: code:addons/web/static/src/xml/base.xml:1587
 #, python-format
 msgid "Mobile support"
 msgstr "Suporte móvel"
@@ -2130,7 +2138,7 @@ msgstr "Modificadores:"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/search/groupby_menu.js:54
-#: code:addons/web/static/src/xml/base.xml:562
+#: code:addons/web/static/src/xml/base.xml:572
 #: code:addons/web/static/src/xml/web_calendar.xml:83
 #, python-format
 msgid "Month"
@@ -2138,43 +2146,43 @@ msgstr "Mês"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/form/form_renderer.js:423
-#: code:addons/web/static/src/xml/base.xml:905
+#: code:addons/web/static/src/js/views/form/form_renderer.js:425
+#: code:addons/web/static/src/xml/base.xml:916
 #, python-format
 msgid "More"
 msgstr "Mais"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1421
+#: code:addons/web/static/src/xml/base.xml:1432
 #, python-format
 msgid "Move Down"
 msgstr "Mover para Baixo"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1420
+#: code:addons/web/static/src/xml/base.xml:1431
 #, python-format
 msgid "Move Up"
 msgstr "Mover para Cima"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1556
+#: code:addons/web/static/src/xml/base.xml:1567
 #, python-format
 msgid "My Odoo.com account"
 msgstr "Minha conta https://www.example.com"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:636
+#: code:addons/web/static/src/xml/base.xml:646
 #, python-format
 msgid "NONE"
 msgstr "NENHUM"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1476
+#: code:addons/web/static/src/xml/base.xml:1487
 #, python-format
 msgid "Name:"
 msgstr "Nome"
@@ -2195,14 +2203,14 @@ msgstr "Nova Senha"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1575
+#: code:addons/web/static/src/xml/base.xml:1586
 #, python-format
 msgid "New design"
 msgstr "Novo design"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1512
+#: code:addons/web/static/src/xml/base.xml:1523
 #: code:addons/web/static/src/xml/web_calendar.xml:78
 #, python-format
 msgid "Next"
@@ -2241,7 +2249,7 @@ msgstr "Sem cor"
 #. openerp-web
 #: code:addons/web/static/src/js/views/graph/graph_renderer.js:112
 #: code:addons/web/static/src/js/views/graph/graph_renderer.js:314
-#: code:addons/web/static/src/xml/base.xml:577
+#: code:addons/web/static/src/xml/base.xml:587
 #, python-format
 msgid "No data to display"
 msgstr "Nenhum dado para exibir."
@@ -2262,35 +2270,28 @@ msgstr "Não há registros"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/relational_fields.js:564
+#: code:addons/web/static/src/js/fields/relational_fields.js:577
 #, python-format
 msgid "No results to show..."
 msgstr "Nenhum resultado para mostrar"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/core/utils.js:249
-#, python-format
-msgid "Node [%s] is not a JSONified XML node"
-msgstr "Nó [%s] não é um nó XML JSONified"
-
-#. module: web
-#. openerp-web
-#: code:addons/web/static/src/xml/base.xml:626
+#: code:addons/web/static/src/xml/base.xml:636
 #, python-format
 msgid "None"
 msgstr "Nenhum"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:927
+#: code:addons/web/static/src/xml/base.xml:938
 #, python-format
 msgid "Not active state"
 msgstr "Estado não ativo"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:932
+#: code:addons/web/static/src/xml/base.xml:943
 #, python-format
 msgid "Not active state, click to change it"
 msgstr "Estado não ativo, clique para alterá-lo"
@@ -2368,8 +2369,8 @@ msgstr ""
 #: code:addons/web/static/src/js/core/dialog.js:314
 #: code:addons/web/static/src/js/core/dialog.js:333
 #: code:addons/web/static/src/js/core/dialog.js:385
-#: code:addons/web/static/src/js/views/kanban/kanban_column.js:313
-#: code:addons/web/static/src/xml/base.xml:1449
+#: code:addons/web/static/src/js/views/kanban/kanban_column.js:315
+#: code:addons/web/static/src/xml/base.xml:1460
 #, python-format
 msgid "Ok"
 msgstr ""
@@ -2397,7 +2398,7 @@ msgstr "Ao alterar:"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/basic_fields.js:2451
+#: code:addons/web/static/src/js/fields/basic_fields.js:2464
 #, python-format
 msgid "Only Integer or Float Value should be valid."
 msgstr "Somente o valor inteiro ou flutuante deve ser válido."
@@ -2410,7 +2411,7 @@ msgstr "Somente colaboradores podem acessar este banco de dados. Entre em contat
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:489
+#: code:addons/web/static/src/xml/base.xml:499
 #, python-format
 msgid "Only you"
 msgstr "Somente eu"
@@ -2473,10 +2474,10 @@ msgstr "Abrir para exibição de lista"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/relational_fields.js:664
-#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:330
-#: code:addons/web/static/src/js/views/form/form_controller.js:644
-#: code:addons/web/static/src/js/views/form/form_controller.js:666
+#: code:addons/web/static/src/js/fields/relational_fields.js:677
+#: code:addons/web/static/src/js/views/calendar/calendar_controller.js:343
+#: code:addons/web/static/src/js/views/form/form_controller.js:665
+#: code:addons/web/static/src/js/views/form/form_controller.js:687
 #, python-format
 msgid "Open: "
 msgstr "Aberto: "
@@ -2484,7 +2485,7 @@ msgstr "Aberto: "
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/kanban/kanban_record.js:22
-#: code:addons/web/static/src/xml/base.xml:863
+#: code:addons/web/static/src/xml/base.xml:873
 #: code:addons/web/static/src/xml/kanban.xml:82
 #, python-format
 msgid "Orange"
@@ -2492,7 +2493,7 @@ msgstr "Laranja"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1008
+#: code:addons/web/static/src/xml/base.xml:1019
 #, python-format
 msgid "PDF controls"
 msgstr "Controles de PDF"
@@ -2541,7 +2542,7 @@ msgstr "Escolha uma cor"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:519
+#: code:addons/web/static/src/xml/base.xml:529
 #, python-format
 msgid "Pie Chart"
 msgstr "Gráfico de Pizza"
@@ -2569,7 +2570,7 @@ msgstr "Pivô"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:545
+#: code:addons/web/static/src/xml/base.xml:555
 #, python-format
 msgid "Pivot settings"
 msgstr "Configurações Pivô"
@@ -2604,7 +2605,7 @@ msgstr "Por favor, selecione os campos para salvar na lista de exportação"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1531
+#: code:addons/web/static/src/xml/base.xml:1542
 #, python-format
 msgid "Please update translations of :"
 msgstr "Atualize as traduções de :"
@@ -2623,7 +2624,7 @@ msgstr "Distribuído por <span>MultiERP</span>"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1555
+#: code:addons/web/static/src/xml/base.xml:1566
 #, python-format
 msgid "Preferences"
 msgstr "Preferências"
@@ -2650,8 +2651,8 @@ msgstr "Pré-visualização do PDF"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:743
-#: code:addons/web/static/src/xml/base.xml:1511
+#: code:addons/web/static/src/xml/base.xml:753
+#: code:addons/web/static/src/xml/base.xml:1522
 #: code:addons/web/static/src/xml/web_calendar.xml:76
 #, python-format
 msgid "Previous"
@@ -2682,7 +2683,7 @@ msgstr "Imprimir"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/kanban/kanban_record.js:31
-#: code:addons/web/static/src/xml/base.xml:872
+#: code:addons/web/static/src/xml/base.xml:882
 #: code:addons/web/static/src/xml/kanban.xml:91
 #, python-format
 msgid "Purple"
@@ -2691,7 +2692,7 @@ msgstr "Roxo"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/search/groupby_menu.js:55
-#: code:addons/web/static/src/xml/base.xml:563
+#: code:addons/web/static/src/xml/base.xml:573
 #, python-format
 msgid "Quarter"
 msgstr "Trimestre"
@@ -2710,7 +2711,7 @@ msgstr "Imagem de Campo QWeb"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1165
+#: code:addons/web/static/src/xml/base.xml:1176
 #, python-format
 msgid "Range"
 msgstr "Intervalo"
@@ -2718,7 +2719,7 @@ msgstr "Intervalo"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/kanban/kanban_record.js:21
-#: code:addons/web/static/src/xml/base.xml:862
+#: code:addons/web/static/src/xml/base.xml:872
 #: code:addons/web/static/src/xml/colorpicker.xml:27
 #: code:addons/web/static/src/xml/kanban.xml:81
 #, python-format
@@ -2741,7 +2742,7 @@ msgstr "Relação não permitida"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:773
+#: code:addons/web/static/src/xml/base.xml:783
 #, python-format
 msgid "Relation to follow"
 msgstr "Relação a seguir"
@@ -2756,15 +2757,15 @@ msgstr "Relação:"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/view_dialogs.js:157
-#: code:addons/web/static/src/xml/base.xml:1243
-#: code:addons/web/static/src/xml/base.xml:1418
+#: code:addons/web/static/src/xml/base.xml:1254
+#: code:addons/web/static/src/xml/base.xml:1429
 #, python-format
 msgid "Remove"
 msgstr "Remover"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1419
+#: code:addons/web/static/src/xml/base.xml:1430
 #, python-format
 msgid "Remove All"
 msgstr "Remover Tudo"
@@ -2778,7 +2779,7 @@ msgstr "Remover dos favoritos"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:698
+#: code:addons/web/static/src/xml/base.xml:708
 #, python-format
 msgid "Remove tag"
 msgstr "Remover tag"
@@ -2839,7 +2840,7 @@ msgstr "Execute o Teste JS"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1231
+#: code:addons/web/static/src/xml/base.xml:1242
 #, python-format
 msgid "SEE RESULT"
 msgstr "VER RESULTADO"
@@ -2847,7 +2848,7 @@ msgstr "VER RESULTADO"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/kanban/kanban_record.js:26
-#: code:addons/web/static/src/xml/base.xml:867
+#: code:addons/web/static/src/xml/base.xml:877
 #: code:addons/web/static/src/xml/kanban.xml:86
 #, python-format
 msgid "Salmon pink"
@@ -2866,8 +2867,8 @@ msgstr "% de Saturação"
 #: code:addons/web/static/src/js/views/view_dialogs.js:137
 #: code:addons/web/static/src/js/widgets/domain_selector_dialog.js:28
 #: code:addons/web/static/src/xml/base.xml:392
-#: code:addons/web/static/src/xml/base.xml:414
-#: code:addons/web/static/src/xml/base.xml:1381
+#: code:addons/web/static/src/xml/base.xml:424
+#: code:addons/web/static/src/xml/base.xml:1392
 #: code:addons/web/static/src/xml/report.xml:17
 #, python-format
 msgid "Save"
@@ -2904,14 +2905,14 @@ msgstr "Salvar um registro"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1449
+#: code:addons/web/static/src/xml/base.xml:1460
 #, python-format
 msgid "Save as:"
 msgstr "Salvar como:"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1363
+#: code:addons/web/static/src/xml/base.xml:1374
 #, python-format
 msgid "Save current search"
 msgstr "Salvar pesquisa atual"
@@ -2925,21 +2926,21 @@ msgstr "Salvar padrão"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1425
+#: code:addons/web/static/src/xml/base.xml:1436
 #, python-format
 msgid "Save fields list"
 msgstr "Salvar lista de campos"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1452
+#: code:addons/web/static/src/xml/base.xml:1463
 #, python-format
 msgid "Saved exports:"
 msgstr "Exportações salvas"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1598
+#: code:addons/web/static/src/xml/base.xml:1609
 #, python-format
 msgid "Search"
 msgstr "Pesquisar"
@@ -2962,21 +2963,21 @@ msgstr "Procurar %(field)s por: %(value)s"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/relational_fields.js:516
+#: code:addons/web/static/src/js/fields/relational_fields.js:529
 #, python-format
 msgid "Search More..."
 msgstr "Pesquisar mais..."
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1236
+#: code:addons/web/static/src/xml/base.xml:1247
 #, python-format
 msgid "Search..."
 msgstr "Pesquisar..."
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/relational_fields.js:587
+#: code:addons/web/static/src/js/fields/relational_fields.js:600
 #, python-format
 msgid "Search: "
 msgstr "Pesquisar: "
@@ -2991,10 +2992,10 @@ msgstr "Ver detalhes"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/view_dialogs.js:418
-#: code:addons/web/static/src/xml/base.xml:979
-#: code:addons/web/static/src/xml/base.xml:980
-#: code:addons/web/static/src/xml/base.xml:1010
-#: code:addons/web/static/src/xml/base.xml:1011
+#: code:addons/web/static/src/xml/base.xml:990
+#: code:addons/web/static/src/xml/base.xml:991
+#: code:addons/web/static/src/xml/base.xml:1021
+#: code:addons/web/static/src/xml/base.xml:1022
 #, python-format
 msgid "Select"
 msgstr "Selecionar"
@@ -3006,7 +3007,7 @@ msgstr "Selecionar <i class=\"fa fa-database\" role=\"img\" aria-label=\"Databas
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:612
+#: code:addons/web/static/src/xml/base.xml:622
 #, python-format
 msgid "Select a model to add a filter."
 msgstr "Selecione um modelo para adicionar um filtro."
@@ -3020,7 +3021,7 @@ msgstr "Selecionar a visualização"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/basic_fields.js:2938
+#: code:addons/web/static/src/js/fields/basic_fields.js:2951
 #, python-format
 msgid "Selected records"
 msgstr "Registros selecionados"
@@ -3055,7 +3056,7 @@ msgstr "Configurações"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1377
+#: code:addons/web/static/src/xml/base.xml:1388
 #, python-format
 msgid "Share with all users"
 msgstr "Compartilhar com todos os usuários"
@@ -3124,7 +3125,7 @@ msgstr "Resumo:"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1553
+#: code:addons/web/static/src/xml/base.xml:1564
 #, python-format
 msgid "Support"
 msgstr "Suporte"
@@ -3242,10 +3243,17 @@ msgstr "O arquivo selecionado excede o tamanho máximo de %s."
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/relational_fields.js:1705
+#: code:addons/web/static/src/js/fields/relational_fields.js:1718
 #, python-format
 msgid "The type of the field '%s' must be a many2many field with a relation to 'ir.attachment' model."
 msgstr "O campo '%s' deve ser do tipo many2many como uma relação com o modelo 'ir.attachment'."
+
+#. module: web
+#. openerp-web
+#: code:addons/web/static/src/js/widgets/float_full_time_widget.js:273
+#, python-format
+msgid "The value of the field: "
+msgstr "O valor do campo: "
 
 #. module: web
 #: code:addons/web/controllers/main.py:1459
@@ -3335,7 +3343,7 @@ msgstr "Intervalo de Tempo"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1144
+#: code:addons/web/static/src/xml/base.xml:1155
 #, python-format
 msgid "Time Ranges"
 msgstr "Intervalos de Tempo"
@@ -3388,7 +3396,7 @@ msgstr "Verdadeiro"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:579
+#: code:addons/web/static/src/xml/base.xml:589
 #, python-format
 msgid "Try to add some records, or make sure\n"
 "                that there is at least one measure and no active filter in the search bar."
@@ -3439,11 +3447,11 @@ msgstr "Desarquivar Tudo"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/calendar/calendar_model.js:637
+#: code:addons/web/static/src/js/views/calendar/calendar_model.js:654
 #: code:addons/web/static/src/js/views/graph/graph_renderer.js:343
 #: code:addons/web/static/src/js/views/graph/graph_renderer.js:529
-#: code:addons/web/static/src/js/views/kanban/kanban_column.js:77
-#: code:addons/web/static/src/js/views/kanban/kanban_column.js:80
+#: code:addons/web/static/src/js/views/kanban/kanban_column.js:79
+#: code:addons/web/static/src/js/views/kanban/kanban_column.js:82
 #: code:addons/web/static/src/js/views/kanban/kanban_renderer_mobile.js:197
 #: code:addons/web/static/src/js/views/list/list_renderer.js:443
 #: code:addons/web/static/src/js/views/list/list_renderer.js:446
@@ -3496,7 +3504,7 @@ msgstr "Sem título"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1399
+#: code:addons/web/static/src/xml/base.xml:1410
 #, python-format
 msgid "Update data (import-compatible export)"
 msgstr "Atualizar dados (exportação compatível com importação)"
@@ -3510,67 +3518,67 @@ msgstr "Atualizar agora"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1583
+#: code:addons/web/static/src/xml/base.xml:1594
 #, python-format
 msgid "Upgrade to enterprise"
 msgstr "Atualize para versão completa"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1577
+#: code:addons/web/static/src/xml/base.xml:1588
 #, python-format
 msgid "Upgrade to future versions"
 msgstr "Atualize para versões futuras"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:979
-#: code:addons/web/static/src/xml/base.xml:1010
+#: code:addons/web/static/src/xml/base.xml:990
+#: code:addons/web/static/src/xml/base.xml:1021
 #, python-format
 msgid "Upload your file"
 msgstr "Faça upload de seu arquivo"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/relational_fields.js:1869
+#: code:addons/web/static/src/js/fields/relational_fields.js:1882
 #, python-format
 msgid "Uploading Error"
 msgstr "Erro no Envio"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:943
-#: code:addons/web/static/src/xml/base.xml:983
-#: code:addons/web/static/src/xml/base.xml:1009
-#: code:addons/web/static/src/xml/base.xml:1065
+#: code:addons/web/static/src/xml/base.xml:954
+#: code:addons/web/static/src/xml/base.xml:994
+#: code:addons/web/static/src/xml/base.xml:1020
+#: code:addons/web/static/src/xml/base.xml:1076
 #, python-format
 msgid "Uploading..."
 msgstr "Enviando..."
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1371
+#: code:addons/web/static/src/xml/base.xml:1382
 #, python-format
 msgid "Use by default"
 msgstr "Usar por padrão"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1393
+#: code:addons/web/static/src/xml/base.xml:1404
 #, python-format
 msgid "Use data in a spreadsheet (export all data)"
 msgstr "Use dados em uma planilha (exporte todos os dados)"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1542
+#: code:addons/web/static/src/xml/base.xml:1553
 #, python-format
 msgid "User"
 msgstr "Usuário"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1377
+#: code:addons/web/static/src/xml/base.xml:1388
 #, python-format
 msgid "Users"
 msgstr "Usuários"
@@ -3620,7 +3628,7 @@ msgstr "Alternador de vista"
 #: code:addons/web/static/src/js/services/crash_manager.js:14
 #: code:addons/web/static/src/js/views/basic/basic_controller.js:82
 #: code:addons/web/static/src/js/views/list/list_renderer.js:360
-#: code:addons/web/static/src/xml/base.xml:608
+#: code:addons/web/static/src/xml/base.xml:618
 #, python-format
 msgid "Warning"
 msgstr "Aviso"
@@ -3656,7 +3664,7 @@ msgstr ""
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/search/groupby_menu.js:53
-#: code:addons/web/static/src/xml/base.xml:561
+#: code:addons/web/static/src/xml/base.xml:571
 #: code:addons/web/static/src/xml/web_calendar.xml:82
 #, python-format
 msgid "Week"
@@ -3671,7 +3679,7 @@ msgstr "Tudo Certo!"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1389
+#: code:addons/web/static/src/xml/base.xml:1400
 #, python-format
 msgid "What do you want to do?"
 msgstr "O que você quer fazer?"
@@ -3698,7 +3706,7 @@ msgstr "Login/Senha Incorreto"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/fields/basic_fields.js:2451
+#: code:addons/web/static/src/js/fields/basic_fields.js:2464
 #, python-format
 msgid "Wrong value entered!"
 msgstr "Valor digitado errado!"
@@ -3713,7 +3721,7 @@ msgstr "Id XML:"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/search/groupby_menu.js:56
-#: code:addons/web/static/src/xml/base.xml:564
+#: code:addons/web/static/src/xml/base.xml:574
 #, python-format
 msgid "Year"
 msgstr "Ano"
@@ -3721,7 +3729,7 @@ msgstr "Ano"
 #. module: web
 #. openerp-web
 #: code:addons/web/static/src/js/views/kanban/kanban_record.js:23
-#: code:addons/web/static/src/xml/base.xml:864
+#: code:addons/web/static/src/xml/base.xml:874
 #: code:addons/web/static/src/xml/kanban.xml:83
 #, python-format
 msgid "Yellow"
@@ -3806,7 +3814,7 @@ msgstr "Sua instalação do Wkhtmltopdf parece estar danificada. O relatório se
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/js/views/kanban/kanban_record.js:250
+#: code:addons/web/static/src/js/views/kanban/kanban_record.js:257
 #, python-format
 msgid "[No widget %s]"
 msgstr "[Nenhum Componente %s]"
@@ -3848,7 +3856,7 @@ msgstr "por volta de uma hora atrás"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:641
+#: code:addons/web/static/src/xml/base.xml:651
 #, python-format
 msgid "all records"
 msgstr "todos os registros"
@@ -3910,7 +3918,7 @@ msgstr "em"
 #: code:addons/web/static/src/js/views/search/search_filters.js:329
 #: code:addons/web/static/src/js/views/search/search_filters.js:364
 #: code:addons/web/static/src/js/widgets/domain_selector.js:863
-#: code:addons/web/static/src/xml/base.xml:729
+#: code:addons/web/static/src/xml/base.xml:739
 #, python-format
 msgid "is"
 msgstr "é"
@@ -4055,7 +4063,7 @@ msgstr "menor ou igual a"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:731
+#: code:addons/web/static/src/xml/base.xml:741
 #, python-format
 msgid "not"
 msgstr "não"
@@ -4090,22 +4098,22 @@ msgstr "não definido (falso)"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:650
+#: code:addons/web/static/src/xml/base.xml:660
 #, python-format
 msgid "of the following rules:"
 msgstr "das seguintes regras:"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:665
+#: code:addons/web/static/src/xml/base.xml:675
 #, python-format
 msgid "of:"
 msgstr "de:"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:722
-#: code:addons/web/static/src/xml/base.xml:1325
+#: code:addons/web/static/src/xml/base.xml:732
+#: code:addons/web/static/src/xml/base.xml:1336
 #, python-format
 msgid "or"
 msgstr "ou"
@@ -4119,7 +4127,7 @@ msgstr "superior de"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:606
+#: code:addons/web/static/src/xml/base.xml:616
 #, python-format
 msgid "record(s)"
 msgstr "registro(s)"
@@ -4133,14 +4141,14 @@ msgstr "restantes)"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:1237
+#: code:addons/web/static/src/xml/base.xml:1248
 #, python-format
 msgid "search"
 msgstr "procurar"
 
 #. module: web
 #. openerp-web
-#: code:addons/web/static/src/xml/base.xml:731
+#: code:addons/web/static/src/xml/base.xml:741
 #, python-format
 msgid "set"
 msgstr "conjunto"
@@ -4151,3 +4159,4 @@ msgstr "conjunto"
 #, python-format
 msgid "set (true)"
 msgstr "conjunto (verdadeiro)"
+

--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -395,6 +395,16 @@
         <button type="button" class="btn btn-secondary o_list_button_discard" accesskey="j">
             Discard
         </button>
+        <t>
+            <button type="button" class="btn btn-secondary dropdown-toggle"
+                    data-toggle="dropdown" aria-expanded="false">
+                <span class="fa fa-file-excel-o"></span>
+                Export
+            </button>
+            <div id="o_list_button_exports" class="dropdown-menu o_dropdown_menu o_list_button_exports" role="menu">
+                <!-- Append on herited modules -->
+            </div>
+        </t>
     </div>
 </t>
 


### PR DESCRIPTION
# Descrição

- Atualiza tradução do módulo WEB

- Adiciona botão para incluir actions de exportação
  - O botão foi adicionado no core, mas só é renderizado caso caso modulos adicionem actions com binding_type in `['export', 'export_action']`.

- Adiciona função para a obtenção das binding actions nas views
  - O código foi transferido para uma função, para possibilitar a herança.
  - A adaptação foi feita para a adição das actions de exportação:
    - `binding_type = 'export'` ou `binding_type = 'export_action'`
    - A nova inclusão foi feita no módulo `br_base_export_excel`.

# Informações adicionais

- [T9064](https://multi.multidados.tech/web?#id=9473&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1705)
- [muk](https://github.com/multidadosti-erp/muk-addons/pull/40)