### PR TITLE
T9133 - Permitir cancelar evento que ja foi faturado para que o evento/contrato seja concluido

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -56,7 +56,7 @@ import odoo
 from . import SUPERUSER_ID
 from . import api
 from . import tools
-from .exceptions import AccessError, MissingError, ValidationError, UserError
+from .exceptions import AccessError, MissingError, ValidationError, UserError, CacheMiss
 from .osv.query import Query
 from .tools import frozendict, lazy_classproperty, lazy_property, ormcache, \
                    Collector, LastOrderedSet, OrderedSet, pycompat, groupby
@@ -5464,6 +5464,10 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
                     vals = {n: rec[n] for n in ns}
                 except MissingError:
                     continue
+                except CacheMiss:
+                    if not rec.exists():
+                        continue
+
                 vals = rec._convert_to_write(vals)
                 updates[frozendict(vals)].add(rec.id)
             # update records in batch when possible


### PR DESCRIPTION
# Descrição

- Corrige erro ao acessar valores em cache de registros apagados

# Informações adicionais

- [T9133](https://multi.multidados.tech/web?#id=9542&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)