### PR TITLE
T10016 - Erro de Casas Decimais na Fatura

### DIFF
--- a/addons/decimal_precision/models/decimal_precision.py
+++ b/addons/decimal_precision/models/decimal_precision.py
@@ -4,6 +4,8 @@
 from odoo import api, fields, models, tools
 
 class DecimalPrecision(models.Model):
+    """Cadastro de precisao decimal por uso funcional."""
+
     _name = 'decimal.precision'
     _description = 'Decimal Precision'
 
@@ -15,48 +17,115 @@ class DecimalPrecision(models.Model):
     ]
 
     @api.model
+    def _normalize_application_name(self, application):
+        """Normaliza a entrada de precisao para um valor simples.
+
+        Este metodo aceita tanto formatos legados (string com nome do uso)
+        quanto estruturas novas em dicionario usadas pelo frontend
+        (default/rules/precision/value/decimal_precision).
+
+        Regras importantes:
+        - prioriza chaves diretas do dict (default, precision, value,
+          decimal_precision);
+        - depois tenta extrair de `rules`;
+        - considera 0 como valor valido (nao depende de truthiness);
+        - retorna False quando nao encontra nenhuma configuracao util.
+        """
+        if isinstance(application, dict):
+            for key in ('default', 'precision', 'value', 'decimal_precision'):
+                if key in application and application[key] is not None:
+                    return application[key]
+
+            rules = application.get('rules')
+            if isinstance(rules, list):
+                for rule in rules:
+                    if not isinstance(rule, dict):
+                        continue
+                    for key in ('precision', 'value', 'decimal_precision'):
+                        if key in rule and rule[key] is not None:
+                            return rule[key]
+
+            return False
+
+        return application
+
+    @api.model
     @tools.ormcache('application')
     def precision_get(self, application):
+        """Retorna a quantidade de casas decimais para um uso/aplicacao.
+
+        Fluxo:
+        - normaliza o valor recebido;
+        - se vier inteiro, usa o proprio inteiro como numero de casas;
+        - se nao houver valor util, retorna 2 como padrao;
+        - se vier nome de uso, busca no banco (`decimal_precision`).
+
+        O resultado e cacheado por `application` via ormcache.
+        """
+        application = self._normalize_application_name(application)
+        if isinstance(application, int):
+            return application
+        if application in (None, False, ''):
+            return 2
         self.env.cr.execute('select digits from decimal_precision where name=%s', (application,))
         res = self.env.cr.fetchone()
         return res[0] if res else 2
 
     @api.model_cr
     def clear_cache(self):
-        """ Deprecated, use `clear_caches` instead. """
+        """Compatibilidade retroativa para limpar caches do modelo.
+
+        Metodo legado mantido por compatibilidade. Internamente delega para
+        `clear_caches`.
+        """
         self.clear_caches()
 
     @api.model_create_multi
     def create(self, vals_list):
+        """Cria registros de precisao e invalida cache apos gravacao."""
         res = super(DecimalPrecision, self).create(vals_list)
         self.clear_caches()
         return res
 
     @api.multi
     def write(self, data):
+        """Atualiza registros de precisao e invalida cache apos gravacao."""
         res = super(DecimalPrecision, self).write(data)
         self.clear_caches()
         return res
 
     @api.multi
     def unlink(self):
+        """Remove registros de precisao e invalida cache apos remocao."""
         res = super(DecimalPrecision, self).unlink()
         self.clear_caches()
         return res
 
 
 class DecimalPrecisionFloat(models.AbstractModel):
