### PR TITLE
T9227 - Erro ao acessar o Sistena (HOME)

### DIFF
--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -17,9 +17,9 @@
     </record>
 
 <data noupdate="1">
-    <record id="base.default_user" model="res.users">
+    <!-- <record id="base.default_user" model="res.users">
         <field name="groups_id" eval="[(4,ref('group_hr_manager'))]"/>
-    </record>
+    </record> -->
 
     <record id="hr_dept_comp_rule" model="ir.rule">
         <field name="name">Department multi company rule</field>

--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -13,9 +13,11 @@
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
 
-    <record id="base.default_user" model="res.users">
+    <!-- Remove a inclusão de qualquer usuário interno à gerente de
+         "Folgas" -->
+    <!-- <record id="base.default_user" model="res.users">
         <field name="groups_id" eval="[(4,ref('hr_holidays.group_hr_holidays_manager'))]"/>
-    </record>
+    </record> -->
 
     <record id="hr_leave_rule_employee" model="ir.rule">
         <field name="name">Leaves: employee: read all</field>


### PR DESCRIPTION
# Descrição

- Remove a inclusão dos usuários comuns à Gerente de RH
  - Por algum motivo, o grupo de usuários Padrão (qualquer usuário) recebia a auto atribuição ao grupo hr_manager, fazendo com que todos os novos usuários ou os existentes, aderissem ao grupo na instalação do módulo.

# Informações adicionais

- [T9227](https://multi.multidados.tech/web?#id=9636&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [l10n_br (antigo)](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1756)
- l10n_br (novo)