### PR TITLE
T9231 - Adicionar aos Menus e SubMenus do Sistema opção de web_icon

### DIFF
--- a/addons/web/static/src/xml/menu.xml
+++ b/addons/web/static/src/xml/menu.xml
@@ -44,6 +44,9 @@
                 t-att-data-menu-xmlid="menu.xmlid"
                 t-attf-class="#{inNavbar ? '' : 'dropdown-item '}o_menu_entry_lvl_#{depth}"
                 data-toggle="collapse" data-target="#o_navbar_collapse.in">
+                <t t-if="menu.web_icon and menu.web_icon.startsWith('fa ')">
+                    <i t-att-class="menu.web_icon" style="margin-right: 5px;"/>
+                </t>            
                 <span><t t-esc="menu.name"/></span>
             </a>
         </t>
@@ -56,6 +59,9 @@
     </t>
     <t t-else="">
         <div t-attf-class="dropdown-header o_menu_header_lvl_#{depth}">
+            <t t-if="menu.web_icon and menu.web_icon.startsWith('fa ')">
+                <i t-att-class="menu.web_icon" style="margin-right: 5px;"/>
+            </t>            
             <span><t t-esc="menu.name"/></span>
         </div>
         <t t-foreach="menu.children" t-as="menu">
@@ -78,6 +84,9 @@
                 <t t-else="">
                     <li>
                         <a href="#" class="dropdown-toggle o-no-caret o_menu_header_lvl_1" t-att-data-menu-xmlid="second_level_menu.xmlid" data-toggle="dropdown" data-display="static" role="button" aria-expanded="false">
+                            <t t-if="second_level_menu.web_icon and second_level_menu.web_icon.startsWith('fa ')">
+                                <i t-att-class="second_level_menu.web_icon" style="margin-right: 2px;"/>
+                            </t>            
                             <t t-esc="second_level_menu.name"/>
                         </a>
                         <div class="dropdown-menu" role="menu">

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -506,9 +506,9 @@ form: module.record_id""" % (xml_id,)
                     groups_value.append((4, group_id))
             values['groups_id'] = groups_value
 
-        if not values.get('parent_id'):
-            if rec.get('web_icon'):
-                values['web_icon'] = rec.get('web_icon')
+        # if not values.get('parent_id'): Comentado para Habilitar web_icon na tag <menuitem>
+        if rec.get('web_icon'):
+            values['web_icon'] = rec.get('web_icon')
 
         xid = self.make_xml_id(rec_id)
         data = dict(xml_id=xid, values=values, noupdate=self.isnoupdate(data_node))


### PR DESCRIPTION
# Descrição

Adiciona web_icon aos sub-menus módulo 'web'
- Adicionado a tag 'web_icon' no '<menuitem>' para mostrar imagens do FontAwesome.

  Ex: 
      <menuitem id="service_contract_revenue" 
                          name="Revenue Contracts" 
                          groups="service_contract_management.group_contract_management" 
                          parent="service_contract_menu" 
                          action="service_contract_action_revenue"
  ===>              web_icon="fa fa-line-chart"
                          sequence="0"/>


# Informações adicionais

Dados da tarefa: [T9231](https://multi.multidados.tech/web?debug=1#id=9640&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)


