### PR TITLE
T9167 - Corrigir aliquota dos impostos ICMS, PIS e Cofins em faturas do POS

### DIFF
--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -7,7 +7,7 @@
             <form string="Point of Sale Orders" create="0">
                 <header>
                     <button name="%(action_pos_payment)d" string="Payment" class="oe_highlight" type="action" states="draft" context="{'pos_session_id' : session_id}"/>
-                    <button name="action_pos_order_invoice" string="Invoice" type="object"
+                    <button name="action_pos_order_invoice" string="Invoice" type="object" class="oe_highlight"
                             attrs="{'invisible': ['|', ('invoice_group', '=', False), ('state','!=','paid')]}"/>
                     <button name="refund" string="Return Products" type="object"
                         attrs="{'invisible':[('state','=','draft')]}"/>


### PR DESCRIPTION
# Descrição

Adiciona classe 'oe_highlight' ao botão de faturar POS

Adiciona classe 'oe_highlight' ao botão de faturas no formulário de pedidos do ponto de venda

# Informações adicionais

Dados da tarefa: [T9167](https://multi.multidados.tech/web#id=9576&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

