### PR TITLE
T9151 - Erro ao tentar incluir itens no orçamento

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1607,6 +1607,26 @@ class SaleOrderLine(models.Model):
 
         return result
 
+    def get_uom_qty_change(self):
+        """
+        Retorna se houve alteração na quantidade da unidade de medida.
+        Por padrão, retorna False. Este método pode ser sobrescrito em módulos específicos, como l10n_br.
+
+        Retorno:
+            bool: False, indicando que não houve alteração.
+        """
+        return False
+
+    def get_old_price(self):
+        """
+        Retorna o valor original do preço unitário.
+        Por padrão, retorna 0. Este método pode ser sobrescrito em módulos específicos, como l10n_br.
+
+        Retorno:
+            Float: 0, indicando que não há preço original. Pois não funcionado no Odoo padrão.
+        """
+        return 0
+
     @api.onchange('product_uom', 'product_uom_qty')
     def product_uom_change(self):
         if not self.product_uom or not self.product_id:
@@ -1622,10 +1642,8 @@ class SaleOrderLine(models.Model):
                 pricelist=self.order_id.pricelist_id.id,
                 uom=self.product_uom.id,
                 fiscal_position=self.env.context.get("fiscal_position"),
-                uom_qty_change=self.env.context.get(
-                    "uom_qty_change", False
-                ),  # flag vem do campo de quantidade da view
-                old_price=self.price_unit,  # valor original, em caso onde nao desejamos alterar o preco unitario
+                uom_qty_change=self.get_uom_qty_change(),
+                old_price=self.get_old_price(),
             )
 
             self.price_unit = self.env["account.tax"]._fix_tax_included_price_company(


### PR DESCRIPTION
# Descrição

Ajusta método 'def product_uom_change' módulo 'sale'
- Fixa o parametro 'uom_qty_change' em um novo método como False.
- Ajusta Verificação para Obter o old_price.

# Informações adicionais

Dados da tarefa: [T9151](https://multi.multidados.tech/web#id=9560&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [1726](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1726)
