### PR TITLE
T9278 - Habilitar a visualização expandida em Dialog Forms

### DIFF
--- a/addons/web/static/src/js/chrome/action_manager.js
+++ b/addons/web/static/src/js/chrome/action_manager.js
@@ -404,6 +404,11 @@ var ActionManager = Widget.extend({
                 dialogClass: controller.className,
                 title: action.name,
                 size: action.context.dialog_size,
+                /* Adicionado pela Multidados:
+                    * como o objeto ActionManager "self", não possui o atributo
+                    * context, força o context da action nas options do Dialog
+                */
+                context: action.context,
             }));
             /**
              * @param {Object} [options={}]

--- a/addons/web/static/src/js/core/dialog.js
+++ b/addons/web/static/src/js/core/dialog.js
@@ -73,6 +73,14 @@ var Dialog = Widget.extend({
         this.size = options.size;
         this.buttons = options.buttons;
         this.technical = options.technical;
+
+        /* Adicionado pela Multidados:
+            * Atribui o contexto do dialog, que é utilizado na exibição.
+            * Quando criado a partir de um campo, o parent possui o
+            * context, então atribui automaticamente. Mas o ActionManager não
+            * possui o context, então é necessário passar explicitamente.
+        */
+        this.context = this.context || options.context || {};
     },
     /**
      * Wait for XML dependencies and instantiate the modal structure (except

--- a/addons/web/static/src/js/views/basic/basic_controller.js
+++ b/addons/web/static/src/js/views/basic/basic_controller.js
@@ -265,6 +265,15 @@ var BasicController = AbstractController.extend(FieldManagerMixin, {
         };
         record = record || this.model.get(this.handle);
 
+        /* Alterado pela Multidados:
+            * O contexto do botão é passado como string, mas o parâmetro
+            * additionalContext do método getContext espera um objeto JS.
+            * Então, convertemos o contexto do botão para um objeto JSON.
+        */
+        attrs.context = attrs.context ? JSON.parse(
+            attrs.context.replace(/'/g, '"').replace(/\bTrue\b/g, 'true').replace(/\bFalse\b/g, 'false')
+        ) : {};
+
         this.trigger_up('execute_action', {
             action_data: _.extend({}, attrs, {
                 context: record.getContext({additionalContext: attrs.context || {}}),

--- a/addons/web/static/src/js/views/basic/basic_view.js
+++ b/addons/web/static/src/js/views/basic/basic_view.js
@@ -382,7 +382,12 @@ var BasicView = AbstractView.extend({
             node.attrs.modifiers = node.attrs.modifiers ? JSON.parse(node.attrs.modifiers) : {};
         }
         if (!_.isObject(node.attrs.options) && node.tag === 'button') {
-            node.attrs.options = node.attrs.options ? JSON.parse(node.attrs.options) : {};
+            // Ajustado pela Multidados:
+            // O options pode vir como string representando um dict Python,
+            // e não como objeto JSON.
+            node.attrs.options = node.attrs.options ? JSON.parse(
+                node.attrs.options.replace(/'/g, '"').replace(/\bTrue\b/g, 'true').replace(/\bFalse\b/g, 'false')
+            ) : {};
         }
         if (node.tag === 'field') {
             var viewType = fv.type;


### PR DESCRIPTION
# Descrição

- Formata atributo options do Botão XML
  - O atributo não formatava de dict Python para objeto JSON.

- Adapta ActionManager e basicController para enviar contexto ao Dialog
  - Como o objeto ActionManager não possui o atributo context, deve passar forçadamente como `options`
  - Formata atributo context da tag de botão no XML.

- Adapta "web.Dialog.js" para obter o contexto a partir das options
  - O contexto do Dialog era obtido somente a partir do parent, na classe básica do `Widget.js`.
  - Caso não tenha obtido no parent, como no caso do ActionManager, ao executar actions a partir de botões ou objetos de retorno em dicionários python, ele tenta a partir das options.

# Informações adicionais

- [T9278](https://multi.multidados.tech/web?#id=9687&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [oca-web](https://github.com/multidadosti-erp/web/pull/16)
- [l10n_br](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1780)
- [private-addons](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/1049)