### PR TITLE
T9356 - Ao faturar eventos de contrato o sistema está atribuindo o usuário como seguindo e disparando e-mails

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2355,10 +2355,11 @@ class MailThread(models.AbstractModel):
         :param default_subtype_ids: coming from ``_get_auto_subscription_subtypes``
         """
         fnames = []
-        for name, field in self._fields.items():
-            if name == 'user_id' and updated_values.get(name) and getattr(field, 'track_visibility', False):
-                if field.comodel_name == 'res.users':
-                    fnames.append(name)
+
+        field = self._fields.get('user_id')
+        if (field and updated_values.get('user_id') and getattr(field, 'track_visibility', False)
+          and field.comodel_name == 'res.users'):
+            fnames.append('user_id')
 
         new_subscriptions = []
         user_ids = [updated_values[fname] for fname in fnames if updated_values[fname]]


### PR DESCRIPTION
# Descrição

- Ajusta função de obtenção do seguidor do registro
  - A função percorria todos os campos para obter somente o campo `user_id`.

# Informações adicionais

- [T9356](https://multi.multidados.tech/web?#id=9765&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- [private-addons](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/1068)