### PR TITLE
T9181 - Erro ao adicionar Grupo e Sub-Grupo Financeiro na receita o sistema está voltando o titulo para aberto

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -1792,6 +1792,9 @@ class AccountInvoice(models.Model):
         Returns:
             bool: Retorna True após a operação ser concluída.
         """
+        if not self:
+            return
+            
         if any(inv.state not in ("in_payment", "paid") for inv in self):
             raise UserError(
                 _("Invoice must be paid in order to set it to register payment.")


### PR DESCRIPTION
# Descrição

Ajusta método 'action_invoice_re_open' módulo 'account'

# Informações adicionais

Dados da tarefa: [T9181](https://multi.multidados.tech/web?#id=9590&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver):
