### PR TITLE
T9111 - Perdendo o Pagamento ao Confirmar no Ponto de Venda

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -1568,10 +1568,12 @@ class AccountInvoice(models.Model):
         # Atualiza os campos da fatura
         update_vals = {
             "account_id": account_id,
-            "payment_term_id": payment_term_id,
             "date_due": False,
-            "fiscal_position_id": fiscal_position,
         }
+        if payment_term_id:
+            update_vals.update({"payment_term_id": payment_term_id})
+        if fiscal_position:
+            update_vals.update({"fiscal_position_id": fiscal_position})
 
         # Define o domínio para o campo de conta bancária
         if invoice_type in ("in_invoice", "out_refund"):


### PR DESCRIPTION
# Descrição

Ajusta Campos Default do Parceiro módulo 'account'
- Somente sobrescreve os campos: payment_term_id e fiscal_position caso tenham valor do cadastro do cliente.

# Informações adicionais

Dados da tarefa: [T9111](https://multi.multidados.tech/web?debug=1#id=9520&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

