### PR TITLE
T9213 - Alteração na tela de Separação de Itens possibilitando assim a separação por codigo de barras

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4743,7 +4743,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
     resolve_o2m_commands_to_record_dicts = resolve_2many_commands
 
     @api.model
-    def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None):
+    def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None, load="_classic_read"):
         """
         Performs a ``search()`` followed by a ``read()``.
 
@@ -4773,7 +4773,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             del context['active_test']
             records = records.with_context(context)
 
-        result = records.read(fields)
+        result = records.read(fields, **({'load': load} if load != '_classic_read' else {}))
         if len(result) <= 1:
             return result
 


### PR DESCRIPTION
# Descrição

- Add utilização do parâmetro 'load' de read() para search_read()
  - O parâmetro pode ser informado para ler somente os ids dos campos relacionados ao inves do name_get(), que retorna uma tupla com o id [0] e o nome [1].

# Informações adicionais

- [T9213](https://multi.multidados.tech/web?#id=9622&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- l10n_br