### PR TITLE
T9485 - Erro ao tentar visualizar documentos importados via API

### DIFF
--- a/addons/resource/models/resource_mixin.py
+++ b/addons/resource/models/resource_mixin.py
@@ -39,6 +39,13 @@ class ResourceMixin(models.AbstractModel):
                   self.env['resource.calendar'].browse(values.get('resource_calendar_id')).tz)
             if tz:
                 resource_vals['tz'] = tz
+
+            # Alterado pela Multidados:
+            #  adiciona a empresa na criação do resource, se ela for passada
+            #  nos valores de criação do registro.
+            if values.get('company_id'):
+                resource_vals['company_id'] = values.get('company_id')
+
             resource = self.env['resource.resource'].create(resource_vals)
             values['resource_id'] = resource.id
         return super(ResourceMixin, self).create(values)


### PR DESCRIPTION
# Descrição

- Adiciona a empresa dinamica ao criar resource relacionado ao employee
  - O campo 'company_id' não respeitava o valor definido para a criação do employee, sempre utilizava o default da empresa ativa.

# Informações adicionais

- [T9485](https://multi.multidados.tech/web?#id=9894&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR relacionado:
- channel-addons