### PR TITLE
T9377 - Baixa de Título de Parcelas antecipadas esta com erro e Confirmação Venda com Parcelas de Adiantamento

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -208,12 +208,19 @@ class SaleOrder(models.Model):
 
     invoice_count = fields.Integer(string='Invoice Count', compute='_get_invoiced', readonly=True)
     invoice_ids = fields.Many2many("account.invoice", string='Invoices', compute="_get_invoiced", readonly=True, copy=False, search="_search_invoice_ids")
-    invoice_status = fields.Selection([
-        ('upselling', 'Upselling Opportunity'),
-        ('invoiced', 'Fully Invoiced'),
-        ('to invoice', 'To Invoice'),
-        ('no', 'Nothing to Invoice')
-        ], string='Invoice Status', compute='_get_invoiced', store=True, readonly=True)
+    invoice_status = fields.Selection(
+        [
+            ("upselling", "Upselling Opportunity"),
+            ("invoiced", "Fully Invoiced"),
+            ("to invoice", "To Invoice"),
+            ("no", "Nothing to Invoice"),
+        ],
+        string="Invoice Status",
+        copy=False,
+        compute="_get_invoiced",
+        store=True,
+        readonly=True,
+    )
 
     note = fields.Text('Terms and conditions', default=_default_note)
 


### PR DESCRIPTION
# Descrição
Ajusta campo 'invoice_status' módulo 'sale'
- Adiciona tag copy=False para recalcular o campo ao duplicar
- Ajusta Formatação código



# Informações adicionais

Dados da tarefa: [T9377](https://multi.multidados.tech/web?debug#id=9786&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver):
