### PR TITLE
T9306 - Relatório de estoque atual não ordena por nro de série

### DIFF
--- a/addons/stock/models/stock_production_lot.py
+++ b/addons/stock/models/stock_production_lot.py
@@ -10,6 +10,8 @@ class ProductionLot(models.Model):
     _inherit = ['mail.thread','mail.activity.mixin']
     _description = 'Lot/Serial'
 
+    _order = 'name asc, id desc'
+
     name = fields.Char(
         'Lot/Serial Number', default=lambda self: self.env['ir.sequence'].next_by_code('stock.lot.serial'),
         track_visibility='always',


### PR DESCRIPTION
# Descrição

Adiciona a definição de ordenação de serie/lot na tree

# Informações adicionais

Dados da tarefa: [T9306](https://multi.multidados.tech/web#id=9715&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)