-    """ Override qweb.field.float to add a `decimal_precision` domain option
-    and use that instead of the column's own value if it is specified
+    """Extensao do formatador QWeb de float com suporte a decimal_precision.
+
+    Permite que templates QWeb informem `options.decimal_precision` e que esta
+    configuracao tenha precedencia sobre o digits do campo.
     """
     _inherit = 'ir.qweb.field.float'
 
 
     @api.model
     def precision(self, field, options=None):
+        """Resolve a precisao de renderizacao para campos float no QWeb.
+
+        Uso:
+        - le `options['decimal_precision']` quando informado;
+        - normaliza o formato recebido (incluindo dict com regras/default);
+        - resolve para numero de casas via `decimal.precision.precision_get`;
+        - se nao houver opcao valida, usa comportamento padrao da superclasse.
+        """
         dp = options and options.get('decimal_precision')
-        if dp:
-            return self.env['decimal.precision'].precision_get(dp)
+        if dp is not None and dp is not False:
+            dp = self.env['decimal.precision']._normalize_application_name(dp)
+            if dp is not None and dp is not False:
+                return self.env['decimal.precision'].precision_get(dp)
 
         return super(DecimalPrecisionFloat, self).precision(field, options=options)
 

--- a/addons/web/static/src/js/fields/basic_fields.js
+++ b/addons/web/static/src/js/fields/basic_fields.js
@@ -16,6 +16,7 @@ var Domain = require('web.Domain');
 var DomainSelector = require('web.DomainSelector');
 var DomainSelectorDialog = require('web.DomainSelectorDialog');
 var framework = require('web.framework');
+var rpc = require('web.rpc');
 var session = require('web.session');
 var utils = require('web.utils');
 var view_dialogs = require('web.view_dialogs');
@@ -23,6 +24,42 @@ var field_utils = require('web.field_utils');
 
 var qweb = core.qweb;
 var _t = core._t;
+var decimalPrecisionMapPromise;
+var decimalPrecisionMap;
+
+/**
+ * Carrega e cacheia o mapa de precisao decimal (nome -> digits).
+ *
+ * Uso:
+ * - chamado por widgets de float que usam a opcao `decimal_precision` por nome;
+ * - na primeira chamada faz RPC em `decimal.precision.search_read`;
+ * - chamadas seguintes reutilizam o resultado em memoria;
+ * - em falha/abort, limpa a promise para permitir nova tentativa.
+ *
+ * @returns {jQuery.Promise<Object<string, Array|number>>}
+ */
+function getDecimalPrecisionMap() {
+    if (decimalPrecisionMap) {
+        return $.when(decimalPrecisionMap);
+    }
+    if (!decimalPrecisionMapPromise) {
+        decimalPrecisionMapPromise = rpc.query({
+            model: 'decimal.precision',
+            method: 'search_read',
+            args: [[], ['name', 'digits']],
+        }).then(function (rows) {
+            decimalPrecisionMap = {};
+            _.each(rows, function (row) {
+                decimalPrecisionMap[row.name] = row.digits;
+            });
+            return decimalPrecisionMap;
+        }).fail(function () {
+            // Allow subsequent widgets to retry if the first RPC was aborted/rejected.
+            decimalPrecisionMapPromise = undefined;
+        });
+    }
+    return decimalPrecisionMapPromise;
+}
 
 var TranslatableFieldMixin = {
     //--------------------------------------------------------------------------
@@ -951,8 +988,13 @@ var FieldFloat = NumericField.extend({
     supportedFieldTypes: ['float'],
 
     /**
-     * Float fields have an additional precision parameter that is read from
-     * either the field node in the view or the field python definition itself.
+        * Inicializa o widget de float e prepara a base de precisao.
+        *
+        * Uso:
+        * - le `attrs.digits` quando informado no XML;
+        * - guarda uma copia do `digits` original para fallback;
+        * - se houver `options.decimal_precision`, ativa recarga em mudancas
+        *   de outros campos e aplica a precisao dinamica inicial.
      *
      * @override
      */
@@ -960,7 +1002,255 @@ var FieldFloat = NumericField.extend({
         this._super.apply(this, arguments);
         if (this.attrs.digits) {
             this.nodeOptions.digits = JSON.parse(this.attrs.digits);
+            this.parseOptions.digits = this.nodeOptions.digits;
+            this.formatOptions.digits = this.nodeOptions.digits;
         }
+        this._hasOriginalDigits = _.has(this.nodeOptions, 'digits');
+        this._originalDigits = _.isArray(this.nodeOptions.digits) ? this.nodeOptions.digits.slice() : this.nodeOptions.digits;
+
+        if (this.nodeOptions.decimal_precision) {
+            // Dynamic decimal precision depends on the record values.
+            this.resetOnAnyFieldChange = true;
+            this._applyDecimalPrecisionOption();
+        }
+    },
+
+    /**
+     * Resolve dependencias assincronas antes da primeira renderizacao.
+     *
+     * Uso:
+     * - quando `decimal_precision` esta presente, busca o mapa de nomes
+     *   de precisao e reaplica as opcoes com os dados carregados.
+     *
+     * @override
+     */
+    willStart: function () {
+        var defs = [this._super.apply(this, arguments)];
+        if (this.nodeOptions.decimal_precision) {
+            defs.push(getDecimalPrecisionMap().then(function (precisionMap) {
+                this._decimalPrecisionMap = precisionMap;
+                this._applyDecimalPrecisionOption();
+            }.bind(this)));
+        }
+        return $.when.apply($, defs);
+    },
+
+    /**
+     * Reaplica a precisao dinamica quando o widget sofre reset.
+     *
+     * Uso:
+     * - garante consistencia apos onchanges/atualizacoes de registro.
+     *
+     * @override
+     */
+    _reset: function () {
+        this._super.apply(this, arguments);
+        if (this.nodeOptions.decimal_precision) {
+            this._applyDecimalPrecisionOption();
+        }
+    },
+
+    /**
+     * Aplica efetivamente a precisao calculada nas opcoes de parse/format.
+     *
+     * Uso:
+     * - resolve a configuracao (`string`, `number`, `rules`, `domain`);
+     * - aceita `0` como valor valido de casas decimais;
+     * - se nao houver precisao valida, restaura o `digits` original.
+     *
+     * @private
+     */
+    _applyDecimalPrecisionOption: function () {
+        var precision = this._resolveDecimalPrecisionOption(this.nodeOptions.decimal_precision);
+        if (_.isUndefined(precision) || _.isNull(precision) || precision === false) {
+            this._restoreOriginalDigitsOptions();
+            return;
+        }
+
+        var precisionDigits = _.isNumber(precision) ? precision : this._decimalPrecisionMap && this._decimalPrecisionMap[precision];
+        if (!_.isNumber(precisionDigits)) {
+            this._restoreOriginalDigitsOptions();
+            return;
+        }
+
+        this.nodeOptions.digits = [16, precisionDigits];
+        this.parseOptions.digits = this.nodeOptions.digits;
+        this.formatOptions.digits = this.nodeOptions.digits;
+    },
+
+    /**
+     * Restaura as opcoes `digits` originais do campo.
+     *
+     * Uso:
+     * - chamada quando nenhuma regra dinamica se aplica;
+     * - preserva fallback original em `nodeOptions`, `parseOptions`
+     *   e `formatOptions`.
+     *
+     * @private
+     */
+    _restoreOriginalDigitsOptions: function () {
+        if (!this._hasOriginalDigits) {
+            delete this.nodeOptions.digits;
+            delete this.parseOptions.digits;
+            delete this.formatOptions.digits;
+            return;
+        }
+
+        if (_.isArray(this._originalDigits)) {
+            this.nodeOptions.digits = this._originalDigits.slice();
+        } else if (_.isObject(this._originalDigits)) {
+            this.nodeOptions.digits = _.clone(this._originalDigits);
+        } else {
+            this.nodeOptions.digits = this._originalDigits;
+        }
+        this.parseOptions.digits = this.nodeOptions.digits;
+        this.formatOptions.digits = this.nodeOptions.digits;
+    },
+
+    /**
+     * Resolve a estrutura de `decimal_precision` em um valor final.
+     *
+     * Uso:
+     * - suporta formatos antigos (`string` e `number`);
+     * - suporta lista de regras e objeto com `rules`/`domain`/`default`;
+     * - faz fallback apenas para `undefined/null` (nao para `0`).
+     *
+     * @private
+     * @param {*} option
+     * @returns {string|number|undefined|false}
+     */
+    _resolveDecimalPrecisionOption: function (option) {
+        if (!option) {
+            return false;
+        }
+
+        if (_.isString(option) || _.isNumber(option)) {
+            return option;
+        }
+
+        if (_.isArray(option)) {
+            var matched = _.find(option, function (rule) {
+                return this._isDecimalPrecisionRuleMatched(rule);
+            }.bind(this));
+            return matched && this._extractDecimalPrecisionValue(matched);
+        }
+
+        if (_.isObject(option)) {
+            if (option.rules && _.isArray(option.rules)) {
+                var rule = _.find(option.rules, function (item) {
+                    return this._isDecimalPrecisionRuleMatched(item);
+                }.bind(this));
+                var resolvedFromRule = this._extractDecimalPrecisionValue(rule);
+                return (_.isUndefined(resolvedFromRule) || _.isNull(resolvedFromRule)) ? option.default : resolvedFromRule;
+            }
+            if (option.domain) {
+                return this._isDecimalPrecisionRuleMatched(option) ? this._extractDecimalPrecisionValue(option) : option.default;
+            }
+
+            var directKeys = ['default', 'precision', 'value', 'decimal_precision'];
+            var directValue = _.find(directKeys, function (key) {
+                return !_.isUndefined(option[key]) && !_.isNull(option[key]);
+            });
+            return _.isUndefined(directValue) ? undefined : option[directValue];
+        }
+
+        return false;
+    },
+
+    /**
+     * Avalia se uma regra de precisao deve ser aplicada ao registro atual.
+     *
+     * Uso:
+     * - se nao houver `domain`, considera a regra como valida;
+     * - se houver `domain`, avalia com `web.Domain` usando `recordData`.
+     *
+     * @private
+     * @param {Object} rule
+     * @returns {boolean}
+     */
+    _isDecimalPrecisionRuleMatched: function (rule) {
+        if (!rule) {
+            return false;
+        }
+        if (!rule.domain) {
+            return true;
+        }
+        try {
+            return new Domain(rule.domain, this.recordData).compute(this.recordData);
+        } catch (e) {
+            return false;
+        }
+    },
+
+    /**
+     * Extrai a precisao de uma regra por ordem de prioridade.
+     *
+     * Uso:
+     * - aceita aliases: `precision`, `value`, `decimal_precision`;
+     * - usa checagem por presenca de chave para manter `0` valido.
+     *
+     * @private
+     * @param {Object} rule
+     * @returns {string|number|undefined}
+     */
+    _extractDecimalPrecisionValue: function (rule) {
+        if (!rule || !_.isObject(rule)) {
+            return undefined;
+        }
+
+        var keys = ['precision', 'value', 'decimal_precision'];
+        var key = _.find(keys, function (name) {
+            return _.has(rule, name) && !_.isUndefined(rule[name]) && !_.isNull(rule[name]);
+        });
+        return _.isUndefined(key) ? undefined : rule[key];
+    },
+
+    /**
+     * Faz parse do valor digitado e aplica arredondamento conforme `digits`.
+     *
+     * Uso:
+     * - delega parse base ao `NumericField`;
+     * - para floats, arredonda pelo numero de casas definido no contexto
+     *   ativo (parseOptions/nodeOptions/field).
+     *
+     * @private
+     * @param {string} value
+     * @returns {number}
+     */
+    _parseValue: function (value) {
+        var parsed = this._super.apply(this, arguments);
+        if (this.formatType !== 'float') {
+            return parsed;
+        }
+
+        var digits = this.parseOptions.digits || this.nodeOptions.digits || (this.field && this.field.digits);
+        if (_.isArray(digits) && _.isNumber(digits[1])) {
+            return utils.round_decimals(parsed, digits[1]);
+        }
+
+        return parsed;
+    },
+
+    /**
+     * Normaliza o valor no blur/change e dispara o fluxo de commit.
+     *
+     * Uso:
+     * - em modo edicao de float, reescreve o input com valor normalizado;
+     * - se parse falhar, preserva texto original para validacao padrao;
+     * - ao final, aciona `_doAction` para propagar mudanca.
+     *
+     * @private
+     */
+    _onChange: function () {
+        if (this.mode === 'edit' && this.formatType === 'float' && this.$input && this.$input.length) {
+            try {
+                var normalized = this._parseValue(this.$input.val());
+                this.$input.val(this._formatValue(normalized));
+            } catch (e) {
+                // Keep original input so default validation flow can handle invalid values.
+            }
+        }
+        this._doAction();
     },
 });
 

--- a/addons/web/static/tests/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/fields/basic_fields_tests.js
@@ -534,6 +534,94 @@ QUnit.module('basic_fields', {
         form.destroy();
     });
 
+    QUnit.test('float field applies named decimal precision option', function (assert) {
+        assert.expect(1);
+
+        var form = createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form string="Partners">' +
+                    '<sheet>' +
+                        '<field name="qux" options="{\'decimal_precision\': \'QUnit Named Precision\'}"/>' +
+                    '</sheet>' +
+                '</form>',
+            res_id: 1,
+            mockRPC: function (route, args) {
+                if (args.model === 'decimal.precision' && args.method === 'search_read') {
+                    return Promise.resolve([
+                        {name: 'QUnit Named Precision', digits: [16, 4]},
+                    ]);
+                }
+                return this._super.apply(this, arguments);
+            },
+        });
+
+        assert.strictEqual(form.$('.o_field_widget[name=qux]').text(), '0.4444',
+            'The named decimal precision should be applied.');
+
+        form.destroy();
+    });
+
+    QUnit.test('float field switches decimal precision with domain rules', function (assert) {
+        assert.expect(3);
+
+        var form = createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form string="Partners">' +
+                    '<sheet>' +
+                        '<field name="bar"/>' +
+                        '<field name="qux" options="{\'decimal_precision\': {\'rules\': [' +
+                            '{\'domain\': [[\'bar\', \'=\', true]], \'precision\': 3},' +
+                            '{\'domain\': [[\'bar\', \'=\', false]], \'precision\': 1}' +
+                        '], \'default\': 2}}"/>' +
+                    '</sheet>' +
+                '</form>',
+            res_id: 1,
+        });
+
+        assert.strictEqual(form.$('.o_field_widget[name=qux]').text(), '0.444',
+            'The first matching rule should apply in readonly mode.');
+
+        testUtilsDom.click(form.$buttons.find('.o_form_button_edit'));
+        form.$('.o_field_widget[name=bar] input').prop('checked', false).trigger('change');
+        assert.strictEqual(form.$('input[name=qux]').val(), '0.4',
+            'The precision should update in edit mode when dependent fields change.');
+
+        testUtilsDom.click(form.$buttons.find('.o_form_button_save'));
+        assert.strictEqual(form.$('.o_field_widget[name=qux]').text(), '0.4',
+            'The updated precision should persist after saving.');
+
+        form.destroy();
+    });
+
+    QUnit.test('float field supports decimal precision zero', function (assert) {
+        assert.expect(2);
+
+        var form = createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form string="Partners">' +
+                    '<sheet>' +
+                        '<field name="qux" options="{\'decimal_precision\': 0}"/>' +
+                    '</sheet>' +
+                '</form>',
+            res_id: 1,
+        });
+
+        assert.strictEqual(form.$('.o_field_widget[name=qux]').text(), '0',
+            'Readonly value should use 0 decimal places.');
+
+        testUtilsDom.click(form.$buttons.find('.o_form_button_edit'));
+        assert.strictEqual(form.$('input[name=qux]').val(), '0',
+            'Edit value should keep 0 decimal places.');
+
+        form.destroy();
+    });
+
     QUnit.test('float field in list view no widget', function (assert) {
         assert.expect(5);
 


### PR DESCRIPTION
# Descrição

Evolui 'decimal_precision' móddulo 'web'
- Evolução permite adicionar regras no campo para utilizar diferentes casas decimais. 
 
Ex:

options="{
  'decimal_precision': { 'rules': [ {'domain': [('campo1', '=', 1)], 'precision': 'X'}, {'domain': [('campo2', '=', 2)], 'precision': 'Y'} ], 'default': 'Z' } }"


# Informações adicionais

Dados da tarefa: [T10016](https://multi.multidados.tech/web#id=10425&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [2075](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/2075)
