### PR TITLE
T9382 - Erro JavaScript

### DIFF
--- a/addons/web_tour/static/src/js/tip.js
+++ b/addons/web_tour/static/src/js/tip.js
@@ -103,7 +103,7 @@ var Tip = Widget.extend({
         clearTimeout(this.timerOut);
 
         // Do not remove the parent class if it contains other tooltips
-        if (this.$ideal_location.children(".o_tooltip").not(this.$el[0]).length === 0) {
+        if (this.$ideal_location && this.$el && this.$ideal_location.children(".o_tooltip").not(this.$el[0]).length === 0) {
             this.$ideal_location.removeClass("o_tooltip_parent");
         }
 


### PR DESCRIPTION
# Descrição

Ajusta método 'destroy' Tip módulo 'web_tour'
- Adiciona verificação antes de remover a class para evitar erro de JS Uncaught TypeError: Cannot read properties of undefined (reading '0')


# Informações adicionais

Dados da tarefa: [T9382](https://multi.multidados.tech/web?debug#id=9791&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

