### PR TITLE
T9967 - Evoluir a Visão de Kanban Padrão

### DIFF
--- a/addons/web/static/src/js/views/kanban/kanban_column.js
+++ b/addons/web/static/src/js/views/kanban/kanban_column.js
@@ -28,6 +28,8 @@ var KanbanColumn = Widget.extend({
         'click .o_kanban_quick_add': '_onAddQuickCreate',
         'click .o_kanban_load_more': '_onLoadMore',
         'click .o_kanban_toggle_fold': '_onToggleFold',
+        'click .o_kanban_subgroup_header': '_onToggleSubGroup',
+        'keydown .o_kanban_subgroup_header': '_onSubGroupHeaderKeyDown',
         'click .o_column_archive_records': '_onArchiveRecords',
         'click .o_column_unarchive_records': '_onUnarchiveRecords'
     },
@@ -61,8 +63,11 @@ var KanbanColumn = Widget.extend({
         this.records_editable = options.records_editable;
         this.records_deletable = options.records_deletable;
         this.relation = options.relation;
+        this.showLevelTotals = !!options.show_level_totals;
         this.offset = 0;
-        this.remaining = data.count - this.data_records.length;
+        this.hasSubGroups = !!(data.groupedBy && data.groupedBy.length);
+        this.subGroupDepth = this.hasSubGroups ? data.groupedBy.length : 0;
+        this.remaining = this.hasSubGroups ? 0 : data.count - this.data_records.length;
 
         if (options.hasProgressBar) {
             this.barOptions = {
@@ -98,18 +103,34 @@ var KanbanColumn = Widget.extend({
         var defs = [this._super.apply(this, arguments)];
         this.$header = this.$('.o_kanban_header');
 
-        for (var i = 0; i < this.data_records.length; i++) {
-            var def = this._addRecord(this.data_records[i]);
-            if (def.state() === 'pending') {
-                defs.push(def);
+        if (this.hasSubGroups) {
+            var $subGroupsContainer = $('<div/>', { class: 'o_kanban_subgroups' });
+            var $loadMore = this.$('.o_kanban_load_more');
+            if ($loadMore.length) {
+                $loadMore.before($subGroupsContainer);
+            } else {
+                $subGroupsContainer.insertAfter(this.$header);
+            }
+            this._addSubGroups(this.data_records, $subGroupsContainer, 1, defs);
+        } else {
+            for (var i = 0; i < this.data_records.length; i++) {
+                var def = this._addRecord(this.data_records[i]);
+                if (def.state() === 'pending') {
+                    defs.push(def);
+                }
             }
         }
         this.$header.find('.o_kanban_header_title').tooltip();
+        this.$el.css('--o-kanban-main-header-offset', (this.$header.outerHeight() || 44) + 'px');
+        this.$el.toggleClass('o_kanban_group_has_subgroups', this.hasSubGroups);
+        if (this.hasSubGroups) {
+            this.$el.addClass('o_kanban_group_subgroup_depth_' + Math.min(this.subGroupDepth, 3));
+        }
 
         // Multidados:
         // Adiicona verificação do campo draggable para indicar se os registros
         // devem poder ser arrastados
-        if (!config.device.isMobile && this.draggable) {
+        if (!config.device.isMobile && this.draggable && !this.hasSubGroups) {
 
             // deactivate sortable in mobile mode.  It does not work anyway,
             // and it breaks horizontal scrolling in kanban views.  Someday, we
@@ -250,13 +271,20 @@ var KanbanColumn = Widget.extend({
      * @private
      * @param {Object} recordState
      * @param {Object} [options]
+     * @param {jQuery} [options.container]
      * @param {string} [options.position]
      *        'before' to add at the top, add at the bottom by default
      * @return {Deferred}
      */
     _addRecord: function (recordState, options) {
+        if (!recordState) {
+            return $.when();
+        }
         var record = new this.KanbanRecord(this, recordState, this.record_options);
         this.records.push(record);
+        if (options && options.container) {
+            return record.appendTo(options.container);
+        }
         if (options && options.position === 'before') {
             return record.insertAfter(this.quickCreateWidget ? this.quickCreateWidget.$el : this.$header);
         } else {
@@ -267,6 +295,117 @@ var KanbanColumn = Widget.extend({
                 return record.appendTo(this.$el);
             }
         }
+    },
+    /**
+     * Renders nested groups in the current column.
+     *
+     * @private
+     * @param {Object[]} groups
+     * @param {jQuery} $container
+     * @param {number} level
+     * @param {Deferred[]} defs
+     */
+    _addSubGroups: function (groups, $container, level, defs) {
+        var self = this;
+        if (this.showLevelTotals && level === 1 && groups.length) {
+            var levelTotal = _.reduce(groups, function (acc, groupState) {
+                return acc + self._countGroupCards(groupState);
+            }, 0);
+            $('<div/>', {
+                class: 'o_kanban_subgroup_level_total o_kanban_subgroup_level_total_' + level,
+                text: _t('Level') + ' ' + level + ': ' + levelTotal + ' ' + _t('cards'),
+            }).appendTo($container);
+        }
+        var collapseByDefault = groups.length > 1;
+        _.each(groups, function (groupState, groupIndex) {
+            if (!groupState) {
+                return;
+            }
+            var startCollapsed = collapseByDefault;
+            if (groups.length > 3 && groupIndex === 0) {
+                startCollapsed = false;
+            }
+            var toneStep = 0;
+            if (groups.length > 1) {
+                toneStep = Math.round((groupIndex / (groups.length - 1)) * 7);
+            }
+            var title = groupState.value;
+            if (title === undefined || title === null || title === false) {
+                title = _t('Undefined');
+            }
+
+            var $group = $('<div/>', {
+                class: 'o_kanban_subgroup o_kanban_subgroup_level_' + level +
+                    ' o_kanban_subgroup_tone_' + toneStep +
+                    (startCollapsed ? ' o_kanban_subgroup_collapsed' : ''),
+            });
+            var $header = $('<div/>', {
+                class: 'o_kanban_subgroup_header',
+                role: 'button',
+                tabindex: 0,
+                'aria-expanded': startCollapsed ? 'false' : 'true',
+            });
+            $('<i/>', {
+                class: 'o_kanban_subgroup_toggle fa ' + (startCollapsed ? 'fa-chevron-right' : 'fa-chevron-down'),
+                role: 'img',
+                'aria-label': startCollapsed ? _t('Expand subgroup') : _t('Collapse subgroup'),
+            }).appendTo($header);
+            $('<span/>', {
+                class: 'o_kanban_subgroup_title',
+                text: title,
+            }).appendTo($header);
+            $('<span/>', {
+                class: 'o_kanban_subgroup_count',
+                text: groupState.count || 0,
+            }).appendTo($header);
+            $group.append($header);
+
+            var $body = $('<div/>', { class: 'o_kanban_subgroup_body' });
+            $group.append($body);
+            $container.append($group);
+
+            if (groupState.groupedBy && groupState.groupedBy.length) {
+                self._addSubGroups(
+                    groupState.data || [],
+                    $body,
+                    level + 1,
+                    defs
+                );
+                return;
+            }
+
+            _.each(groupState.data || [], function (recordState) {
+                if (!recordState) {
+                    return;
+                }
+                var def = self._addRecord(recordState, {container: $body});
+                if (def.state() === 'pending') {
+                    defs.push(def);
+                }
+            });
+        });
+    },
+    /**
+     * Counts records inside one group recursively.
+     *
+     * @private
+     * @param {Object} groupState
+     * @returns {number}
+     */
+    _countGroupCards: function (groupState) {
+        var self = this;
+        if (!groupState) {
+            return 0;
+        }
+        if (groupState.type === 'record') {
+            return 1;
+        }
+        if (groupState.count !== undefined && groupState.count !== null) {
+            return parseInt(groupState.count, 10) || 0;
+        }
+        return _.reduce(groupState.data || [], function (acc, item) {
+            return acc + self._countGroupCards(item);
+        }, 0);
     },
     /**
      * Destroys the QuickCreate widget.
@@ -362,6 +501,32 @@ var KanbanColumn = Widget.extend({
     _onToggleFold: function (event) {
         event.preventDefault();
         this.trigger_up('column_toggle_fold');
+    },
+    /**
+     * @private
+     * @param {KeyboardEvent} event
+     */
+    _onSubGroupHeaderKeyDown: function (event) {
+        if (event.which === $.ui.keyCode.ENTER || event.which === $.ui.keyCode.SPACE) {
+            this._onToggleSubGroup(event);
+        }
+    },
+    /**
+     * @private
+     * @param {MouseEvent|KeyboardEvent} event
+     */
+    _onToggleSubGroup: function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        var $header = $(event.currentTarget);
+        var $group = $header.closest('.o_kanban_subgroup');
+        var collapsed = $group.toggleClass('o_kanban_subgroup_collapsed').hasClass('o_kanban_subgroup_collapsed');
+        $header.attr('aria-expanded', String(!collapsed));
+        $header.find('.o_kanban_subgroup_toggle')
+            .toggleClass('fa-chevron-down', !collapsed)
+            .toggleClass('fa-chevron-right', collapsed)
+            .attr('aria-label', collapsed ? _t('Expand subgroup') : _t('Collapse subgroup'));
     },
     /**
      * @private

--- a/addons/web/static/src/js/views/kanban/kanban_column_progressbar.js
+++ b/addons/web/static/src/js/views/kanban/kanban_column_progressbar.js
@@ -25,12 +25,13 @@ var KanbanColumnProgressBar = Widget.extend({
 
         this.columnID = options.columnID;
         this.columnState = columnState;
+        this.progressBarValues = columnState.progressBarValues || {};
 
         // <progressbar/> attributes
-        this.fieldName = columnState.progressBarValues.field;
-        this.colors = columnState.progressBarValues.colors;
-        this.sumField = columnState.progressBarValues.sum_field;
-        this.progressBarHelp = columnState.progressBarValues.help;
+        this.fieldName = this.progressBarValues.field || false;
+        this.colors = this.progressBarValues.colors || {};
+        this.sumField = this.progressBarValues.sum_field || false;
+        this.progressBarHelp = this.progressBarValues.help || false;
 
         // Previous progressBar state
         var state = options.progressBarStates[this.columnID];
@@ -45,7 +46,11 @@ var KanbanColumnProgressBar = Widget.extend({
         var sumFieldInfo = this.sumField && columnState.fieldsInfo.kanban[this.sumField];
         var currencyField = sumFieldInfo && sumFieldInfo.options && sumFieldInfo.options.currency_field;
         if (currencyField && columnState.data.length) {
-            this.currency = session.currencies[columnState.data[0].data[currencyField].res_id];
+            var firstRecord = this._findFirstRecord(columnState.data);
+            var currencyDP = firstRecord && firstRecord.data && firstRecord.data[currencyField];
+            if (currencyDP && currencyDP.res_id && session.currencies[currencyDP.res_id]) {
+                this.currency = session.currencies[currencyDP.res_id];
+            }
         }
     },
     /**
@@ -78,8 +83,9 @@ var KanbanColumnProgressBar = Widget.extend({
             // current use of progressbars
 
             var subgroupCounts = {};
+            var counts = self.progressBarValues.counts || {};
             _.each(self.colors, function (val, key) {
-                var subgroupCount = self.columnState.progressBarValues.counts[key] || 0;
+                var subgroupCount = counts[key] || 0;
                 if (self.activeFilter === key && subgroupCount === 0) {
                     self.activeFilter = false;
                 }
@@ -186,13 +192,7 @@ var KanbanColumnProgressBar = Widget.extend({
 
         if (this.activeFilter) {
             if (this.sumField) {
-                end = 0;
-                _.each(self.columnState.data, function (record) {
-                    var recordData = record.data;
-                    if (self.activeFilter === recordData[self.fieldName]) {
-                        end += parseFloat(recordData[self.sumField]);
-                    }
-                });
+                end = this._sumFilteredValue(self.columnState.data, this.activeFilter);
             } else {
                 end = this.subgroupCounts[this.activeFilter];
             }
@@ -239,6 +239,57 @@ var KanbanColumnProgressBar = Widget.extend({
                 activeFilter: this.activeFilter,
             },
         });
+    },
+    /**
+     * Returns the first record found in a nested list (records/subgroups).
+     *
+     * @private
+     * @param {Object[]} data
+     * @returns {Object|undefined}
+     */
+    _findFirstRecord: function (data) {
+        var result;
+        _.some(data || [], function (item) {
+            if (!item) {
+                return false;
+            }
+            if (item.type === 'record') {
+                result = item;
+                return true;
+            }
+            if (item.type === 'list' && item.data && item.data.length) {
+                result = this._findFirstRecord(item.data);
+                return !!result;
+            }
+            return false;
+        }, this);
+        return result;
+    },
+    /**
+     * Sums current measure for a given active filter in nested data.
+     *
+     * @private
+     * @param {Object[]} data
+     * @param {string} activeFilter
+     * @returns {number}
+     */
+    _sumFilteredValue: function (data, activeFilter) {
+        var self = this;
+        var total = 0;
+        _.each(data || [], function (item) {
+            if (!item) {
+                return;
+            }
+            if (item.type === 'list') {
+                total += self._sumFilteredValue(item.data, activeFilter);
+                return;
+            }
+            var recordData = item.data || {};
+            if (activeFilter === recordData[self.fieldName]) {
+                total += parseFloat(recordData[self.sumField]) || 0;
+            }
+        });
+        return total;
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/src/js/views/kanban/kanban_model.js
+++ b/addons/web/static/src/js/views/kanban/kanban_model.js
@@ -106,7 +106,7 @@ var KanbanModel = BasicModel.extend({
         var group = this.localData[groupID];
         var context = this._getContext(group);
         var parent = this.localData[group.parentID];
-        var groupedBy = parent.groupedBy;
+        var groupedBy = parent.groupedBy[0];
         context['default_' + groupedBy] = viewUtils.getGroupValue(group, groupedBy);
         var def;
         if (Object.keys(values).length === 1 && 'display_name' in values) {
@@ -146,6 +146,9 @@ var KanbanModel = BasicModel.extend({
     get: function () {
         var result = this._super.apply(this, arguments);
         var dp = result && this.localData[result.id];
+        if (result && result.type === 'list' && _.isArray(result.data)) {
+            result.data = _.compact(result.data);
+        }
         if (dp) {
             if (dp.tooltipData) {
                 result.tooltipData = $.extend(true, {}, dp.tooltipData);
@@ -180,7 +183,11 @@ var KanbanModel = BasicModel.extend({
      */
     load: function (params) {
         this.defaultGroupedBy = params.groupBy;
-        params.groupedBy = (params.groupedBy && params.groupedBy.length) ? params.groupedBy : this.defaultGroupedBy;
+        if (params.groupedBy && params.groupedBy.length) {
+            params.groupedBy = this._normalizeGroupedByOrder(params.groupedBy);
+        } else {
+            params.groupedBy = this._normalizeGroupedByOrder(this.defaultGroupedBy);
+        }
         return this._super(params);
     },
     /**
@@ -272,6 +279,8 @@ var KanbanModel = BasicModel.extend({
         // fallback on the default groupBy
         if (options && options.groupBy && !options.groupBy.length) {
             options.groupBy = this.defaultGroupedBy;
+        } else if (options && options.groupBy) {
+            options.groupBy = this._normalizeGroupedByOrder(options.groupBy);
         }
         var def = this._super(id, options);
         if (options && options.loadMoreOffset) {
@@ -311,8 +320,7 @@ var KanbanModel = BasicModel.extend({
         return this._super.apply(this, arguments);
     },
     /**
-     * Ensures that there is no nested groups in Kanban (only the first grouping
-     * level is taken into account).
+     * Reads grouped data for kanban columns.
      *
      * @override
      * @private
@@ -320,8 +328,10 @@ var KanbanModel = BasicModel.extend({
      */
     _readGroup: function (list) {
         var self = this;
-        if (list.groupedBy.length > 1) {
-            list.groupedBy = [list.groupedBy[0]];
+        // For nested kanban grouping, keep groups open by default so inner
+        // levels are loaded and can be rendered inside the main column.
+        if (list.groupedBy && list.groupedBy.length > 1) {
+            list.openGroupByDefault = true;
         }
         return this._super.apply(this, arguments).then(function (result) {
             return self._readTooltipFields(list).then(_.constant(result));
@@ -436,6 +446,39 @@ var KanbanModel = BasicModel.extend({
             element = this.localData[element.parentID];
         }
         return def;
+    },
+    /**
+     * Keeps the primary grouped field (default kanban column) at first
+     * position, so extra group_by fields are rendered as nested levels.
+     *
+     * @private
+     * @param {string[]|string} groupedBy
+     * @returns {string[]}
+     */
+    _normalizeGroupedByOrder: function (groupedBy) {
+        if (!groupedBy) {
+            return [];
+        }
+        if (typeof groupedBy === 'string') {
+            groupedBy = [groupedBy];
+        }
+        groupedBy = groupedBy.slice();
+
+        if (!this.defaultGroupedBy || !this.defaultGroupedBy.length) {
+            return groupedBy;
+        }
+
+        var primaryField = this.defaultGroupedBy[0].split(':')[0];
+        var primaryIndex = _.findIndex(groupedBy, function (expr) {
+            return expr.split(':')[0] === primaryField;
+        });
+        if (primaryIndex <= 0) {
+            return groupedBy;
+        }
+
+        var primaryExpr = groupedBy.splice(primaryIndex, 1)[0];
+        groupedBy.unshift(primaryExpr);
+        return groupedBy;
     },
 });
 return KanbanModel;

--- a/addons/web/static/src/js/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/js/views/kanban/kanban_renderer.js
@@ -186,21 +186,34 @@ var KanbanRenderer = BasicRenderer.extend({
      */
     updateColumn: function (localID, columnState, options) {
         var self = this;
-        var KanbanColumn = this.config.KanbanColumn;
-        var newColumn = new KanbanColumn(this, columnState, this.columnOptions, this.recordOptions);
-        var index = _.findIndex(this.widgets, {db_id: localID});
-        var column = this.widgets[index];
-        this.widgets[index] = newColumn;
+        var index = _.findIndex(this.widgets, function (widget) {
+            return widget && (widget.db_id === localID || String(widget.db_id) === String(localID));
+        });
+        var column = index >= 0 ? this.widgets[index] : null;
         if (options && options.state) {
             this.state = options.state;
         }
+        if (!column || !column.$el || !column.$el.length) {
+            // In nested grouping flows, incremental updates can target a column
+            // not present in renderer widgets. Ask controller for a safe refresh.
+            this.trigger_up('reload');
+            return $.when();
+        }
+
+        var KanbanColumn = this.config.KanbanColumn;
+        var newColumn = new KanbanColumn(this, columnState, this.columnOptions, this.recordOptions);
+        this.widgets[index] = newColumn;
         return newColumn.appendTo(document.createDocumentFragment()).then(function () {
             var def;
             if (options && options.openQuickCreate) {
                 def = newColumn.addQuickCreate();
             }
             return $.when(def).then(function () {
-                newColumn.$el.insertAfter(column.$el);
+                if (column.$el && column.$el.parent().length) {
+                    newColumn.$el.insertAfter(column.$el);
+                } else {
+                    self.$el.append(newColumn.$el);
+                }
                 self._toggleNoContentHelper();
                 // When a record has been quick created, the new column directly
                 // renders the quick create widget (to allow quick creating several
@@ -295,6 +308,9 @@ var KanbanRenderer = BasicRenderer.extend({
         // Render columns
         var KanbanColumn = this.config.KanbanColumn;
         _.each(this.state.data, function (group) {
+            if (!group) {
+                return;
+            }
             var column = new KanbanColumn(self, group, self.columnOptions, self.recordOptions);
             var def;
             if (!group.value) {

--- a/addons/web/static/src/js/views/kanban/kanban_view.js
+++ b/addons/web/static/src/js/views/kanban/kanban_view.js
@@ -68,6 +68,7 @@ var KanbanView = BasicView.extend({
             draggable: this.arch.attrs.draggable ? JSON.parse(this.arch.attrs.draggable) : true,
             archivable: this.arch.attrs.archivable ? JSON.parse(this.arch.attrs.archivable) : true,
             group_creatable: activeActions.group_create && !config.device.isMobile,
+            show_level_totals: this.arch.attrs.show_level_totals ? JSON.parse(this.arch.attrs.show_level_totals) : false,
             quickCreateView: this.arch.attrs.quick_create_view || null,
             hasProgressBar: !!progressBar,
         };

--- a/addons/web/static/src/scss/kanban_view.scss
+++ b/addons/web/static/src/scss/kanban_view.scss
@@ -414,8 +414,26 @@
             width: $o-kanban-small-record-width + 2*$o-kanban-group-padding;
         }
 
+        &.o_kanban_small_column .o_kanban_group.o_kanban_group_has_subgroups:not(.o_column_folded) {
+            width: $o-kanban-small-record-width + 2*$o-kanban-group-padding + 110px;
+        }
+
+        &.o_kanban_small_column .o_kanban_group.o_kanban_group_subgroup_depth_2:not(.o_column_folded),
+        &.o_kanban_small_column .o_kanban_group.o_kanban_group_subgroup_depth_3:not(.o_column_folded) {
+            width: $o-kanban-small-record-width + 2*$o-kanban-group-padding + 150px;
+        }
+
         &.o_kanban_large_column .o_kanban_group:not(.o_column_folded) {
             width: $o-kanban-large-record-width + 2*$o-kanban-group-padding;
+        }
+
+        &.o_kanban_large_column .o_kanban_group.o_kanban_group_has_subgroups:not(.o_column_folded) {
+            width: $o-kanban-large-record-width + 2*$o-kanban-group-padding + 120px;
+        }
+
+        &.o_kanban_large_column .o_kanban_group.o_kanban_group_subgroup_depth_2:not(.o_column_folded),
+        &.o_kanban_large_column .o_kanban_group.o_kanban_group_subgroup_depth_3:not(.o_column_folded) {
+            width: $o-kanban-large-record-width + 2*$o-kanban-group-padding + 160px;
         }
     }
 
@@ -423,6 +441,199 @@
     .o_kanban_group {
         flex: 0 0 auto;
         padding: 0 $o-kanban-group-padding $o-kanban-group-padding $o-kanban-group-padding;
+
+        .o_kanban_header {
+            position: sticky;
+            top: 0;
+            z-index: 3;
+            background-color: desaturate($gray-100, 100%);
+            padding-top: 2px;
+
+            &:after {
+                content: '';
+                position: absolute;
+                left: 0;
+                right: 0;
+                bottom: -2px;
+                height: 2px;
+                box-shadow: 0 3px 8px -6px rgba(0, 0, 0, 0.45);
+                pointer-events: none;
+            }
+        }
+
+        .o_kanban_subgroups {
+            margin-top: $o-kanban-record-margin;
+        }
+
+        .o_kanban_subgroup_level_total {
+            margin: 0 0 $o-kanban-record-margin 0;
+            padding: 4px 8px;
+            border-radius: 999px;
+            display: inline-flex;
+            align-items: center;
+            font-size: 11px;
+            font-weight: 600;
+            color: darken(theme-color('primary'), 12%);
+            background-color: rgba(theme-color('primary'), 0.10);
+            border: 1px solid rgba(theme-color('primary'), 0.25);
+        }
+
+        .o_kanban_subgroup {
+            padding: $o-kanban-inside-vgutter $o-kanban-inside-hgutter;
+            margin-bottom: $o-kanban-record-margin;
+            border: 1px solid $gray-300;
+            border-left: 4px solid rgba(theme-color('primary'), 0.30);
+            border-radius: $border-radius;
+            background: linear-gradient(90deg, rgba(theme-color('primary'), 0.08) 0, rgba(theme-color('primary'), 0) 22px), $white;
+            box-shadow: 0 1px 4px -3px rgba(0, 0, 0, 0.45);
+        }
+
+        .o_kanban_subgroup_header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: $o-kanban-record-margin;
+            font-size: 12px;
+            font-weight: 600;
+            color: $gray-700;
+            text-transform: uppercase;
+            cursor: pointer;
+            user-select: none;
+            position: sticky;
+            top: calc(var(--o-kanban-main-header-offset, 44px) + 2px);
+            z-index: 2;
+            background-color: $white;
+            border-radius: $border-radius;
+            padding: 4px 6px;
+            border: 1px dashed rgba(theme-color('primary'), 0.35);
+        }
+
+        .o_kanban_subgroup_toggle {
+            margin-right: $o-kanban-inside-hgutter;
+            color: $gray-600;
+            font-size: 11px;
+            flex: 0 0 auto;
+        }
+
+        .o_kanban_subgroup_count {
+            color: darken(theme-color('primary'), 15%);
+            font-weight: 700;
+            background-color: rgba(theme-color('primary'), 0.12);
+            border-radius: 999px;
+            padding: 2px 8px;
+            margin-left: $o-kanban-inside-hgutter;
+        }
+
+        .o_kanban_subgroup_title {
+            flex: 1 1 auto;
+            @include o-text-overflow;
+            color: darken(theme-color('primary'), 20%);
+            letter-spacing: 0.02em;
+        }
+
+        .o_kanban_subgroup_body {
+            min-height: 16px;
+
+            .o_kanban_record:last-child {
+                margin-bottom: 0;
+            }
+
+            &.o_kanban_hover {
+                background-color: rgba($gray-300, 0.15);
+            }
+        }
+
+        .o_kanban_subgroup.o_kanban_subgroup_collapsed {
+            > .o_kanban_subgroup_body {
+                display: none;
+            }
+
+            > .o_kanban_subgroup_header {
+                margin-bottom: 0;
+            }
+        }
+
+        .o_kanban_subgroup_level_2,
+        .o_kanban_subgroup_level_3,
+        .o_kanban_subgroup_level_4 {
+            margin-left: $o-kanban-inside-hgutter;
+        }
+
+        .o_kanban_subgroup_level_2 {
+            margin-bottom: $o-kanban-record-margin * 1.8;
+        }
+
+        .o_kanban_subgroup_tone_0 {
+            border-left-color: rgba(theme-color('primary'), 0.28);
+            background: linear-gradient(90deg, rgba(theme-color('primary'), 0.08) 0, rgba(theme-color('primary'), 0) 22px), $white;
+
+            > .o_kanban_subgroup_header { border-color: rgba(theme-color('primary'), 0.30); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_title { color: darken(theme-color('primary'), 22%); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_count { background-color: rgba(theme-color('primary'), 0.10); }
+        }
+
+        .o_kanban_subgroup_tone_1 {
+            border-left-color: rgba(theme-color('primary'), 0.32);
+            background: linear-gradient(90deg, rgba(theme-color('primary'), 0.10) 0, rgba(theme-color('primary'), 0) 22px), $white;
+
+            > .o_kanban_subgroup_header { border-color: rgba(theme-color('primary'), 0.35); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_title { color: darken(theme-color('primary'), 20%); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_count { background-color: rgba(theme-color('primary'), 0.12); }
+        }
+
+        .o_kanban_subgroup_tone_2 {
+            border-left-color: rgba(theme-color('primary'), 0.36);
+            background: linear-gradient(90deg, rgba(theme-color('primary'), 0.12) 0, rgba(theme-color('primary'), 0) 22px), $white;
+
+            > .o_kanban_subgroup_header { border-color: rgba(theme-color('primary'), 0.40); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_title { color: darken(theme-color('primary'), 18%); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_count { background-color: rgba(theme-color('primary'), 0.14); }
+        }
+
+        .o_kanban_subgroup_tone_3 {
+            border-left-color: rgba(theme-color('primary'), 0.40);
+            background: linear-gradient(90deg, rgba(theme-color('primary'), 0.14) 0, rgba(theme-color('primary'), 0) 22px), $white;
+
+            > .o_kanban_subgroup_header { border-color: rgba(theme-color('primary'), 0.45); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_title { color: darken(theme-color('primary'), 16%); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_count { background-color: rgba(theme-color('primary'), 0.16); }
+        }
+
+        .o_kanban_subgroup_tone_4 {
+            border-left-color: rgba(theme-color('primary'), 0.44);
+            background: linear-gradient(90deg, rgba(theme-color('primary'), 0.16) 0, rgba(theme-color('primary'), 0) 22px), $white;
+
+            > .o_kanban_subgroup_header { border-color: rgba(theme-color('primary'), 0.50); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_title { color: darken(theme-color('primary'), 14%); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_count { background-color: rgba(theme-color('primary'), 0.18); }
+        }
+
+        .o_kanban_subgroup_tone_5 {
+            border-left-color: rgba(theme-color('primary'), 0.48);
+            background: linear-gradient(90deg, rgba(theme-color('primary'), 0.18) 0, rgba(theme-color('primary'), 0) 22px), $white;
+
+            > .o_kanban_subgroup_header { border-color: rgba(theme-color('primary'), 0.55); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_title { color: darken(theme-color('primary'), 12%); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_count { background-color: rgba(theme-color('primary'), 0.20); }
+        }
+
+        .o_kanban_subgroup_tone_6 {
+            border-left-color: rgba(theme-color('primary'), 0.52);
+            background: linear-gradient(90deg, rgba(theme-color('primary'), 0.20) 0, rgba(theme-color('primary'), 0) 22px), $white;
+
+            > .o_kanban_subgroup_header { border-color: rgba(theme-color('primary'), 0.60); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_title { color: darken(theme-color('primary'), 10%); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_count { background-color: rgba(theme-color('primary'), 0.22); }
+        }
+
+        .o_kanban_subgroup_tone_7 {
+            border-left-color: rgba(theme-color('primary'), 0.56);
+            background: linear-gradient(90deg, rgba(theme-color('primary'), 0.22) 0, rgba(theme-color('primary'), 0) 22px), $white;
+
+            > .o_kanban_subgroup_header { border-color: rgba(theme-color('primary'), 0.65); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_title { color: darken(theme-color('primary'), 8%); }
+            > .o_kanban_subgroup_header .o_kanban_subgroup_count { background-color: rgba(theme-color('primary'), 0.24); }
+        }
 
         .o_kanban_header > .o_kanban_header_title {
             @include o-kanban-header-title;
@@ -474,6 +685,15 @@
 
         &:not(.o_column_folded) {
             width: $o-kanban-default-record-width + 2*$o-kanban-group-padding;
+        }
+
+        &.o_kanban_group_has_subgroups:not(.o_column_folded) {
+            width: $o-kanban-default-record-width + 2*$o-kanban-group-padding + 70px !important;
+        }
+
+        &.o_kanban_group_subgroup_depth_2:not(.o_column_folded),
+        &.o_kanban_group_subgroup_depth_3:not(.o_column_folded) {
+            width: $o-kanban-default-record-width + 2*$o-kanban-group-padding + 100px !important;
         }
 
         &.o_kanban_dragged {


### PR DESCRIPTION
# Descrição

Ajusta Visão Kanban módulo 'web'

- Kanban passa a suportar agrupamento multinível dentro das colunas.
- Interface permite colapso e expansão de subgrupos com acessibilidade por teclado.
- Progressbar funciona corretamente com dados aninhados.
- Informação de total por nível não fica duplicada em subníveis.
- Configuração de totais por nível fica controlável por atributo da própria view.


# Informações adicionais

Dados da tarefa: [T9967](https://multi.multidados.tech/web?#id=10376&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

