### PR TITLE
T9322 - Corrigir mensagem ao cancelar fatura com titulo cancelado

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -2527,7 +2527,8 @@ class AccountInvoice(models.Model):
                 invoice.reference = invoice._get_computed_reference()
 
             # Atualiza as referências no lançamento contábil associado
-            invoice.move_id.ref = invoice.reference
+            if invoice.move_id:
+                invoice.move_id.ref = invoice.reference
 
         # Verifica duplicidade de referência para faturas de fornecedores
         self._check_duplicate_supplier_reference()


### PR DESCRIPTION
# Descrição

Ajusta método 'invoice_validate' módulo 'account'
- Verifica se o move_id existe para atribuir a 'ref'



# Informações adicionais

Dados da tarefa: [T9322](https://multi.multidados.tech/web?debug#id=9731&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver):
[1812](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1812)
[536](https://github.com/multidadosti-erp/multidadosti-financial-addons/pull/536)
