### PR TITLE
T9435 - Erro ao tentar incluir um novo orçamento

### DIFF
--- a/addons/sale_timesheet/security/sale_timesheet_security.xml
+++ b/addons/sale_timesheet/security/sale_timesheet_security.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
-    <data noupdate="1">
+    <function name="write" model="ir.model.data">
+        <function name="search" model="ir.model.data">
+            <value eval="[('model', '=', 'ir.rule'),('name', '=', 'sale_order_line_rule_project_manager')]" />
+        </function>
+        <value eval="{'noupdate': False}" />
+    </function>
 
+    <data noupdate="0">
         <record id="sale_order_line_rule_project_manager" model="ir.rule">
             <field name="name">Project Manager Sales Orders Line</field>
             <field name="model_id" ref="sale.model_sale_order_line"/>
-            <field name="domain_force">['&amp;', '&amp;', ('state', 'in', ['sale', 'done']), ('is_service', '=', True), '|', ('project_id','!=', False), ('task_ids','!=', False)]</field>
+            <field name="domain_force">['&amp;', '&amp;', ('state', 'in', ['sale', 'done']), ('is_service', '=', True), ('task_ids','!=', False)]</field>
             <field name="groups" eval="[(4, ref('project.group_project_manager'))]"/>
             <field name="perm_create" eval="0"/>
             <field name="perm_write" eval="0"/>


### PR DESCRIPTION
# Descrição

- Ajusta regra para visualização de linhas de orçamento (projeto)
  - O campo project_id foi removido das linhas do pedido, mas ainda estava sendo utilizado para regra de registro.
  - Torna ela atualizável e muda seu domain, removendo o campo antigo

# Informações adicionais

- [T9435](https://multi.multidados.tech/web?debug#id=9844&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)