### PR TITLE
T9211 - Ajusta a Cor dos Itens Separados no Stock Picking

### DIFF
--- a/addons/web/static/lib/bootstrap/scss/_variables.scss
+++ b/addons/web/static/lib/bootstrap/scss/_variables.scss
@@ -14,7 +14,7 @@ $gray-200: #e9ecef !default;
 $gray-300: #dee2e6 !default;
 $gray-400: #ced4da !default;
 $gray-500: #adb5bd !default;
-$gray-600: #6c757d !default;
+$gray-600: #8d9297 !default;
 $gray-700: #495057 !default;
 $gray-800: #343a40 !default;
 $gray-900: #212529 !default;

--- a/addons/web/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden.scss
@@ -14,7 +14,7 @@ $gray-200: #e9ecef !default;
 $gray-300: #dee2e6 !default;
 $gray-400: #ced4da !default;
 $gray-500: #adb5bd !default;
-$gray-600: #6c757d !default;
+$gray-600: #8d9297 !default;
 $gray-700: #495057 !default;
 $gray-800: #343a40 !default;
 $gray-900: #212529 !default;
@@ -40,7 +40,7 @@ $link-hover-decoration: none;
 //
 // Style .text-muted elements
 
-$text-muted: $gray-500 !default;
+$text-muted: $gray-600 !default;
 
 // Grid columns
 //

--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -719,7 +719,7 @@
         clear: left;
     }
     .text-muted {
-        color: #aaaaaa;
+        color: $text-muted;
     }
     .o_setting_box {
         margin-bottom: 8px;


### PR DESCRIPTION
# Descrição

- Altera cor padrão para o estilo "text-muted"
  - Altera cor para mais escuro, melhorando a visibilidade.

# Informações adicionais

- [T9211](https://multi.multidados.tech/web?#id=9620&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)