### PR TITLE
T9996 - Erro em visualização de diagnostico kanban

### DIFF
--- a/addons/web/static/src/js/views/kanban/kanban_column.js
+++ b/addons/web/static/src/js/views/kanban/kanban_column.js
@@ -14,6 +14,13 @@ var KanbanColumnProgressBar = require('web.KanbanColumnProgressBar');
 var _t = core._t;
 var QWeb = core.qweb;
 
+/**
+ * Documentacao PT-BR (customizacoes principais):
+ * - Renderiza subgrupos aninhados dentro de cada coluna do kanban.
+ * - Mantem estado visual aberto/fechado baseado em `isOpen` do model.
+ * - Faz lazy-load de subgrupo ao expandir quando ha contador sem cards carregados.
+ */
+
 var KanbanColumn = Widget.extend({
     template: 'KanbanView.Group',
     custom_events: {
@@ -304,6 +311,10 @@ var KanbanColumn = Widget.extend({
      * @param {jQuery} $container
      * @param {number} level
      * @param {Deferred[]} defs
+      *
+      * PT-BR:
+      * Monta recursivamente a hierarquia de subgrupos e records dentro da
+      * coluna atual, respeitando o estado aberto/fechado retornado pelo model.
      */
     _addSubGroups: function (groups, $container, level, defs) {
         var self = this;
@@ -321,9 +332,14 @@ var KanbanColumn = Widget.extend({
             if (!groupState) {
                 return;
             }
-            var startCollapsed = collapseByDefault;
-            if (groups.length > 3 && groupIndex === 0) {
-                startCollapsed = false;
+            var startCollapsed;
+            if (groupState.isOpen !== undefined) {
+                startCollapsed = !groupState.isOpen;
+            } else {
+                startCollapsed = collapseByDefault;
+                if (groups.length > 3 && groupIndex === 0) {
+                    startCollapsed = false;
+                }
             }
             var toneStep = 0;
             if (groups.length > 1) {
@@ -338,6 +354,8 @@ var KanbanColumn = Widget.extend({
                 class: 'o_kanban_subgroup o_kanban_subgroup_level_' + level +
                     ' o_kanban_subgroup_tone_' + toneStep +
                     (startCollapsed ? ' o_kanban_subgroup_collapsed' : ''),
+                'data-subgroup-id': groupState.id,
+                'data-subgroup-count': groupState.count || 0,
             });
             var $header = $('<div/>', {
                 class: 'o_kanban_subgroup_header',
@@ -391,6 +409,10 @@ var KanbanColumn = Widget.extend({
      * @private
      * @param {Object} groupState
      * @returns {number}
+      *
+      * PT-BR:
+      * Calcula total de cards de um grupo, usando `count` quando disponivel
+      * e fallback recursivo quando necessario.
      */
     _countGroupCards: function (groupState) {
         var self = this;
@@ -514,6 +536,10 @@ var KanbanColumn = Widget.extend({
     /**
      * @private
      * @param {MouseEvent|KeyboardEvent} event
+      *
+      * PT-BR:
+      * Alterna visualmente o subgrupo e, na primeira expansao de um subgrupo
+      * ainda nao carregado, dispara carregamento sob demanda para os registros.
      */
     _onToggleSubGroup: function (event) {
         event.preventDefault();
@@ -521,12 +547,39 @@ var KanbanColumn = Widget.extend({
 
         var $header = $(event.currentTarget);
         var $group = $header.closest('.o_kanban_subgroup');
+        var $body = $group.children('.o_kanban_subgroup_body');
         var collapsed = $group.toggleClass('o_kanban_subgroup_collapsed').hasClass('o_kanban_subgroup_collapsed');
         $header.attr('aria-expanded', String(!collapsed));
         $header.find('.o_kanban_subgroup_toggle')
             .toggleClass('fa-chevron-down', !collapsed)
             .toggleClass('fa-chevron-right', collapsed)
             .attr('aria-label', collapsed ? _t('Expand subgroup') : _t('Collapse subgroup'));
+
+        if (!collapsed &&
+                !$group.data('subgroupLoaded') &&
+                !$body.children().length &&
+                (parseInt($group.attr('data-subgroup-count'), 10) || 0) > 0) {
+            var subgroupId = $group.attr('data-subgroup-id');
+            if (subgroupId) {
+                var $count = $header.find('.o_kanban_subgroup_count');
+                var previousCountText = $count.text();
+                $group.addClass('o_kanban_subgroup_loading');
+                $header.attr('aria-busy', 'true');
+                $count.text(_t('Loading...'));
+                this.trigger_up('kanban_load_subgroup_records', {
+                    subgroupID: subgroupId,
+                    columnID: this.db_id,
+                    onComplete: function () {
+                        $group.removeClass('o_kanban_subgroup_loading');
+                        $header.removeAttr('aria-busy');
+                        if ($count.length) {
+                            $count.text(previousCountText);
+                        }
+                    },
+                });
+                $group.data('subgroupLoaded', true);
+            }
+        }
     },
     /**
      * @private

--- a/addons/web/static/src/js/views/kanban/kanban_column.js
+++ b/addons/web/static/src/js/views/kanban/kanban_column.js
@@ -555,6 +555,14 @@ var KanbanColumn = Widget.extend({
             .toggleClass('fa-chevron-right', collapsed)
             .attr('aria-label', collapsed ? _t('Expand subgroup') : _t('Collapse subgroup'));
 
+        var toggledSubgroupId = $group.attr('data-subgroup-id');
+        if (toggledSubgroupId) {
+            this.trigger_up('kanban_subgroup_toggle', {
+                subgroupID: toggledSubgroupId,
+                isOpen: !collapsed,
+            });
+        }
+
         if (!collapsed &&
                 !$group.data('subgroupLoaded') &&
                 !$body.children().length &&
@@ -569,15 +577,19 @@ var KanbanColumn = Widget.extend({
                 this.trigger_up('kanban_load_subgroup_records', {
                     subgroupID: subgroupId,
                     columnID: this.db_id,
-                    onComplete: function () {
+                    onComplete: function (success) {
                         $group.removeClass('o_kanban_subgroup_loading');
                         $header.removeAttr('aria-busy');
                         if ($count.length) {
                             $count.text(previousCountText);
                         }
+                        if (success) {
+                            $group.data('subgroupLoaded', true);
+                        } else {
+                            $group.removeData('subgroupLoaded');
+                        }
                     },
                 });
-                $group.data('subgroupLoaded', true);
             }
         }
     },

--- a/addons/web/static/src/js/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/js/views/kanban/kanban_controller.js
@@ -5,6 +5,11 @@ odoo.define('web.KanbanController', function (require) {
  * The KanbanController is the class that coordinates the kanban model and the
  * kanban renderer.  It also makes sure that update from the search view are
  * properly interpreted.
+ *
+ * Documentacao PT-BR (customizacoes principais):
+ * - Trata evento de lazy-load de subgrupo no kanban com agrupamento multiplo.
+ * - Preserva scroll ao atualizar coluna para evitar "salto" para o topo.
+ * - Exibe cursor de espera durante carregamentos de subgrupo.
  */
 
 var BasicController = require('web.BasicController');
@@ -30,6 +35,7 @@ var KanbanController = BasicController.extend({
         kanban_column_resequence: '_onColumnResequence',
         kanban_load_more: '_onLoadMore',
         kanban_load_records: '_onLoadColumnRecords',
+        kanban_load_subgroup_records: '_onLoadSubGroupRecords',
         column_toggle_fold: '_onToggleColumn',
         kanban_column_records_toggle_active: '_onToggleActiveRecords',
     }),
@@ -45,6 +51,7 @@ var KanbanController = BasicController.extend({
         this.on_create = params.on_create;
         this.hasButtons = params.hasButtons;
         this.quickCreateEnabled = params.quickCreateEnabled;
+        this._subgroupLoadingCount = 0;
     },
 
     //--------------------------------------------------------------------------
@@ -357,6 +364,41 @@ var KanbanController = BasicController.extend({
     /**
      * @private
      * @param {OdooEvent} event
+      *
+      * PT-BR:
+      * Carrega registros de um subgrupo sob demanda e atualiza apenas a
+      * coluna afetada, preservando scroll e estado visual de loading.
+     */
+    _onLoadSubGroupRecords: function (event) {
+        var self = this;
+        var $origin = event.target && event.target.$el;
+        var scrollState = this._captureScrollState(event.target && event.target.$el);
+        this._setSubGroupLoading(true, $origin);
+        this.model.loadColumnRecords(event.data.subgroupID).then(function () {
+            var columnID = event.data.columnID;
+            var columnData = self.model.get(columnID);
+            if (!columnData) {
+                return self.reload().then(function () {
+                    self._restoreScrollState(scrollState);
+                });
+            }
+            return self.renderer.updateColumn(columnID, columnData).then(function () {
+                self._restoreScrollState(scrollState);
+                setTimeout(function () {
+                    self._restoreScrollState(scrollState);
+                }, 0);
+                self._updateEnv();
+            });
+        }).always(function () {
+            if (event.data.onComplete) {
+                event.data.onComplete();
+            }
+            self._setSubGroupLoading(false, $origin);
+        });
+    },
+    /**
+     * @private
+     * @param {OdooEvent} event
      */
     _onLoadMore: function (event) {
         var self = this;
@@ -428,6 +470,93 @@ var KanbanController = BasicController.extend({
     _onRecordDelete: function (event) {
         this._deleteRecords([event.data.id]);
     },
+
+    /**
+     * Captures current vertical/horizontal scroll positions for the window
+     * and all scrollable ancestors of a widget element.
+     *
+     * @private
+     * @param {jQuery} $origin
+     * @returns {Object[]}
+      *
+      * PT-BR:
+      * Salva a posicao de rolagem global e dos containers pais para restaurar
+      * apos re-render da coluna.
+     */
+    _captureScrollState: function ($origin) {
+        var state = [{
+            isWindow: true,
+            top: window.pageYOffset || window.scrollY || 0,
+            left: window.pageXOffset || window.scrollX || 0,
+        }];
+
+        if (!$origin || !$origin.length) {
+            return state;
+        }
+
+        $origin.parents().each(function () {
+            var el = this;
+            if (el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth) {
+                state.push({
+                    el: el,
+                    top: el.scrollTop,
+                    left: el.scrollLeft,
+                });
+            }
+        });
+
+        return state;
+    },
+
+    /**
+     * Restores positions previously captured by _captureScrollState.
+     *
+     * @private
+     * @param {Object[]} state
+      *
+      * PT-BR:
+      * Restaura as posicoes de rolagem salvas antes do carregamento.
+     */
+    _restoreScrollState: function (state) {
+        _.each(state || [], function (entry) {
+            if (entry.isWindow) {
+                window.scrollTo(entry.left, entry.top);
+            } else if (entry.el) {
+                entry.el.scrollTop = entry.top;
+                entry.el.scrollLeft = entry.left;
+            }
+        });
+    },
+
+    /**
+     * Toggles wait cursor while subgroup records are being loaded.
+     *
+     * @private
+     * @param {boolean} isLoading
+     * @param {jQuery} $origin
+      *
+      * PT-BR:
+      * Ativa/desativa cursor de espera no elemento de origem e no documento,
+      * com contador para suportar carregamentos concorrentes.
+     */
+    _setSubGroupLoading: function (isLoading, $origin) {
+        if (isLoading) {
+            this._subgroupLoadingCount += 1;
+            if ($origin && $origin.length) {
+                $origin.css('cursor', 'wait');
+            }
+        } else {
+            this._subgroupLoadingCount = Math.max(0, this._subgroupLoadingCount - 1);
+            if ($origin && $origin.length) {
+                $origin.css('cursor', '');
+            }
+        }
+
+        var waiting = this._subgroupLoadingCount > 0;
+        document.body.style.cursor = waiting ? 'wait' : '';
+        document.documentElement.style.cursor = waiting ? 'wait' : '';
+    },
+
     /**
      * @private
      * @param {OdooEvent} event

--- a/addons/web/static/src/js/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/js/views/kanban/kanban_controller.js
@@ -36,6 +36,7 @@ var KanbanController = BasicController.extend({
         kanban_load_more: '_onLoadMore',
         kanban_load_records: '_onLoadColumnRecords',
         kanban_load_subgroup_records: '_onLoadSubGroupRecords',
+        kanban_subgroup_toggle: '_onSubGroupToggle',
         column_toggle_fold: '_onToggleColumn',
         kanban_column_records_toggle_active: '_onToggleActiveRecords',
     }),
@@ -373,6 +374,7 @@ var KanbanController = BasicController.extend({
         var self = this;
         var $origin = event.target && event.target.$el;
         var scrollState = this._captureScrollState(event.target && event.target.$el);
+        var loaded = false;
         this._setSubGroupLoading(true, $origin);
         this.model.loadColumnRecords(event.data.subgroupID).then(function () {
             var columnID = event.data.columnID;
@@ -389,9 +391,11 @@ var KanbanController = BasicController.extend({
                 }, 0);
                 self._updateEnv();
             });
+        }).then(function () {
+            loaded = true;
         }).always(function () {
             if (event.data.onComplete) {
-                event.data.onComplete();
+                event.data.onComplete(loaded);
             }
             self._setSubGroupLoading(false, $origin);
         });
@@ -408,6 +412,13 @@ var KanbanController = BasicController.extend({
             self.renderer.updateColumn(db_id, data);
             self._updateEnv();
         });
+    },
+    /**
+     * @private
+     * @param {OdooEvent} event
+     */
+    _onSubGroupToggle: function (event) {
+        this.model.setGroupOpenState(event.data.subgroupID, event.data.isOpen);
     },
     /**
      * @private

--- a/addons/web/static/src/js/views/kanban/kanban_model.js
+++ b/addons/web/static/src/js/views/kanban/kanban_model.js
@@ -4,6 +4,11 @@ odoo.define('web.KanbanModel', function (require) {
 /**
  * The KanbanModel extends the BasicModel to add Kanban specific features like
  * moving a record from a group to another, resequencing records...
+ *
+ * Documentacao PT-BR (customizacoes principais):
+ * - Organiza o groupedBy para manter o agrupamento principal como coluna.
+ * - Em agrupamento multiplo, deixa os niveis internos abertos por padrao.
+ * - Reaproveita o fluxo padrao de leitura de grupos e tooltips.
  */
 
 var BasicModel = require('web.BasicModel');
@@ -325,15 +330,19 @@ var KanbanModel = BasicModel.extend({
      * @override
      * @private
      * @param {Object} list valid resource object
+      *
+      * PT-BR:
+      * Em cenarios com agrupamento em mais de um nivel, força abertura
+      * padrao dos subgrupos para permitir renderizacao hierarquica.
      */
-    _readGroup: function (list) {
+    _readGroup: function (list, options) {
         var self = this;
         // For nested kanban grouping, keep groups open by default so inner
         // levels are loaded and can be rendered inside the main column.
         if (list.groupedBy && list.groupedBy.length > 1) {
             list.openGroupByDefault = true;
         }
-        return this._super.apply(this, arguments).then(function (result) {
+        return this._super(list, options).then(function (result) {
             return self._readTooltipFields(list).then(_.constant(result));
         });
     },
@@ -459,6 +468,10 @@ var KanbanModel = BasicModel.extend({
      * @private
      * @param {string[]|string} groupedBy
      * @returns {string[]}
+      *
+      * PT-BR:
+      * Garante que o primeiro agrupamento continue sendo a coluna principal
+      * do kanban, mesmo quando o usuario adiciona group_by extras.
      */
     _normalizeGroupedByOrder: function (groupedBy) {
         if (!groupedBy) {

--- a/addons/web/static/src/js/views/kanban/kanban_model.js
+++ b/addons/web/static/src/js/views/kanban/kanban_model.js
@@ -220,6 +220,19 @@ var KanbanModel = BasicModel.extend({
         });
     },
     /**
+     * Persiste localmente o estado visual de abertura de um subgrupo.
+     * Isso evita que rerenders da coluna restaurem estado antigo.
+     *
+     * @param {string} groupID localID do subgrupo
+     * @param {boolean} isOpen
+    */
+    setGroupOpenState: function (groupID, isOpen) {
+        var group = this.localData[groupID];
+        if (group) {
+            group.isOpen = !!isOpen;
+        }
+    },
+    /**
      * Moves a record from a group to another.
      *
      * @param {string} recordID localID of the record
@@ -339,7 +352,9 @@ var KanbanModel = BasicModel.extend({
         var self = this;
         // For nested kanban grouping, keep groups open by default so inner
         // levels are loaded and can be rendered inside the main column.
-        if (list.groupedBy && list.groupedBy.length > 1) {
+        // Preserve explicit values (notably mobile lazy loading sets this to
+        // false in KanbanView).
+        if (list.groupedBy && list.groupedBy.length > 1 && list.openGroupByDefault === undefined) {
             list.openGroupByDefault = true;
         }
         return this._super(list, options).then(function (result) {


### PR DESCRIPTION
# Descrição

Ajusta Kanban módulo 'web'
- Subgrupos com contador agora carregam registros corretamente no clique.
- Não precisa mais do segundo clique para exibir.
- Não perde mais a posição de rolagem ao expandir.
- Cursor muda para aguardando durante carga.
- Indicador visual de carregamento no próprio subgrupo durante o fetch.
- Documenta em português os métodos do JavaScript.

[Ajustes JS Kanban módulo 'web'](https://github.com/multidadosti-erp/odoo/pull/421/commits/a2953c53c15f82df76ae4455a5057ff3d34a03f5) 
[a2953c5](https://github.com/multidadosti-erp/odoo/pull/421/commits/a2953c53c15f82df76ae4455a5057ff3d34a03f5)
- SubgroupLoaded não é mais marcado antes do RPC terminar.
- O controller agora informa sucesso/falha do lazy-load para a coluna.
- A coluna só marca subgroupLoaded = true quando o carregamento realmente conclui com sucesso.
- Em falha, limpa a flag para permitir nova tentativa no próximo expand.

# Informações adicionais

Dados da tarefa: [T9996](https://multi.multidados.tech/web#id=10405&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)


