### PR TITLE
T9175 - Adicionar Módulo EvoOdoo (adaptar da V18 para V12)

### DIFF
--- a/addons/mail/static/src/xml/discuss.xml
+++ b/addons/mail/static/src/xml/discuss.xml
@@ -105,7 +105,7 @@
         <t t-if="!disableAddThread || !empty">
             <div class="o_mail_sidebar_title">
                 <h4 t-att-class="type == 'public' ? 'o_mail_open_channels' : ''">
-                    <i t-if="icon" t-attf-class="mr4 fa-fw fa #{icon}" role="img" aria-label="Channel" title="Channel"></i>
+                    <i t-if="icon" t-attf-class="fa #{icon}" role="img" aria-label="Channel" title="Channel"></i>
                     <b><t t-esc="title"/></b>
                 </h4>
                 <span t-if="!disableAddThread" class="fa fa-plus o_add" title="Add" t-attf-data-type="#{type}" role="img" aria-label="Add"/>

--- a/odoo/__init__.py
+++ b/odoo/__init__.py
@@ -137,6 +137,7 @@ from . import models
 from . import fields
 from . import api
 from odoo.tools.translate import _
+from odoo.fields import Command
 
 #----------------------------------------------------------
 # Other imports, which may require stuff from above

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -11,6 +11,7 @@ from operator import attrgetter
 import itertools
 import logging
 import base64
+import enum
 
 import pytz
 
@@ -2303,6 +2304,129 @@ class _RelationalMultiUpdate(object):
         val = field.convert_to_cache(record[field.name] | value, record, validate=False)
         cache.set(record, field, val)
         return val
+
+
+#class Command(enum.IntEnum):
+class Command():
+    """
+    IMPORTADO DO ODOO v18:
+    HINT: Somente foi importado para utilização do 'evoodoo_connector',
+    portanto no back-end da ORM não é aplicada.
+
+
+    :class:`~odoo.fields.One2many` and :class:`~odoo.fields.Many2many` fields
+    expect a special command to manipulate the relation they implement.
+
+    Internally, each command is a 3-elements tuple where the first element is a
+    mandatory integer that identifies the command, the second element is either
+    the related record id to apply the command on (commands update, delete,
+    unlink and link) either 0 (commands create, clear and set), the third
+    element is either the ``values`` to write on the record (commands create
+    and update) either the new ``ids`` list of related records (command set),
+    either 0 (commands delete, unlink, link, and clear).
+
+    Via Python, we encourage developers craft new commands via the various
+    functions of this namespace. We also encourage developers to use the
+    command identifier constant names when comparing the 1st element of
+    existing commands.
+
+    Via RPC, it is impossible nor to use the functions nor the command constant
+    names. It is required to instead write the literal 3-elements tuple where
+    the first element is the integer identifier of the command.
+    """
+
+    CREATE = 0
+    UPDATE = 1
+    DELETE = 2
+    UNLINK = 3
+    LINK = 4
+    CLEAR = 5
+    SET = 6
+
+    @classmethod
+    def create(cls, values: dict):
+        """
+        Create new records in the comodel using ``values``, link the created
+        records to ``self``.
+
+        In case of a :class:`~odoo.fields.Many2many` relation, one unique
+        new record is created in the comodel such that all records in `self`
+        are linked to the new record.
+
+        In case of a :class:`~odoo.fields.One2many` relation, one new record
+        is created in the comodel for every record in ``self`` such that every
+        record in ``self`` is linked to exactly one of the new records.
+
+        Return the command triple :samp:`(CREATE, 0, {values})`
+        """
+        return (cls.CREATE, 0, values)
+
+    @classmethod
+    def update(cls, id: int, values: dict):
+        """
+        Write ``values`` on the related record.
+
+        Return the command triple :samp:`(UPDATE, {id}, {values})`
+        """
+        return (cls.UPDATE, id, values)
+
+    @classmethod
+    def delete(cls, id: int):
+        """
+        Remove the related record from the database and remove its relation
+        with ``self``.
+
+        In case of a :class:`~odoo.fields.Many2many` relation, removing the
+        record from the database may be prevented if it is still linked to
+        other records.
+
+        Return the command triple :samp:`(DELETE, {id}, 0)`
+        """
+        return (cls.DELETE, id, 0)
+
+    @classmethod
+    def unlink(cls, id: int):
+        """
+        Remove the relation between ``self`` and the related record.
+
+        In case of a :class:`~odoo.fields.One2many` relation, the given record
+        is deleted from the database if the inverse field is set as
+        ``ondelete='cascade'``. Otherwise, the value of the inverse field is
+        set to False and the record is kept.
+
+        Return the command triple :samp:`(UNLINK, {id}, 0)`
+        """
+        return (cls.UNLINK, id, 0)
+
+    @classmethod
+    def link(cls, id: int):
+        """
+        Add a relation between ``self`` and the related record.
+
+        Return the command triple :samp:`(LINK, {id}, 0)`
+        """
+        return (cls.LINK, id)
+
+    @classmethod
+    def clear(cls):
+        """
+        Remove all records from the relation with ``self``. It behaves like
+        executing the `unlink` command on every record.
+
+        Return the command triple :samp:`(CLEAR, 0, 0)`
+        """
+        return (cls.CLEAR, 0, 0)
+
+    @classmethod
+    def set(cls, ids: list):
+        """
+        Replace the current relations of ``self`` by the given ones. It behaves
+        like executing the ``unlink`` command on every removed relation then
+        executing the ``link`` command on every new relation.
+
+        Return the command triple :samp:`(SET, 0, {ids})`
+        """
+        return (cls.SET, 0, ids)
 
 
 class _RelationalMulti(_Relational):


### PR DESCRIPTION
# Descrição

- Ajustes na renderização do ícone do canal de comunicação

- Importa a classe Command do Odoo 18 (x2many operations)
  - No Odoo 18, é utilizado a classe Command para obter os valores de gravação para campos x2many.
    - Ex: `[(4, <id>), (6, 0, [<ids>])]`

# Informações adicionais

- [T9175](https://multi.multidados.tech/web?#id=9584&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver):
- [channel-addons](https://github.com/multidadosti-erp/multichannels-addons/pull/120)